### PR TITLE
feat: implement collectible burning for in-game perks

### DIFF
--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -164,6 +164,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -292,6 +298,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -668,7 +684,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "hello-world"
 version = "0.0.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 23.4.1",
 ]
 
 [[package]]
@@ -1144,7 +1160,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1215,6 +1231,18 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2e42bf80fcdefb3aae6ff3c7101a62cf942e95320ed5b518a1705bc11c6b2f"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "soroban-builtin-sdk-macros"
 version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9336adeabcd6f636a4e0889c8baf494658ef5a3c4e7e227569acd2ce9091e85"
@@ -1223,6 +1251,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "soroban-env-common"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027cd856171bfd6ad2c0ffb3b7dfe55ad7080fb3050c36ad20970f80da634472"
+dependencies = [
+ "arbitrary",
+ "crate-git-revision",
+ "ethnum",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "soroban-env-macros 22.1.3",
+ "soroban-wasmi",
+ "static_assertions",
+ "stellar-xdr 22.1.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1237,11 +1284,21 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "soroban-env-macros",
+ "soroban-env-macros 23.0.1",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr",
+ "stellar-xdr 23.0.0",
  "wasmparser",
+]
+
+[[package]]
+name = "soroban-env-guest"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a07dda1ae5220d975979b19ad4fd56bc86ec7ec1b4b25bc1c5d403f934e592e"
+dependencies = [
+ "soroban-env-common 22.1.3",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1250,8 +1307,44 @@ version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd1e40963517b10963a8e404348d3fe6caf9c278ac47a6effd48771297374d6"
 dependencies = [
- "soroban-env-common",
+ "soroban-env-common 23.0.1",
  "static_assertions",
+]
+
+[[package]]
+name = "soroban-env-host"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e8b03a4191d485eab03f066336112b2a50541a7553179553dc838b986b94dd"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "curve25519-dalek",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "generic-array",
+ "getrandom",
+ "hex-literal",
+ "hmac",
+ "k256",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "p256",
+ "rand",
+ "rand_chacha",
+ "sec1",
+ "sha2",
+ "sha3",
+ "soroban-builtin-sdk-macros 22.1.3",
+ "soroban-env-common 22.1.3",
+ "soroban-wasmi",
+ "static_assertions",
+ "stellar-strkey 0.0.9",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1282,12 +1375,27 @@ dependencies = [
  "sec1",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros",
- "soroban-env-common",
+ "soroban-builtin-sdk-macros 23.0.1",
+ "soroban-env-common 23.0.1",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey",
+ "stellar-strkey 0.0.13",
  "wasmparser",
+]
+
+[[package]]
+name = "soroban-env-macros"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00eff744764ade3bc480e4909e3a581a240091f3d262acdce80b41f7069b2bd9"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "stellar-xdr 22.1.0",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1301,8 +1409,22 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr",
+ "stellar-xdr 23.0.0",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "soroban-ledger-snapshot"
+version = "22.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2826e2c9d364edbb2ea112dc861077c74557bdad0a7a00487969088c7c648169"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "soroban-env-common 22.1.3",
+ "soroban-env-host 22.1.3",
+ "thiserror",
 ]
 
 [[package]]
@@ -1314,9 +1436,31 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "soroban-env-common",
- "soroban-env-host",
+ "soroban-env-common 23.0.1",
+ "soroban-env-host 23.0.1",
  "thiserror",
+]
+
+[[package]]
+name = "soroban-sdk"
+version = "22.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac27d7573e62b745513fa1be8dab7a09b9676a7f39db97164f1d458a344749"
+dependencies = [
+ "arbitrary",
+ "bytes-lit",
+ "ctor 0.2.9",
+ "derive_arbitrary",
+ "ed25519-dalek",
+ "rand",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "soroban-env-guest 22.1.3",
+ "soroban-env-host 22.1.3",
+ "soroban-ledger-snapshot 22.0.8",
+ "soroban-sdk-macros 22.0.8",
+ "stellar-strkey 0.0.9",
 ]
 
 [[package]]
@@ -1328,19 +1472,39 @@ dependencies = [
  "arbitrary",
  "bytes-lit",
  "crate-git-revision",
- "ctor",
+ "ctor 0.5.0",
  "derive_arbitrary",
  "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
  "serde_json",
- "soroban-env-guest",
- "soroban-env-host",
- "soroban-ledger-snapshot",
- "soroban-sdk-macros",
- "stellar-strkey",
+ "soroban-env-guest 23.0.1",
+ "soroban-env-host 23.0.1",
+ "soroban-ledger-snapshot 23.4.1",
+ "soroban-sdk-macros 23.4.1",
+ "stellar-strkey 0.0.13",
  "visibility",
+]
+
+[[package]]
+name = "soroban-sdk-macros"
+version = "22.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef0d7d62b2584696d306b8766728971c7d0731a03a5e047f1fc68722ac8cf0c"
+dependencies = [
+ "crate-git-revision",
+ "darling 0.20.11",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "sha2",
+ "soroban-env-common 22.1.3",
+ "soroban-spec 22.0.8",
+ "soroban-spec-rust 22.0.8",
+ "stellar-xdr 22.1.0",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1356,11 +1520,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "soroban-env-common",
- "soroban-spec",
- "soroban-spec-rust",
- "stellar-xdr",
+ "soroban-env-common 23.0.1",
+ "soroban-spec 23.4.1",
+ "soroban-spec-rust 23.4.1",
+ "stellar-xdr 23.0.0",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "soroban-spec"
+version = "22.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ad0867aec99770ed614fedbec7ac4591791df162ff9e548ab7ebd07cd23a9c"
+dependencies = [
+ "base64 0.13.1",
+ "stellar-xdr 22.1.0",
+ "thiserror",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1369,10 +1545,26 @@ version = "23.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12864bda598c4941907cf24efe33c361e712a333749a4afd5b37b56fbf2e3a30"
 dependencies = [
- "base64",
- "stellar-xdr",
+ "base64 0.22.1",
+ "stellar-xdr 23.0.0",
  "thiserror",
  "wasmparser",
+]
+
+[[package]]
+name = "soroban-spec-rust"
+version = "22.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebe31c042adfa2885ec47b67b08fcead8707da80a3fe737eaf2a9ae1a8cfdc3"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "soroban-spec 22.0.8",
+ "stellar-xdr 22.1.0",
+ "syn 2.0.114",
+ "thiserror",
 ]
 
 [[package]]
@@ -1385,8 +1577,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "soroban-spec",
- "stellar-xdr",
+ "soroban-spec 23.4.1",
+ "stellar-xdr 23.0.0",
  "syn 2.0.114",
  "thiserror",
 ]
@@ -1428,6 +1620,17 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-strkey"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3aa3ed00e70082cb43febc1c2afa5056b9bb3e348bbb43d0cd0aa88a611144"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "stellar-strkey"
 version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
@@ -1438,12 +1641,28 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce69db907e64d1e70a3dce8d4824655d154749426a6132b25395c49136013e4"
+dependencies = [
+ "arbitrary",
+ "base64 0.13.1",
+ "crate-git-revision",
+ "escape-bytes",
+ "hex",
+ "serde",
+ "serde_with",
+ "stellar-strkey 0.0.9",
+]
+
+[[package]]
+name = "stellar-xdr"
 version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d2848e1694b0c8db81fd812bfab5ea71ee28073e09ccc45620ef3cf7a75a9b"
 dependencies = [
  "arbitrary",
- "base64",
+ "base64 0.22.1",
  "cfg_eval",
  "crate-git-revision",
  "escape-bytes",
@@ -1452,7 +1671,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "stellar-strkey",
+ "stellar-strkey 0.0.13",
 ]
 
 [[package]]
@@ -1541,10 +1760,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tycoon-collectibles"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 22.0.8",
+]
+
+[[package]]
 name = "tycoon-reward-system"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 23.4.1",
 ]
 
 [[package]]

--- a/contract/contracts/tycoon-collectibles/src/errors.rs
+++ b/contract/contracts/tycoon-collectibles/src/errors.rs
@@ -9,4 +9,7 @@ pub enum CollectibleError {
     InvalidAmount = 3,
     Unauthorized = 4,
     TokenIdMismatch = 5,
+    ContractPaused = 6,
+    InvalidPerk = 7,
+    InvalidStrength = 8,
 }

--- a/contract/contracts/tycoon-collectibles/src/events.rs
+++ b/contract/contracts/tycoon-collectibles/src/events.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{Address, Env, symbol_short};
+use crate::types::Perk;
 
 /// Emit a transfer event
 /// Similar to ERC-1155's TransferSingle event
@@ -27,5 +28,32 @@ pub fn emit_batch_transfer_event(
     env.events().publish(
         (symbol_short!("batch_tx"),),
         (from.clone(), to.clone(), token_ids.clone(), amounts.clone()),
+    );
+}
+
+/// Emit a collectible burned event
+pub fn emit_collectible_burned_event(
+    env: &Env,
+    burner: &Address,
+    token_id: u128,
+    perk: Perk,
+    strength: u32,
+) {
+    env.events().publish(
+        (symbol_short!("coll_burn"),),
+        (burner.clone(), token_id, perk, strength),
+    );
+}
+
+/// Emit a cash perk activated event
+pub fn emit_cash_perk_activated_event(
+    env: &Env,
+    activator: &Address,
+    token_id: u128,
+    cash_value: u64,
+) {
+    env.events().publish(
+        (symbol_short!("cash_perk"),),
+        (activator.clone(), token_id, cash_value),
     );
 }

--- a/contract/contracts/tycoon-collectibles/src/lib.rs
+++ b/contract/contracts/tycoon-collectibles/src/lib.rs
@@ -63,6 +63,95 @@ impl TycoonCollectibles {
         _safe_burn(&env, &owner, token_id, amount)
     }
 
+    /// Burn a collectible to activate its perk
+    pub fn burn_collectible_for_perk(
+        env: Env,
+        caller: Address,
+        token_id: u128,
+    ) -> Result<(), CollectibleError> {
+        // Require caller authentication
+        caller.require_auth();
+        
+        // Check if contract is paused
+        if is_paused(&env) {
+            return Err(CollectibleError::ContractPaused);
+        }
+        
+        // Check caller owns at least 1 unit
+        let balance = get_balance(&env, &caller, token_id);
+        if balance < 1 {
+            return Err(CollectibleError::InsufficientBalance);
+        }
+        
+        // Get perk and strength
+        let perk = get_perk(&env, token_id);
+        let strength = get_strength(&env, token_id);
+        
+        // Validate perk is not None
+        if matches!(perk, Perk::None) {
+            return Err(CollectibleError::InvalidPerk);
+        }
+        
+        // Special handling for CashTiered and TaxRefund
+        if matches!(perk, Perk::CashTiered | Perk::TaxRefund) {
+            // Validate strength is 1-5
+            if strength < 1 || strength > 5 {
+                return Err(CollectibleError::InvalidStrength);
+            }
+            
+            // Get cash value from CASH_TIERS
+            let cash_value = CASH_TIERS[(strength - 1) as usize];
+            
+            // Emit CashPerkActivated event
+            emit_cash_perk_activated_event(&env, &caller, token_id, cash_value);
+        }
+        
+        // Burn 1 unit
+        _safe_burn(&env, &caller, token_id, 1)?;
+        
+        // Emit CollectibleBurned event
+        emit_collectible_burned_event(&env, &caller, token_id, perk, strength);
+        
+        Ok(())
+    }
+
+    /// Set perk for a token (admin only)
+    pub fn set_token_perk(
+        env: Env,
+        admin: Address,
+        token_id: u128,
+        perk: Perk,
+        strength: u32,
+    ) -> Result<(), CollectibleError> {
+        admin.require_auth();
+        
+        // Verify admin
+        let stored_admin = get_admin(&env);
+        if admin != stored_admin {
+            return Err(CollectibleError::Unauthorized);
+        }
+        
+        set_perk(&env, token_id, perk);
+        set_strength(&env, token_id, strength);
+        
+        Ok(())
+    }
+
+    /// Pause the contract (admin only)
+    pub fn set_pause(env: Env, admin: Address, paused: bool) -> Result<(), CollectibleError> {
+        admin.require_auth();
+        
+        // Verify admin
+        let stored_admin = get_admin(&env);
+        if admin != stored_admin {
+            return Err(CollectibleError::Unauthorized);
+        }
+        
+        set_paused(&env, paused);
+        
+        Ok(())
+    }
+
     /// Get balance of a specific token for an address
     pub fn balance_of(env: Env, owner: Address, token_id: u128) -> u64 {
         get_balance(&env, &owner, token_id)
@@ -71,6 +160,21 @@ impl TycoonCollectibles {
     /// Get all token IDs owned by an address
     pub fn tokens_of(env: Env, owner: Address) -> soroban_sdk::Vec<u128> {
         get_owned_tokens(&env, &owner)
+    }
+
+    /// Get perk for a token
+    pub fn get_token_perk(env: Env, token_id: u128) -> Perk {
+        get_perk(&env, token_id)
+    }
+
+    /// Get strength for a token
+    pub fn get_token_strength(env: Env, token_id: u128) -> u32 {
+        get_strength(&env, token_id)
+    }
+
+    /// Check if contract is paused
+    pub fn is_contract_paused(env: Env) -> bool {
+        is_paused(&env)
     }
 }
 

--- a/contract/contracts/tycoon-collectibles/src/storage.rs
+++ b/contract/contracts/tycoon-collectibles/src/storage.rs
@@ -1,7 +1,11 @@
 use soroban_sdk::{Address, Env};
+use crate::types::Perk;
 
 const ADMIN_KEY: &str = "ADMIN";
 const BALANCE_PREFIX: &str = "BAL";
+const PAUSED_KEY: &str = "PAUSED";
+const PERK_PREFIX: &str = "PERK";
+const STRENGTH_PREFIX: &str = "STRENGTH";
 
 /// Check if admin is set
 pub fn has_admin(env: &Env) -> bool {
@@ -18,6 +22,16 @@ pub fn get_admin(env: &Env) -> Address {
     env.storage().instance().get(&ADMIN_KEY).unwrap()
 }
 
+/// Check if contract is paused
+pub fn is_paused(env: &Env) -> bool {
+    env.storage().instance().get(&PAUSED_KEY).unwrap_or(false)
+}
+
+/// Set pause state
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().instance().set(&PAUSED_KEY, &paused);
+}
+
 /// Get balance for a specific token
 pub fn get_balance(env: &Env, owner: &Address, token_id: u128) -> u64 {
     let key = (BALANCE_PREFIX, owner.clone(), token_id);
@@ -32,4 +46,28 @@ pub fn set_balance(env: &Env, owner: &Address, token_id: u128, amount: u64) {
     } else {
         env.storage().persistent().set(&key, &amount);
     }
+}
+
+/// Get perk for a token
+pub fn get_perk(env: &Env, token_id: u128) -> Perk {
+    let key = (PERK_PREFIX, token_id);
+    env.storage().persistent().get(&key).unwrap_or(Perk::None)
+}
+
+/// Set perk for a token
+pub fn set_perk(env: &Env, token_id: u128, perk: Perk) {
+    let key = (PERK_PREFIX, token_id);
+    env.storage().persistent().set(&key, &perk);
+}
+
+/// Get strength for a token
+pub fn get_strength(env: &Env, token_id: u128) -> u32 {
+    let key = (STRENGTH_PREFIX, token_id);
+    env.storage().persistent().get(&key).unwrap_or(0)
+}
+
+/// Set strength for a token
+pub fn set_strength(env: &Env, token_id: u128, strength: u32) {
+    let key = (STRENGTH_PREFIX, token_id);
+    env.storage().persistent().set(&key, &strength);
 }

--- a/contract/contracts/tycoon-collectibles/src/types.rs
+++ b/contract/contracts/tycoon-collectibles/src/types.rs
@@ -7,3 +7,17 @@ pub struct CollectibleMetadata {
     pub description: soroban_sdk::String,
     pub image_url: soroban_sdk::String,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Perk {
+    None = 0,
+    CashTiered = 1,
+    TaxRefund = 2,
+    RentBoost = 3,
+    PropertyDiscount = 4,
+}
+
+// Cash tier values based on strength (1-5)
+pub const CASH_TIERS: [u64; 5] = [100, 250, 500, 1000, 2500];


### PR DESCRIPTION
- Add burn_collectible_for_perk entry point with perk validation
- Support tiered perks (CashTiered, TaxRefund) with strength 1-5
- Emit CashPerkActivated event with cash tier values (100-2500)
- Add pause mechanism for emergency stops
- Implement perk and strength storage per token
- Add comprehensive test coverage (18 tests)
- Fix all compiler warnings