### PR TITLE
feat: implement list community chest cards

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -20,7 +20,7 @@ export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly usersService: UsersService,
-  ) { }
+  ) {}
 
   @UseGuards(LocalAuthGuard)
   @Post('login')
@@ -46,13 +46,15 @@ export class AuthController {
   @UseGuards(JwtAuthGuard)
   @Post('logout')
   @HttpCode(HttpStatus.OK)
-  async logout(@Request() req) { // Type changed to 'any' or inferred
+  async logout(@Request() req) {
+    // Type changed to 'any' or inferred
     return this.authService.logout(req.user.id);
   }
 
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
-  async register(@Body() createUserDto: CreateUserDto) { // Type fixed
+  async register(@Body() createUserDto: CreateUserDto) {
+    // Type fixed
     return this.usersService.create(createUserDto); // Service and method call corrected
   }
 }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -2,7 +2,9 @@ import {
   ConflictException,
   Injectable,
   InternalServerErrorException,
-  UnauthorizedException, NotFoundException, BadRequestException 
+  UnauthorizedException,
+  NotFoundException,
+  BadRequestException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
@@ -21,9 +23,8 @@ export class AuthService {
     @InjectRepository(RefreshToken)
     private readonly refreshTokenRepository: Repository<RefreshToken>,
     @InjectRepository(User)
-    private readonly userRepo: Repository<User>
-
-  ) { }
+    private readonly userRepo: Repository<User>,
+  ) {}
 
   async validateUser(
     email: string,

--- a/backend/src/modules/chance/chance.controller.ts
+++ b/backend/src/modules/chance/chance.controller.ts
@@ -24,7 +24,7 @@ import { Role } from '../auth/enums/role.enum';
 import { CreateChanceDto } from './dto/create-chance.dto';
 @Controller('chances')
 export class ChanceController {
-  constructor(private readonly chanceService: ChanceService) { }
+  constructor(private readonly chanceService: ChanceService) {}
 
   @Get()
   async getAllChances(
@@ -50,7 +50,6 @@ export class ChanceController {
   }
 
   @Post()
-
   @Get('draw')
   async draw(): Promise<Chance> {
     return await this.chanceService.drawCard();

--- a/backend/src/modules/community-chest/community-chest.controller.ts
+++ b/backend/src/modules/community-chest/community-chest.controller.ts
@@ -7,10 +7,12 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Query,
 } from '@nestjs/common';
 import { CommunityChestService } from './community-chest.service';
 import { CommunityChest } from './entities/community-chest.entity';
 import { CreateCommunityChestDto } from './dto/create-community-chest.dto';
+import { GetCommunityChestListDto } from './dto/get-community-chest-list.dto';
 
 @Controller('community-chest')
 export class CommunityChestController {
@@ -30,8 +32,10 @@ export class CommunityChestController {
   }
 
   @Get()
-  async findAll(): Promise<CommunityChest[]> {
-    return this.communityChestService.findAll();
+  async findAll(
+    @Query() query: GetCommunityChestListDto,
+  ): Promise<CommunityChest[]> {
+    return this.communityChestService.findAll(query);
   }
 
   @Get(':id')

--- a/backend/src/modules/community-chest/community-chest.service.spec.ts
+++ b/backend/src/modules/community-chest/community-chest.service.spec.ts
@@ -2,6 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { CommunityChestService } from './community-chest.service';
 import { CommunityChest } from './entities/community-chest.entity';
+import {
+  GetCommunityChestListDto,
+  CommunityChestSortBy,
+  SortOrder,
+} from './dto/get-community-chest-list.dto';
 
 const mockCommunityChest = {
   id: 1,
@@ -12,16 +17,36 @@ const mockCommunityChest = {
   extra: null,
 };
 
+const mockCommunityChest2 = {
+  id: 2,
+  instruction: 'Go to Jail',
+  type: 'go_to_jail',
+  amount: 0,
+  position: 0,
+  extra: null,
+};
+
 describe('CommunityChestService', () => {
   let service: CommunityChestService;
   let mockCreateQueryBuilder: jest.Mock;
+  let mockQueryBuilder: {
+    andWhere: jest.Mock;
+    orderBy: jest.Mock;
+    limit: jest.Mock;
+    getOne: jest.Mock;
+    getMany: jest.Mock;
+  };
 
   beforeEach(async () => {
-    mockCreateQueryBuilder = jest.fn(() => ({
+    mockQueryBuilder = {
+      andWhere: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
       limit: jest.fn().mockReturnThis(),
       getOne: jest.fn().mockResolvedValue(mockCommunityChest),
-    }));
+      getMany: jest.fn().mockResolvedValue([mockCommunityChest]),
+    };
+
+    mockCreateQueryBuilder = jest.fn().mockReturnValue(mockQueryBuilder);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -47,6 +72,99 @@ describe('CommunityChestService', () => {
       const result = await service.drawCard();
       expect(result).toEqual(mockCommunityChest);
       expect(mockCreateQueryBuilder).toHaveBeenCalledWith('community_chest');
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all community chest cards with default sorting', async () => {
+      const query: GetCommunityChestListDto = {};
+      mockQueryBuilder.getMany.mockResolvedValue([
+        mockCommunityChest,
+        mockCommunityChest2,
+      ]);
+
+      const result = await service.findAll(query);
+
+      expect(result).toEqual([mockCommunityChest, mockCommunityChest2]);
+      expect(mockCreateQueryBuilder).toHaveBeenCalledWith('community_chest');
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.id',
+        'ASC',
+      );
+    });
+
+    it('should sort by specified field in descending order', async () => {
+      const query: GetCommunityChestListDto = {
+        sortBy: CommunityChestSortBy.CREATED_AT,
+        sortOrder: SortOrder.DESC,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.createdAt',
+        'DESC',
+      );
+    });
+
+    it('should filter by type when provided', async () => {
+      const query: GetCommunityChestListDto = {
+        type: 'advance_to_go',
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'community_chest.type = :type',
+        { type: 'advance_to_go' },
+      );
+      expect(mockQueryBuilder.getMany).toHaveBeenCalled();
+    });
+
+    it('should handle invalid sortBy gracefully by defaulting to id', async () => {
+      const query: GetCommunityChestListDto = {
+        sortBy: 'invalidSort' as CommunityChestSortBy,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.id',
+        'ASC',
+      );
+    });
+
+    it('should sort by type field', async () => {
+      const query: GetCommunityChestListDto = {
+        sortBy: CommunityChestSortBy.TYPE,
+        sortOrder: SortOrder.ASC,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.type',
+        'ASC',
+      );
+    });
+
+    it('should combine type filter with custom sorting', async () => {
+      const query: GetCommunityChestListDto = {
+        type: 'go_to_jail',
+        sortBy: CommunityChestSortBy.AMOUNT,
+        sortOrder: SortOrder.DESC,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'community_chest.type = :type',
+        { type: 'go_to_jail' },
+      );
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.amount',
+        'DESC',
+      );
     });
   });
 });

--- a/backend/src/modules/community-chest/dto/get-community-chest-list.dto.ts
+++ b/backend/src/modules/community-chest/dto/get-community-chest-list.dto.ts
@@ -1,0 +1,29 @@
+import { IsOptional, IsEnum, IsString } from 'class-validator';
+
+export enum CommunityChestSortBy {
+  ID = 'id',
+  INSTRUCTION = 'instruction',
+  TYPE = 'type',
+  AMOUNT = 'amount',
+  CREATED_AT = 'createdAt',
+  UPDATED_AT = 'updatedAt',
+}
+
+export enum SortOrder {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+export class GetCommunityChestListDto {
+  @IsOptional()
+  @IsEnum(CommunityChestSortBy)
+  sortBy?: CommunityChestSortBy = CommunityChestSortBy.ID;
+
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortOrder?: SortOrder = SortOrder.ASC;
+
+  @IsOptional()
+  @IsString()
+  type?: string;
+}

--- a/backend/src/modules/community-chest/entities/community-chest.entity.ts
+++ b/backend/src/modules/community-chest/entities/community-chest.entity.ts
@@ -4,10 +4,13 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  Index,
 } from 'typeorm';
 import { ChanceType } from '../../chance/enums/chance-type.enum';
 
 @Entity('community_chests')
+@Index(['type']) // Index for filtering by type
+@Index(['createdAt']) // Index for sorting by creation date
 export class CommunityChest {
   @PrimaryGeneratedColumn()
   id: number;

--- a/backend/src/modules/properties/dto/get-properties.dto.ts
+++ b/backend/src/modules/properties/dto/get-properties.dto.ts
@@ -2,12 +2,12 @@ import { IsOptional, IsString, IsNumber } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class GetPropertiesDto {
-    @IsOptional()
-    @IsString()
-    type?: string;
+  @IsOptional()
+  @IsString()
+  type?: string;
 
-    @IsOptional()
-    @Type(() => Number)
-    @IsNumber()
-    group_id?: number;
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  group_id?: number;
 }

--- a/backend/src/modules/properties/dto/toggle-mortgage.dto.ts
+++ b/backend/src/modules/properties/dto/toggle-mortgage.dto.ts
@@ -1,7 +1,7 @@
 import { IsBoolean, IsNotEmpty } from 'class-validator';
 
 export class ToggleMortgageDto {
-    @IsBoolean()
-    @IsNotEmpty()
-    is_mortgaged: boolean;
+  @IsBoolean()
+  @IsNotEmpty()
+  is_mortgaged: boolean;
 }

--- a/backend/src/modules/properties/properties.controller.ts
+++ b/backend/src/modules/properties/properties.controller.ts
@@ -11,17 +11,17 @@ import {
   Query,
   BadRequestException,
   ParseIntPipe,
-} from "@nestjs/common";
-import { PropertiesService } from "./properties.service";
-import { CreatePropertyDto } from "./dto/create-property.dto";
-import { UpdatePropertyDto } from "./dto/update-property.dto";
-import { ToggleMortgageDto } from "./dto/toggle-mortgage.dto";
-import { GetPropertiesDto } from "./dto/get-properties.dto";
-import { Property } from "./entities/property.entity";
+} from '@nestjs/common';
+import { PropertiesService } from './properties.service';
+import { CreatePropertyDto } from './dto/create-property.dto';
+import { UpdatePropertyDto } from './dto/update-property.dto';
+import { ToggleMortgageDto } from './dto/toggle-mortgage.dto';
+import { GetPropertiesDto } from './dto/get-properties.dto';
+import { Property } from './entities/property.entity';
 
-@Controller("properties")
+@Controller('properties')
 export class PropertiesController {
-  constructor(private readonly propertiesService: PropertiesService) { }
+  constructor(private readonly propertiesService: PropertiesService) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
@@ -44,10 +44,10 @@ export class PropertiesController {
    * Toggle mortgage state of a property
    * PATCH /properties/:id/mortgage
    */
-  @Patch(":id/mortgage")
+  @Patch(':id/mortgage')
   @HttpCode(HttpStatus.OK)
   async toggleMortgage(
-    @Param("id", ParseIntPipe) id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Body() toggleMortgageDto: ToggleMortgageDto,
   ): Promise<Property> {
     return await this.propertiesService.toggleMortgage(

--- a/backend/src/modules/properties/properties.service.ts
+++ b/backend/src/modules/properties/properties.service.ts
@@ -2,20 +2,20 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
-} from "@nestjs/common";
-import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
-import { Property } from "./entities/property.entity";
-import { CreatePropertyDto } from "./dto/create-property.dto";
-import { UpdatePropertyDto } from "./dto/update-property.dto";
-import { GetPropertiesDto } from "./dto/get-properties.dto";
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Property } from './entities/property.entity';
+import { CreatePropertyDto } from './dto/create-property.dto';
+import { UpdatePropertyDto } from './dto/update-property.dto';
+import { GetPropertiesDto } from './dto/get-properties.dto';
 
 @Injectable()
 export class PropertiesService {
   constructor(
     @InjectRepository(Property)
     private propertiesRepository: Repository<Property>,
-  ) { }
+  ) {}
 
   async create(createPropertyDto: CreatePropertyDto): Promise<Property> {
     // Check for duplicate ID
@@ -40,17 +40,17 @@ export class PropertiesService {
    */
   async findAll(query: GetPropertiesDto): Promise<Property[]> {
     const { type, group_id } = query;
-    const qb = this.propertiesRepository.createQueryBuilder("property");
+    const qb = this.propertiesRepository.createQueryBuilder('property');
 
     if (type) {
-      qb.andWhere("property.type = :type", { type });
+      qb.andWhere('property.type = :type', { type });
     }
 
     if (group_id !== undefined) {
-      qb.andWhere("property.group_id = :group_id", { group_id });
+      qb.andWhere('property.group_id = :group_id', { group_id });
     }
 
-    qb.orderBy("property.id", "ASC");
+    qb.orderBy('property.id', 'ASC');
 
     // Optimization: Select only column fields, avoiding any potential heavy relation data if added in future
     // For now, selecting all is efficient enough as Property entity is flat

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -20,7 +20,7 @@ export class UsersService {
     private readonly userRepository: Repository<User>,
     private readonly paginationService: PaginationService,
     private readonly redisService: RedisService,
-  ) { }
+  ) {}
 
   /**
    * Create a new user


### PR DESCRIPTION
Completed #67 

Worked on ensuring the end points perform as expected. 

### What I did 

Adds the ability to fetch all Community Chest cards with support for ordering and filtering.

### Changed Implemented
New DTO: GetCommunityChestListDto - supports sortBy, sortOrder, and type filter query params
Enhanced Service: findAll() method now uses TypeORM Query Builder for efficient queries with dynamic sorting and filtering
Updated Controller: GET /community-chest endpoint accepts query parameters for sorting/filtering
Database Optimization: Added indexes on type and createdAt columns for query performance
Tests: 8 unit tests covering all sorting, filtering, and edge case scenarios

API Usage
```
GET /community-chest                                    # Default (sorted by id ASC)
GET /community-chest?sortBy=createdAt&sortOrder=DESC    # Custom sorting
GET /community-chest?type=advance_to_go                 # Filter by type
```

Ran `npm run test` and got this outcome 

All tests passing 

```

 PASS  src/common/filters/all-exceptions.filter.spec.ts
 PASS  src/common/guards/auth.guard.spec.ts
 PASS  src/common/interceptors/logging.interceptor.spec.ts
 PASS  src/app.controller.spec.ts
 PASS  src/common/interceptors/response.interceptor.spec.ts

Test Suites: 11 passed, 11 total
Tests:       53 passed, 53 total
Snapshots:   0 total
Time:        7.524 s
Ran all test suites.
```
