### PR TITLE
feat: add pagination, sorting & filtering utilities

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { appConfig } from './config/app.config';
 import { databaseConfig } from './config/database.config';
+import { CommonModule } from './common/common.module';
 import { UsersModule } from './modules/users/users.module';
 
 @Module({
@@ -30,9 +31,10 @@ import { UsersModule } from './modules/users/users.module';
     }),
 
     // Feature Modules
+    CommonModule,
     UsersModule,
   ],
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule { }

--- a/backend/src/common/common.module.ts
+++ b/backend/src/common/common.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { PaginationService } from './services/pagination.service';
+
+@Global()
+@Module({
+    providers: [PaginationService],
+    exports: [PaginationService],
+})
+export class CommonModule { }

--- a/backend/src/common/dto/pagination.dto.ts
+++ b/backend/src/common/dto/pagination.dto.ts
@@ -1,0 +1,33 @@
+import { IsOptional, IsInt, Min, IsString, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum SortOrder {
+    ASC = 'ASC',
+    DESC = 'DESC',
+}
+
+export class PaginationDto {
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    page?: number = 1;
+
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    limit?: number = 10;
+
+    @IsOptional()
+    @IsString()
+    sortBy?: string;
+
+    @IsOptional()
+    @IsEnum(SortOrder)
+    sortOrder?: SortOrder = SortOrder.ASC;
+
+    @IsOptional()
+    @IsString()
+    search?: string;
+}

--- a/backend/src/common/index.ts
+++ b/backend/src/common/index.ts
@@ -1,0 +1,4 @@
+export * from './common.module';
+export * from './dto/pagination.dto';
+export * from './interfaces/paginated-response.interface';
+export * from './services/pagination.service';

--- a/backend/src/common/interfaces/paginated-response.interface.ts
+++ b/backend/src/common/interfaces/paginated-response.interface.ts
@@ -1,0 +1,11 @@
+export interface PaginatedResponse<T> {
+    data: T[];
+    meta: {
+        page: number;
+        limit: number;
+        totalItems: number;
+        totalPages: number;
+        hasNextPage: boolean;
+        hasPreviousPage: boolean;
+    };
+}

--- a/backend/src/common/services/pagination.service.ts
+++ b/backend/src/common/services/pagination.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { SelectQueryBuilder, ObjectLiteral } from 'typeorm';
+import { PaginationDto, SortOrder } from '../dto/pagination.dto';
+import { PaginatedResponse } from '../interfaces/paginated-response.interface';
+
+@Injectable()
+export class PaginationService {
+    async paginate<T extends ObjectLiteral>(
+        queryBuilder: SelectQueryBuilder<T>,
+        paginationDto: PaginationDto,
+        searchableFields?: string[],
+    ): Promise<PaginatedResponse<T>> {
+        const { page = 1, limit = 10, sortBy, sortOrder = SortOrder.ASC, search } = paginationDto;
+
+        // Apply search filter
+        if (search && searchableFields && searchableFields.length > 0) {
+            const searchConditions = searchableFields
+                .map((field) => `${queryBuilder.alias}.${field} ILIKE :search`)
+                .join(' OR ');
+            queryBuilder.andWhere(`(${searchConditions})`, { search: `%${search}%` });
+        }
+
+        // Apply sorting
+        if (sortBy) {
+            queryBuilder.orderBy(`${queryBuilder.alias}.${sortBy}`, sortOrder);
+        }
+
+        // Calculate pagination
+        const skip = (page - 1) * limit;
+        queryBuilder.skip(skip).take(limit);
+
+        // Execute query
+        const [data, totalItems] = await queryBuilder.getManyAndCount();
+
+        const totalPages = Math.ceil(totalItems / limit);
+
+        return {
+            data,
+            meta: {
+                page,
+                limit,
+                totalItems,
+                totalPages,
+                hasNextPage: page < totalPages,
+                hasPreviousPage: page > 1,
+            },
+        };
+    }
+}

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -8,15 +8,17 @@ import {
   Delete,
   HttpCode,
   HttpStatus,
+  Query,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './entities/user.entity';
+import { PaginationDto, PaginatedResponse } from '../../common';
 
 @Controller('users')
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(private readonly usersService: UsersService) { }
 
   /**
    * Create a new user
@@ -33,8 +35,8 @@ export class UsersController {
    * GET /users
    */
   @Get()
-  async findAll(): Promise<User[]> {
-    return await this.usersService.findAll();
+  async findAll(@Query() paginationDto: PaginationDto): Promise<PaginatedResponse<User>> {
+    return await this.usersService.findAll(paginationDto);
   }
 
   /**

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -4,13 +4,15 @@ import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { PaginationService, PaginationDto, PaginatedResponse } from '../../common';
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
-  ) {}
+    private readonly paginationService: PaginationService,
+  ) { }
 
   /**
    * Create a new user
@@ -21,10 +23,12 @@ export class UsersService {
   }
 
   /**
-   * Get all users
+   * Get all users with pagination, sorting, and filtering
    */
-  async findAll(): Promise<User[]> {
-    return await this.userRepository.find();
+  async findAll(paginationDto: PaginationDto): Promise<PaginatedResponse<User>> {
+    const queryBuilder = this.userRepository.createQueryBuilder('user');
+    const searchableFields = ['email', 'firstName', 'lastName'];
+    return await this.paginationService.paginate(queryBuilder, paginationDto, searchableFields);
   }
 
   /**


### PR DESCRIPTION
### Summary
Add reusable pagination, sorting, and filtering utilities and apply them to all list endpoints as specified in issue #27.

### Changes
- Created `PaginationDto` with page, limit, sortBy, sortOrder, and search fields
- Implemented reusable `PaginationService` using TypeORM QueryBuilder with skip/take for efficient large dataset support
- Defined standardized `PaginatedResponse<T>` interface with data array and meta object
- Created global `CommonModule` exporting pagination utilities
- Applied pagination to the users list endpoint (`GET /users`)

### API Usage Example
```bash
GET /users?page=1&limit=10&sortBy=createdAt&sortOrder=DESC&search=john
````
Closes #27 