### PR TITLE
Pending game

### DIFF
--- a/contract/contracts/tycoon-game/src/events.rs
+++ b/contract/contracts/tycoon-game/src/events.rs
@@ -28,3 +28,20 @@ pub fn emit_game_created(env: &Env, data: &GameCreatedData) {
     #[allow(deprecated)]
     env.events().publish(topics, data);
 }
+
+/// Data payload for PlayerJoined event
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct PlayerJoinedData {
+    pub game_id: u64,
+    pub player: Address,
+    pub player_symbol: u32,
+    pub joined_count: u32,
+}
+
+/// Emit PlayerJoined event
+pub fn emit_player_joined(env: &Env, data: &PlayerJoinedData) {
+    let topics = (Symbol::new(env, "PlayerJoined"), data.player.clone());
+    #[allow(deprecated)]
+    env.events().publish(topics, data);
+}

--- a/contract/contracts/tycoon-game/src/storage.rs
+++ b/contract/contracts/tycoon-game/src/storage.rs
@@ -16,6 +16,7 @@ pub enum DataKey {
     RewardSystem,       // reward system contract address
     Game(u64),           // game_id -> Game
     GamePlayers(u64),    // game_id -> Vec<Address>
+    GamePlayerSymbols(u64), // game_id -> Vec<u32> (symbols taken)
     NextGameId,          // u64
 }
 
@@ -230,4 +231,19 @@ pub fn set_game_players(env: &Env, game_id: u64, players: &Vec<Address>) {
     env.storage()
         .persistent()
         .set(&DataKey::GamePlayers(game_id), players);
+}
+
+/// Get taken player symbols for a game
+pub fn get_game_player_symbols(env: &Env, game_id: u64) -> Vec<u32> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::GamePlayerSymbols(game_id))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Set game player symbols (creator + joiners)
+pub fn set_game_player_symbols(env: &Env, game_id: u64, symbols: &Vec<u32>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::GamePlayerSymbols(game_id), symbols);
 }


### PR DESCRIPTION
# Join Pending Game (`join_game`)

## Summary
Adds support for joining pending (Waiting) human-vs-human games. Registered players can join public games or private games with a valid code. When the game has a stake, USDC is transferred from the joining player to the contract.

## Changes

### Contract (`tycoon-game`)

- **`join_game`**
  - New entrypoint: `join_game(env, game_id, player, player_username, player_symbol, join_code)`
  - **Validations:** player must be registered; username must match stored user; game must exist and be `Waiting`; private games require correct `join_code`; max players enforced; `player_symbol` must not already be taken.
  - **Flow:** If `stake_amount > 0`, transfers USDC from player to contract; adds player to `GamePlayers`; adds symbol to taken symbols; emits **PlayerJoined** event.

- **Storage**
  - New key: `GamePlayerSymbols(u64)` → `Vec<u32>` (symbols used per game).
  - New helpers: `get_game_player_symbols`, `set_game_player_symbols`.
  - `create_game` updated to set creator’s symbol in `GamePlayerSymbols`.

- **Events**
  - **PlayerJoined** event with payload: `game_id`, `player`, `player_symbol`, `joined_count`.

### Tests
- 8 tests added: public join; private with correct/wrong code; stake transfer; unregistered player; symbol taken; game full; PlayerJoined emitted.
- All 32 contract tests pass.

## Acceptance criteria
- [x] Player can join a pending game  
- [x] Stake is transferred when required  
- [x] Private games require correct join code  
- [x] **PlayerJoined** event is emitted  
- [x] Player must be registered  
- [x] Symbol must not be taken  
- [x] Max players enforced  
- [x] Tests pass  

## Notes
- `player` must be passed as `Address` and authorized with `require_auth()`; the frontend should pass the signer’s address when calling `join_game`.
- Branch is based on `feature/human-vs-human-create-game` (which introduces `create_game`).
closes #109 