### PR TITLE
GameSettings in Create Game API

### DIFF
--- a/backend/src/modules/games/dto/create-game-settings.dto.ts
+++ b/backend/src/modules/games/dto/create-game-settings.dto.ts
@@ -1,0 +1,35 @@
+import { IsOptional, IsBoolean, IsInt, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateGameSettingsDto {
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  auction?: boolean;
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  rentInPrison?: boolean;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  mortgage?: boolean;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  evenBuild?: boolean;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  randomizePlayOrder?: boolean;
+
+  @ApiPropertyOptional({ default: 1500 })
+  @IsOptional()
+  @IsInt()
+  @Min(100)
+  startingCash?: number;
+}

--- a/backend/src/modules/games/dto/create-game.dto.ts
+++ b/backend/src/modules/games/dto/create-game.dto.ts
@@ -1,0 +1,22 @@
+import { IsOptional, IsString, IsInt, Min, Max, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { CreateGameSettingsDto } from './create-game-settings.dto';
+
+export class CreateGameDto {
+  @ApiProperty({ example: 'PUBLIC' })
+  @IsString()
+  mode: string;
+
+  @ApiProperty({ example: 4 })
+  @IsInt()
+  @Min(2)
+  @Max(8)
+  numberOfPlayers: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateGameSettingsDto)
+  settings?: CreateGameSettingsDto;
+}

--- a/backend/src/modules/games/entities/game-settings.entity.ts
+++ b/backend/src/modules/games/entities/game-settings.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  OneToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Game } from './game.entity';
+
+@Entity({ name: 'game_settings' })
+export class GameSettings {
+  @PrimaryGeneratedColumn({ type: 'int', unsigned: true })
+  id: number;
+
+  @Column({ type: 'int', unsigned: true, unique: true })
+  game_id: number;
+
+  @OneToOne(() => Game, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'game_id' })
+  game: Game;
+
+  @Column({ type: 'boolean', default: true })
+  auction: boolean;
+
+  @Column({ type: 'boolean', default: false, name: 'rent_in_prison' })
+  rentInPrison: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  mortgage: boolean;
+
+  @Column({ type: 'boolean', default: true, name: 'even_build' })
+  evenBuild: boolean;
+
+  @Column({ type: 'boolean', default: true, name: 'randomize_play_order' })
+  randomizePlayOrder: boolean;
+
+  @Column({ type: 'int', unsigned: true, default: 1500, name: 'starting_cash' })
+  startingCash: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at: Date;
+}

--- a/backend/src/modules/games/entities/game.entity.ts
+++ b/backend/src/modules/games/entities/game.entity.ts
@@ -17,6 +17,12 @@ export class Game {
   @PrimaryGeneratedColumn({ type: 'int', unsigned: true })
   id: number;
 
+  @Column({ type: 'varchar', length: 50, default: 'PUBLIC' })
+  mode: string;
+
+  @Column({ type: 'int', unsigned: true, default: 4, name: 'number_of_players' })
+  numberOfPlayers: number;
+
   @Column({ type: 'varchar', length: 50, default: GameStatus.PENDING })
   status: string;
 

--- a/backend/src/modules/games/games.controller.ts
+++ b/backend/src/modules/games/games.controller.ts
@@ -1,20 +1,35 @@
 import {
   Body,
   Controller,
+  Post,
   Patch,
   Param,
   ParseIntPipe,
   UseGuards,
   Req,
 } from '@nestjs/common';
-import { Request } from 'express';
+import type { Request } from 'express';
+import { ApiTags, ApiOperation, ApiCreatedResponse } from '@nestjs/swagger';
 import { GamePlayersService } from './game-players.service';
+import { GamesService } from './games.service';
 import { UpdateGamePlayerDto } from './dto/update-game-player.dto';
+import { CreateGameDto } from './dto/create-game.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
+@ApiTags('games')
 @Controller('games')
 export class GamesController {
-  constructor(private readonly gamePlayersService: GamePlayersService) {}
+  constructor(
+    private readonly gamePlayersService: GamePlayersService,
+    private readonly gamesService: GamesService,
+  ) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new game' })
+  @ApiCreatedResponse({ description: 'Game and settings created' })
+  async create(@Body() dto: CreateGameDto) {
+    return this.gamesService.create(dto);
+  }
 
   @Patch(':gameId/players/:playerId')
   @UseGuards(JwtAuthGuard)

--- a/backend/src/modules/games/games.module.ts
+++ b/backend/src/modules/games/games.module.ts
@@ -1,14 +1,16 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Game } from './entities/game.entity';
+import { GameSettings } from './entities/game-settings.entity';
 import { GamePlayer } from './entities/game-player.entity';
 import { GamePlayersService } from './game-players.service';
+import { GamesService } from './games.service';
 import { GamesController } from './games.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Game, GamePlayer])],
+  imports: [TypeOrmModule.forFeature([Game, GameSettings, GamePlayer])],
   controllers: [GamesController],
-  providers: [GamePlayersService],
+  providers: [GamePlayersService, GamesService],
   exports: [GamePlayersService],
 })
 export class GamesModule {}

--- a/backend/src/modules/games/games.service.ts
+++ b/backend/src/modules/games/games.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { Game, GameStatus } from './entities/game.entity';
+import { GameSettings } from './entities/game-settings.entity';
+import { CreateGameDto } from './dto/create-game.dto';
+
+const DEFAULT_SETTINGS = {
+  auction: true,
+  rentInPrison: false,
+  mortgage: true,
+  evenBuild: true,
+  randomizePlayOrder: true,
+  startingCash: 1500,
+};
+
+@Injectable()
+export class GamesService {
+  constructor(
+    @InjectRepository(Game)
+    private readonly gameRepository: Repository<Game>,
+    @InjectRepository(GameSettings)
+    private readonly gameSettingsRepository: Repository<GameSettings>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  /**
+   * Create a game with optional settings in a single transaction.
+   * Uses defaults if no settings provided. Rollback on failure.
+   */
+  async create(dto: CreateGameDto): Promise<{
+    id: number;
+    mode: string;
+    numberOfPlayers: number;
+    status: string;
+    created_at: Date;
+    settings: {
+      auction: boolean;
+      rentInPrison: boolean;
+      mortgage: boolean;
+      evenBuild: boolean;
+      randomizePlayOrder: boolean;
+      startingCash: number;
+    };
+  }> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const game = queryRunner.manager.create(Game, {
+        mode: dto.mode,
+        numberOfPlayers: dto.numberOfPlayers,
+        status: GameStatus.PENDING,
+      });
+      const savedGame = await queryRunner.manager.save(game);
+
+      const settingsPayload = {
+        ...DEFAULT_SETTINGS,
+        ...(dto.settings ?? {}),
+      };
+
+      const gameSettings = queryRunner.manager.create(GameSettings, {
+        game_id: savedGame.id,
+        auction: settingsPayload.auction,
+        rentInPrison: settingsPayload.rentInPrison,
+        mortgage: settingsPayload.mortgage,
+        evenBuild: settingsPayload.evenBuild,
+        randomizePlayOrder: settingsPayload.randomizePlayOrder,
+        startingCash: settingsPayload.startingCash,
+      });
+      await queryRunner.manager.save(gameSettings);
+
+      await queryRunner.commitTransaction();
+
+      return {
+        id: savedGame.id,
+        mode: savedGame.mode,
+        numberOfPlayers: savedGame.numberOfPlayers,
+        status: savedGame.status,
+        created_at: savedGame.created_at,
+        settings: {
+          auction: settingsPayload.auction,
+          rentInPrison: settingsPayload.rentInPrison,
+          mortgage: settingsPayload.mortgage,
+          evenBuild: settingsPayload.evenBuild,
+          randomizePlayOrder: settingsPayload.randomizePlayOrder,
+          startingCash: settingsPayload.startingCash,
+        },
+      };
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      throw err;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}


### PR DESCRIPTION
`settings` is optional; defaults are used when omitted.

### New Entities & DTOs

- **`GameSettings`** – `game_id`, `auction`, `rentInPrison`, `mortgage`, `evenBuild`, `randomizePlayOrder`, `startingCash`
- **`CreateGameDto`** – `mode`, `numberOfPlayers`, optional `settings`
- **`CreateGameSettingsDto`** – optional settings fields

### Updated `Game` Entity

- `mode` (default: `PUBLIC`)
- `numberOfPlayers` (default: 4)

### `GamesService.create()`

- Uses `DataSource.createQueryRunner()` for a transaction
- Creates game and settings in one transaction
- Default settings: `auction: true`, `rentInPrison: false`, `mortgage: true`, `evenBuild: true`, `randomizePlayOrder: true`, `startingCash: 1500`
- Rollback on failure
- Response includes `{ id, mode, numberOfPlayers, status, created_at, settings }`

## Acceptance Criteria

- [x] Game and settings saved in a single transaction
- [x] Defaults used when settings are missing
- [x] Settings returned in response
- [x] No orphan settings (FK + transaction)
closes #152 