### PR TITLE
player-list-component

### DIFF
--- a/frontend/src/components/game/GameWaiting.tsx
+++ b/frontend/src/components/game/GameWaiting.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { toast } from "react-toastify";
 import { Spinner } from "@/components/ui/spinner";
+import { PlayerList } from "@/components/game/PlayerList";
 
 // --- TYPES ---
 export interface PlayerSymbol {
@@ -360,27 +361,16 @@ export default function GameWaiting(): React.JSX.Element {
               Auto-start in: <span className="text-[#00F0FF] font-bold">{countdown}s</span>
             </p>
 
-            {/* Player slots */}
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 justify-center">
-              {Array.from({ length: maxPlayersThreshold }).map((_, index) => {
-                const player = gamePlayers[index];
-                return (
-                  <div
-                    key={index}
-                    className="bg-[#010F10]/70 p-3 rounded-lg border border-[#00F0FF]/30 flex flex-col items-center justify-center shadow-md hover:shadow-[#00F0FF]/50 transition-shadow duration-300"
-                  >
-                    <span className="text-4xl mb-1">
-                      {player
-                        ? SYMBOLS.find((s) => s.value === player.symbol)?.emoji ?? "❓"
-                        : "❓"}
-                    </span>
-                    <p className="text-[#F0F7F7] text-xs font-semibold truncate max-w-[80px]">
-                      {player?.username ?? "Slot Open"}
-                    </p>
-                  </div>
-                );
-              })}
-            </div>
+            {/* Player slots (reusable PlayerList) */}
+            <PlayerList
+              players={gamePlayers.map((p, i) => ({
+                id: p.address,
+                name: p.username,
+                symbol: p.symbol,
+                state: i === 0 ? ("host" as const) : undefined,
+              }))}
+              maxPlayers={maxPlayersThreshold}
+            />
           </div>
 
           {/* Chat / Status messages */}

--- a/frontend/src/components/game/PlayerList.tsx
+++ b/frontend/src/components/game/PlayerList.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import React from "react";
+import { Crown, Check, Clock } from "lucide-react";
+
+/** Slot state for lobby/game */
+export type SlotState = "ready" | "not_ready" | "host";
+
+export interface PlayerSlot {
+  id: string;
+  name: string;
+  symbol?: string;
+  state?: SlotState;
+}
+
+/** Symbol value -> emoji mapping (Tycoon default symbols) */
+const SYMBOL_EMOJI: Record<string, string> = {
+  ship: "🚢",
+  car: "🚗",
+  plane: "✈️",
+  truck: "🚚",
+};
+
+function getSymbolDisplay(symbol?: string): string {
+  if (!symbol) return "❓";
+  return SYMBOL_EMOJI[symbol] ?? symbol;
+}
+
+export interface PlayerListProps {
+  /** Array of players (may be shorter than maxPlayers; empty slots render as "Open") */
+  players: PlayerSlot[];
+  /** Maximum number of slots (default 4). Renders this many slots. */
+  maxPlayers?: number;
+  /** Optional CSS class for the grid container */
+  className?: string;
+}
+
+/**
+ * Reusable player list for lobby/game.
+ * Renders player slots; empty slots show "Open".
+ * Supports slot states: ready, not_ready, host.
+ * Uses Tycoon styling (cyan accent, dark card).
+ */
+export function PlayerList({
+  players,
+  maxPlayers = 4,
+  className = "",
+}: PlayerListProps): React.JSX.Element {
+  const slots = Array.from({ length: maxPlayers }, (_, i) => players[i] ?? null);
+
+  return (
+    <div
+      className={`grid grid-cols-2 sm:grid-cols-4 gap-3 justify-center ${className}`.trim()}
+      data-testid="player-list"
+    >
+      {slots.map((player, index) => (
+        <PlayerSlotCard key={player?.id ?? `empty-${index}`} player={player} index={index} />
+      ))}
+    </div>
+  );
+}
+
+function PlayerSlotCard({
+  player,
+  index,
+}: {
+  player: PlayerSlot | null;
+  index: number;
+}): React.JSX.Element {
+  const isEmpty = !player;
+
+  return (
+    <div
+      className="bg-[#010F10]/70 p-3 rounded-lg border border-[#00F0FF]/30 flex flex-col items-center justify-center shadow-md hover:shadow-[#00F0FF]/50 transition-shadow duration-300 min-h-[88px]"
+      data-slot-index={index}
+      data-empty={isEmpty}
+      data-state={player?.state ?? "empty"}
+    >
+      {/* Symbol or placeholder */}
+      <span className="text-4xl mb-1" aria-hidden>
+        {isEmpty ? "❓" : getSymbolDisplay(player.symbol)}
+      </span>
+
+      {/* Name or "Open" */}
+      <p className="text-[#F0F7F7] text-xs font-semibold truncate max-w-[80px] text-center">
+        {isEmpty ? "Open" : player.name}
+      </p>
+
+      {/* Slot state badge (host / ready / not ready) */}
+      {!isEmpty && player.state && (
+        <span
+          className={`mt-1 flex items-center gap-0.5 text-[10px] font-orbitron ${
+            player.state === "host"
+              ? "text-amber-400"
+              : player.state === "ready"
+                ? "text-emerald-400"
+                : "text-amber-200/80"
+          }`}
+        >
+          {player.state === "host" && <Crown className="w-3 h-3" aria-hidden />}
+          {player.state === "ready" && <Check className="w-3 h-3" aria-hidden />}
+          {player.state === "not_ready" && <Clock className="w-3 h-3" aria-hidden />}
+          <span>
+            {player.state === "host"
+              ? "Host"
+              : player.state === "ready"
+                ? "Ready"
+                : "Not Ready"}
+          </span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default PlayerList;


### PR DESCRIPTION
# Player List Component (`PlayerList.tsx`)

## Summary
Adds a reusable PlayerList component for lobby/game screens. Shows player slots, marks empty slots as "Open", and supports host, ready, and not-ready states. Uses Tycoon layout and styling.

## Changes

### New Component: `src/components/game/PlayerList.tsx`

- **Props:**
  - `players: { id: string; name: string; symbol?: string; state?: "ready" | "not_ready" | "host" }[]`
  - `maxPlayers?: number` (default: 4)
  - `className?: string`

- **Behavior:**
  - Renders slots up to `maxPlayers`; empty slots show "Open"
  - Slot states: `host` (crown), `ready` (check), `not_ready` (clock)
  - Tycoon theme: `#010F10` background, `#00F0FF` accents, `#F0F7F7` text
  - Grid: 2 columns mobile, 4 columns desktop
  - Symbol emoji map for ship, car, plane, truck

### Integration

- **GameWaiting.tsx:** Inline player slots replaced with `PlayerList`
- First player mapped as host; passes `maxPlayers` from game config

## Acceptance criteria

- [x] Component renders player slots
- [x] Empty slots display "Open"
- [x] Supports host, ready, and not_ready slot states
- [x] Matches Tycoon layout and styling
- [x] Build succeeds
closes #123 