### PR TITLE
feat: add mint collectible feature changes

### DIFF
--- a/contract/contracts/tycoon-collectibles/src/events.rs
+++ b/contract/contracts/tycoon-collectibles/src/events.rs
@@ -90,3 +90,16 @@ pub fn emit_price_updated_event(
         (token_id, new_tyc_price, new_usdc_price),
     );
 }
+
+pub fn emit_collectible_minted_event(
+    env: &Env,
+    token_id: u128,
+    recipient: &Address,
+    perk: u32,
+    strength: u32,
+) {
+    env.events().publish(
+        (symbol_short!("coll_mint"), recipient.clone()),
+        (token_id, perk, strength),
+    );
+}

--- a/contract/contracts/tycoon-collectibles/src/storage.rs
+++ b/contract/contracts/tycoon-collectibles/src/storage.rs
@@ -174,6 +174,9 @@ pub fn get_minter(env: &Env) -> Option<Address> {
     env.storage().instance().get(&MINTER_KEY)
 }
 
+/// Collectible ID offset for reward collectibles (2 billion)
+pub const COLLECTIBLE_ID_OFFSET: u128 = 2_000_000_000;
+
 /// Get the next available token ID
 pub fn get_next_token_id(env: &Env) -> u128 {
     env.storage()
@@ -192,4 +195,17 @@ pub fn increment_token_id(env: &Env) -> u128 {
     let current = get_next_token_id(env);
     set_next_token_id(env, current + 1);
     current
+}
+
+/// Get the next available collectible ID (in the 2e9+ range)
+pub fn get_next_collectible_id(env: &Env) -> u128 {
+    let current = get_next_token_id(env);
+    // Initialize to offset if this is the first collectible
+    let collectible_id = if current < COLLECTIBLE_ID_OFFSET {
+        COLLECTIBLE_ID_OFFSET
+    } else {
+        current
+    };
+    set_next_token_id(env, collectible_id + 1);
+    collectible_id
 }


### PR DESCRIPTION
## Description of changes 

Added files. tests and more implementation details in the `tycoon-collectibles` folder

This PR is closing #13 

Here are the changes made

- [x] Added `mint_collectible` entry point with admin/minter authorization
- [x] Generate unique token IDs in 2e9+ range for collectibles
- [x] Validate perk/strength with proper error handling
- [x] Emit CollectibleMinted events
- [x] Add 10 comprehensive tests (all passing)"


All tests passing for `tycoon-collectibles` 

See image below:

<img width="847" height="503" alt="image" src="https://github.com/user-attachments/assets/e038816e-4e78-4639-bc2c-bd188ef63850" />

Closes #13 