### PR TITLE
feat: add TradeModal component for property trades between players

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -151,7 +151,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -501,7 +500,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -545,7 +543,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2638,6 +2635,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2727,7 +2725,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2819,7 +2818,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2830,7 +2828,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2841,7 +2838,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2891,7 +2887,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -3523,7 +3518,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3574,6 +3568,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3840,7 +3835,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -3915,7 +3909,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4326,6 +4319,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4358,7 +4352,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4671,7 +4666,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4857,7 +4851,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6164,7 +6157,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -6627,6 +6619,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7186,6 +7179,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7201,6 +7195,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7213,14 +7208,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7263,7 +7258,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7273,7 +7267,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8173,7 +8166,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8392,7 +8384,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8533,7 +8524,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8627,7 +8617,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8970,7 +8959,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/trade-demo/page.tsx
+++ b/frontend/src/app/trade-demo/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import React, { useState } from "react";
+import { TradeModal, TradePlayer } from "@/components/game/TradeModal";
+
+// ─── Mock data ───────────────────────────────────────────────────────────────
+
+const MOCK_PLAYERS: TradePlayer[] = [
+    {
+        id: "p1",
+        name: "You (Alice)",
+        cash: 1500,
+        properties: [
+            { name: "Park Place", color: "bg-blue-700", price: 350, type: "property" },
+            { name: "Boardwalk", color: "bg-blue-700", price: 400, type: "property" },
+            { name: "Reading Railroad", color: "bg-gray-800", price: 200, type: "railroad" },
+            { name: "Water Works", color: "bg-yellow-400", price: 150, type: "utility" },
+        ],
+    },
+    {
+        id: "p2",
+        name: "Bob",
+        cash: 1200,
+        properties: [
+            { name: "Mediterranean Ave", color: "bg-purple-900", price: 60, type: "property" },
+            { name: "Baltic Ave", color: "bg-purple-900", price: 60, type: "property" },
+            { name: "Electric Company", color: "bg-yellow-400", price: 150, type: "utility" },
+        ],
+    },
+    {
+        id: "p3",
+        name: "Carol",
+        cash: 800,
+        properties: [
+            { name: "Oriental Ave", color: "bg-cyan-400", price: 100, type: "property" },
+            { name: "Vermont Ave", color: "bg-cyan-400", price: 100, type: "property" },
+            { name: "Connecticut Ave", color: "bg-cyan-400", price: 120, type: "property" },
+        ],
+    },
+    {
+        id: "p4",
+        name: "Dave",
+        cash: 950,
+        properties: [
+            { name: "St. Charles Place", color: "bg-pink-500", price: 140, type: "property" },
+            { name: "B&O Railroad", color: "bg-gray-800", price: 200, type: "railroad" },
+        ],
+    },
+];
+
+// ─── Demo page ───────────────────────────────────────────────────────────────
+
+export default function TradeModalDemo() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+        <main className="min-h-screen bg-[#010F10] flex flex-col items-center justify-center gap-8 p-8">
+            {/* Header */}
+            <div className="text-center space-y-3">
+                <h1 className="text-3xl font-bold text-[#00F0FF] font-orbitron tracking-wider">
+                    Trade Modal Demo
+                </h1>
+                <p className="text-[#F0F7F7]/60 text-sm max-w-md">
+                    Click the button below to open the trade modal. You are playing as{" "}
+                    <span className="text-[#00F0FF] font-semibold">Alice</span> with $1,500 and 4 properties.
+                </p>
+            </div>
+
+            {/* Player cards preview */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 w-full max-w-2xl">
+                {MOCK_PLAYERS.map((player, i) => (
+                    <div
+                        key={player.id}
+                        className={`rounded-lg border p-4 text-center transition-all ${i === 0
+                                ? "border-[#00F0FF] bg-[#00F0FF]/10 shadow-[0_0_12px_rgba(0,240,255,0.2)]"
+                                : "border-[#003B3E] bg-[#0E1415]/60"
+                            }`}
+                    >
+                        <p className="text-2xl mb-1">{["🚢", "🚗", "✈️", "🚚"][i]}</p>
+                        <p className={`text-sm font-semibold ${i === 0 ? "text-[#00F0FF]" : "text-[#F0F7F7]"}`}>
+                            {player.name}
+                        </p>
+                        <p className="text-xs text-[#F0F7F7]/50 mt-1">${player.cash}</p>
+                        <p className="text-[10px] text-[#F0F7F7]/40">
+                            {player.properties.length} properties
+                        </p>
+                    </div>
+                ))}
+            </div>
+
+            {/* Open button */}
+            <button
+                onClick={() => setIsOpen(true)}
+                className="flex items-center gap-2 rounded-xl bg-[#00F0FF] px-8 py-3 text-base font-bold text-[#010F10] hover:bg-[#00F0FF]/80 shadow-[0_0_24px_rgba(0,240,255,0.35)] hover:shadow-[0_0_32px_rgba(0,240,255,0.5)] transition-all active:scale-95"
+            >
+                🤝 Open Trade Modal
+            </button>
+
+            {/* The modal */}
+            <TradeModal
+                isOpen={isOpen}
+                onClose={() => setIsOpen(false)}
+                players={MOCK_PLAYERS}
+                currentPlayer={MOCK_PLAYERS[0]}
+            />
+        </main>
+    );
+}

--- a/frontend/src/components/game/TradeModal.tsx
+++ b/frontend/src/components/game/TradeModal.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import {
+  X,
+  Handshake,
+  ArrowLeftRight,
+  DollarSign,
+  Check,
+  AlertCircle,
+} from "lucide-react";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface TradeProperty {
+  name: string;
+  color: string;
+  price: number;
+  type: "property" | "railroad" | "utility";
+}
+
+export interface TradePlayer {
+  id: string;
+  name: string;
+  cash: number;
+  properties: TradeProperty[];
+}
+
+export interface TradeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  players: TradePlayer[];
+  currentPlayer: TradePlayer;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const TYPE_ICON: Record<TradeProperty["type"], string> = {
+  property: "🏠",
+  railroad: "🚂",
+  utility: "💡",
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function TradeModal({
+  isOpen,
+  onClose,
+  players,
+  currentPlayer,
+}: TradeModalProps): React.JSX.Element | null {
+  // ── State ────────────────────────────────────────────────────────────────
+  const [partnerId, setPartnerId] = useState<string>("");
+  const [offeredProperties, setOfferedProperties] = useState<Set<string>>(
+    new Set()
+  );
+  const [requestedProperties, setRequestedProperties] = useState<Set<string>>(
+    new Set()
+  );
+  const [offeredCash, setOfferedCash] = useState<string>("");
+  const [requestedCash, setRequestedCash] = useState<string>("");
+  const [validationError, setValidationError] = useState<string>("");
+
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const partner = players.find((p) => p.id === partnerId) ?? null;
+  const otherPlayers = players.filter((p) => p.id !== currentPlayer.id);
+
+  // ── Reset on open/close ──────────────────────────────────────────────────
+  useEffect(() => {
+    if (isOpen) {
+      setPartnerId("");
+      setOfferedProperties(new Set());
+      setRequestedProperties(new Set());
+      setOfferedCash("");
+      setRequestedCash("");
+      setValidationError("");
+      // Focus the close button when modal opens
+      requestAnimationFrame(() => closeButtonRef.current?.focus());
+    }
+  }, [isOpen]);
+
+  // ── Escape key handler ───────────────────────────────────────────────────
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isOpen, onClose]);
+
+  // ── Focus trap ───────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!isOpen) return;
+    const modal = modalRef.current;
+    if (!modal) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusable = modal.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isOpen]);
+
+  // ── Togglers ─────────────────────────────────────────────────────────────
+  const toggleOffered = useCallback((name: string) => {
+    setOfferedProperties((prev) => {
+      const next = new Set(prev);
+      next.has(name) ? next.delete(name) : next.add(name);
+      return next;
+    });
+    setValidationError("");
+  }, []);
+
+  const toggleRequested = useCallback((name: string) => {
+    setRequestedProperties((prev) => {
+      const next = new Set(prev);
+      next.has(name) ? next.delete(name) : next.add(name);
+      return next;
+    });
+    setValidationError("");
+  }, []);
+
+  // ── Validation & confirm ─────────────────────────────────────────────────
+  const handleConfirm = () => {
+    if (!partnerId) {
+      setValidationError("Please select a trade partner.");
+      return;
+    }
+
+    const cashOffer = Number(offeredCash) || 0;
+    const cashRequest = Number(requestedCash) || 0;
+
+    if (cashOffer < 0 || cashRequest < 0) {
+      setValidationError("Cash values cannot be negative.");
+      return;
+    }
+    if (cashOffer > currentPlayer.cash) {
+      setValidationError(
+        `You only have $${currentPlayer.cash} available to offer.`
+      );
+      return;
+    }
+    if (partner && cashRequest > partner.cash) {
+      setValidationError(
+        `${partner.name} only has $${partner.cash} available.`
+      );
+      return;
+    }
+    if (
+      offeredProperties.size === 0 &&
+      requestedProperties.size === 0 &&
+      cashOffer === 0 &&
+      cashRequest === 0
+    ) {
+      setValidationError(
+        "You must offer or request at least one property or some cash."
+      );
+      return;
+    }
+
+    // Mock: log trade details and close
+    console.log("Trade proposed:", {
+      from: currentPlayer.name,
+      to: partner?.name,
+      offeredProperties: [...offeredProperties],
+      requestedProperties: [...requestedProperties],
+      offeredCash: cashOffer,
+      requestedCash: cashRequest,
+    });
+
+    onClose();
+  };
+
+  // ── Render nothing when closed ───────────────────────────────────────────
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"
+        data-testid="trade-modal-backdrop"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Modal */}
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="trade-modal-title"
+        data-testid="trade-modal"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none"
+      >
+        <div className="pointer-events-auto w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl border-2 border-[#003B3E] bg-[#010F10] shadow-[0_0_40px_rgba(0,240,255,0.12)]">
+          {/* ── Header ──────────────────────────────────────────────── */}
+          <div className="flex items-center justify-between border-b border-[#003B3E] px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Handshake className="h-6 w-6 text-[#00F0FF]" aria-hidden />
+              <h2
+                id="trade-modal-title"
+                className="text-lg font-bold text-[#F0F7F7] font-orbitron tracking-wide"
+              >
+                Propose Trade
+              </h2>
+            </div>
+            <button
+              ref={closeButtonRef}
+              onClick={onClose}
+              aria-label="Close trade modal"
+              className="rounded-lg p-1.5 text-[#F0F7F7]/60 hover:bg-[#003B3E]/40 hover:text-[#00F0FF] transition-colors"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="px-6 py-5 space-y-6">
+            {/* ── Partner selector ───────────────────────────────────── */}
+            <div>
+              <label
+                htmlFor="partner-select"
+                className="block text-xs font-semibold uppercase tracking-wider text-[#00F0FF]/80 mb-2 font-orbitron"
+              >
+                Trade Partner
+              </label>
+              <div className="relative">
+                <select
+                  id="partner-select"
+                  value={partnerId}
+                  onChange={(e) => {
+                    setPartnerId(e.target.value);
+                    setRequestedProperties(new Set());
+                    setRequestedCash("");
+                    setValidationError("");
+                  }}
+                  className="w-full appearance-none rounded-lg border border-[#003B3E] bg-[#0E1415] px-4 py-2.5 pr-10 text-sm text-[#F0F7F7] outline-none focus:border-[#00F0FF] focus:ring-1 focus:ring-[#00F0FF]/50 transition-colors"
+                >
+                  <option value="">Select a player…</option>
+                  {otherPlayers.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name} — ${p.cash}
+                    </option>
+                  ))}
+                </select>
+                <ArrowLeftRight className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[#00F0FF]/50" />
+              </div>
+            </div>
+
+            {/* ── Two-column trade area ─────────────────────────────── */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+              {/* YOU OFFER */}
+              <TradeColumn
+                heading="You Offer"
+                accentClass="text-rose-400"
+                properties={currentPlayer.properties}
+                selectedProperties={offeredProperties}
+                onToggle={toggleOffered}
+                cash={offeredCash}
+                onCashChange={(v) => {
+                  setOfferedCash(v);
+                  setValidationError("");
+                }}
+                maxCash={currentPlayer.cash}
+                testIdPrefix="offer"
+              />
+
+              {/* YOU REQUEST */}
+              <TradeColumn
+                heading="You Request"
+                accentClass="text-emerald-400"
+                properties={partner?.properties ?? []}
+                selectedProperties={requestedProperties}
+                onToggle={toggleRequested}
+                cash={requestedCash}
+                onCashChange={(v) => {
+                  setRequestedCash(v);
+                  setValidationError("");
+                }}
+                maxCash={partner?.cash ?? 0}
+                testIdPrefix="request"
+                disabled={!partnerId}
+              />
+            </div>
+
+            {/* ── Validation error ──────────────────────────────────── */}
+            {validationError && (
+              <div
+                role="alert"
+                className="flex items-center gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-2.5 text-sm text-rose-300"
+                data-testid="validation-error"
+              >
+                <AlertCircle className="h-4 w-4 shrink-0" />
+                {validationError}
+              </div>
+            )}
+          </div>
+
+          {/* ── Footer ──────────────────────────────────────────────── */}
+          <div className="flex items-center justify-end gap-3 border-t border-[#003B3E] px-6 py-4">
+            <button
+              onClick={onClose}
+              data-testid="cancel-button"
+              className="rounded-lg border border-[#003B3E] bg-transparent px-5 py-2 text-sm font-semibold text-[#F0F7F7]/80 hover:bg-[#003B3E]/40 hover:text-[#F0F7F7] transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirm}
+              data-testid="confirm-button"
+              className="flex items-center gap-2 rounded-lg bg-[#00F0FF] px-5 py-2 text-sm font-bold text-[#010F10] hover:bg-[#00F0FF]/80 shadow-[0_0_12px_rgba(0,240,255,0.3)] transition-all"
+            >
+              <Check className="h-4 w-4" />
+              Confirm Trade
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+interface TradeColumnProps {
+  heading: string;
+  accentClass: string;
+  properties: TradeProperty[];
+  selectedProperties: Set<string>;
+  onToggle: (name: string) => void;
+  cash: string;
+  onCashChange: (value: string) => void;
+  maxCash: number;
+  testIdPrefix: string;
+  disabled?: boolean;
+}
+
+function TradeColumn({
+  heading,
+  accentClass,
+  properties,
+  selectedProperties,
+  onToggle,
+  cash,
+  onCashChange,
+  maxCash,
+  testIdPrefix,
+  disabled = false,
+}: TradeColumnProps): React.JSX.Element {
+  return (
+    <div
+      className={`rounded-lg border border-[#003B3E] bg-[#0E1415]/60 p-4 ${disabled ? "opacity-40 pointer-events-none" : ""}`}
+      data-testid={`${testIdPrefix}-column`}
+    >
+      <h3
+        className={`text-xs font-bold uppercase tracking-wider mb-3 font-orbitron ${accentClass}`}
+      >
+        {heading}
+      </h3>
+
+      {/* Property cards */}
+      <div className="space-y-2 mb-4 max-h-48 overflow-y-auto pr-1">
+        {properties.length === 0 ? (
+          <p className="text-xs text-[#F0F7F7]/40 italic">
+            No properties available
+          </p>
+        ) : (
+          properties.map((prop) => {
+            const selected = selectedProperties.has(prop.name);
+            return (
+              <button
+                key={prop.name}
+                type="button"
+                onClick={() => onToggle(prop.name)}
+                data-testid={`${testIdPrefix}-property-${prop.name.replace(/\s+/g, "-").toLowerCase()}`}
+                className={`w-full flex items-center gap-3 rounded-lg border px-3 py-2 text-left text-sm transition-all ${
+                  selected
+                    ? "border-[#00F0FF] bg-[#00F0FF]/10 text-[#F0F7F7] shadow-[0_0_8px_rgba(0,240,255,0.15)]"
+                    : "border-[#003B3E]/60 bg-[#010F10]/50 text-[#F0F7F7]/70 hover:border-[#003B3E] hover:text-[#F0F7F7]"
+                }`}
+              >
+                {/* Color swatch */}
+                <span
+                  className={`inline-block h-4 w-4 rounded ${prop.color}`}
+                  aria-hidden
+                />
+                <span className="text-base" aria-hidden>
+                  {TYPE_ICON[prop.type]}
+                </span>
+                <span className="flex-1 truncate font-medium">{prop.name}</span>
+                <span className="text-xs text-[#F0F7F7]/50">
+                  ${prop.price}
+                </span>
+                {selected && (
+                  <Check className="h-4 w-4 text-[#00F0FF] shrink-0" />
+                )}
+              </button>
+            );
+          })
+        )}
+      </div>
+
+      {/* Cash input */}
+      <div>
+        <label
+          htmlFor={`${testIdPrefix}-cash`}
+          className="flex items-center gap-1.5 text-xs text-[#F0F7F7]/60 mb-1"
+        >
+          <DollarSign className="h-3.5 w-3.5" />
+          Cash (max ${maxCash})
+        </label>
+        <input
+          id={`${testIdPrefix}-cash`}
+          type="number"
+          min={0}
+          max={maxCash}
+          value={cash}
+          onChange={(e) => onCashChange(e.target.value)}
+          placeholder="0"
+          data-testid={`${testIdPrefix}-cash-input`}
+          className="w-full rounded-lg border border-[#003B3E] bg-[#010F10] px-3 py-2 text-sm text-[#F0F7F7] outline-none placeholder:text-[#F0F7F7]/30 focus:border-[#00F0FF] focus:ring-1 focus:ring-[#00F0FF]/50 transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default TradeModal;

--- a/frontend/test/TradeModal.test.tsx
+++ b/frontend/test/TradeModal.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TradeModal, TradePlayer } from "../src/components/game/TradeModal";
+
+// ─── Mock data ───────────────────────────────────────────────────────────────
+
+const mockCurrentPlayer: TradePlayer = {
+    id: "p1",
+    name: "Alice",
+    cash: 1500,
+    properties: [
+        { name: "Park Place", color: "bg-blue-700", price: 350, type: "property" },
+        {
+            name: "Boardwalk",
+            color: "bg-blue-700",
+            price: 400,
+            type: "property",
+        },
+        {
+            name: "Reading Railroad",
+            color: "bg-gray-800",
+            price: 200,
+            type: "railroad",
+        },
+    ],
+};
+
+const mockPlayers: TradePlayer[] = [
+    mockCurrentPlayer,
+    {
+        id: "p2",
+        name: "Bob",
+        cash: 1200,
+        properties: [
+            {
+                name: "Mediterranean Ave",
+                color: "bg-purple-900",
+                price: 60,
+                type: "property",
+            },
+            {
+                name: "Electric Company",
+                color: "bg-yellow-400",
+                price: 150,
+                type: "utility",
+            },
+        ],
+    },
+    {
+        id: "p3",
+        name: "Carol",
+        cash: 800,
+        properties: [
+            {
+                name: "Oriental Ave",
+                color: "bg-cyan-400",
+                price: 100,
+                type: "property",
+            },
+        ],
+    },
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderModal(props: Partial<React.ComponentProps<typeof TradeModal>> = {}) {
+    const defaultProps = {
+        isOpen: true,
+        onClose: vi.fn(),
+        players: mockPlayers,
+        currentPlayer: mockCurrentPlayer,
+    };
+    const merged = { ...defaultProps, ...props };
+    const result = render(<TradeModal {...merged} />);
+    return { ...result, onClose: merged.onClose };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("TradeModal", () => {
+    let user: ReturnType<typeof userEvent.setup>;
+
+    beforeEach(() => {
+        user = userEvent.setup();
+    });
+
+    // 1. Renders when open
+    it("renders trade UI when isOpen is true", () => {
+        renderModal();
+        expect(screen.getByTestId("trade-modal")).toBeDefined();
+        expect(screen.getByText("Propose Trade")).toBeDefined();
+        expect(screen.getByLabelText("Trade Partner")).toBeDefined();
+        expect(screen.getByTestId("offer-column")).toBeDefined();
+        expect(screen.getByTestId("request-column")).toBeDefined();
+        expect(screen.getByTestId("cancel-button")).toBeDefined();
+        expect(screen.getByTestId("confirm-button")).toBeDefined();
+    });
+
+    // 2. Hidden when closed
+    it("does not render when isOpen is false", () => {
+        renderModal({ isOpen: false });
+        expect(screen.queryByTestId("trade-modal")).toBeNull();
+    });
+
+    // 3. Close via Cancel button
+    it("calls onClose when Cancel is clicked", async () => {
+        const { onClose } = renderModal();
+        await user.click(screen.getByTestId("cancel-button"));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    // 4. Close via Escape key
+    it("calls onClose when Escape is pressed", async () => {
+        const { onClose } = renderModal();
+        await user.keyboard("{Escape}");
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    // 5. Close via backdrop click
+    it("calls onClose when backdrop is clicked", async () => {
+        const { onClose } = renderModal();
+        await user.click(screen.getByTestId("trade-modal-backdrop"));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    // 6. Partner selection
+    it("allows selecting a trade partner", async () => {
+        renderModal();
+        const select = screen.getByLabelText("Trade Partner") as HTMLSelectElement;
+        await user.selectOptions(select, "p2");
+        expect(select.value).toBe("p2");
+    });
+
+    // 7. Validation: no partner selected
+    it("shows error when confirming without selecting a partner", async () => {
+        renderModal();
+        await user.click(screen.getByTestId("confirm-button"));
+        expect(screen.getByTestId("validation-error")).toBeDefined();
+        expect(screen.getByText("Please select a trade partner.")).toBeDefined();
+    });
+
+    // 8. Validation: empty trade (nothing offered or requested)
+    it("shows error when confirming an empty trade", async () => {
+        renderModal();
+        // Select partner first
+        const select = screen.getByLabelText("Trade Partner") as HTMLSelectElement;
+        await user.selectOptions(select, "p2");
+        // Confirm without selecting anything
+        await user.click(screen.getByTestId("confirm-button"));
+        expect(screen.getByTestId("validation-error")).toBeDefined();
+        expect(
+            screen.getByText(
+                "You must offer or request at least one property or some cash."
+            )
+        ).toBeDefined();
+    });
+
+    // 9. Full mock trade flow
+    it("completes a full mock trade flow", async () => {
+        const { onClose } = renderModal();
+        const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { });
+
+        // Select trade partner
+        const select = screen.getByLabelText("Trade Partner") as HTMLSelectElement;
+        await user.selectOptions(select, "p2");
+        expect(select.value).toBe("p2");
+
+        // Offer a property
+        const parkPlace = screen.getByTestId("offer-property-park-place");
+        await user.click(parkPlace);
+
+        // Request a property
+        const medAve = screen.getByTestId("request-property-mediterranean-ave");
+        await user.click(medAve);
+
+        // Offer cash
+        const offerCashInput = screen.getByTestId("offer-cash-input");
+        await user.type(offerCashInput, "100");
+
+        // Confirm trade
+        await user.click(screen.getByTestId("confirm-button"));
+
+        // Validation error should NOT appear
+        expect(screen.queryByTestId("validation-error")).toBeNull();
+
+        // onClose should have been called
+        expect(onClose).toHaveBeenCalledTimes(1);
+
+        // Console log should have been called with trade details
+        expect(consoleSpy).toHaveBeenCalledWith(
+            "Trade proposed:",
+            expect.objectContaining({
+                from: "Alice",
+                to: "Bob",
+                offeredProperties: ["Park Place"],
+                requestedProperties: ["Mediterranean Ave"],
+                offeredCash: 100,
+            })
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    // 10. Shows current player's properties in offer column
+    it("displays current player properties in the offer column", () => {
+        renderModal();
+        const offerCol = screen.getByTestId("offer-column");
+        expect(within(offerCol).getByText("Park Place")).toBeDefined();
+        expect(within(offerCol).getByText("Boardwalk")).toBeDefined();
+        expect(within(offerCol).getByText("Reading Railroad")).toBeDefined();
+    });
+
+    // 11. Request column disabled until partner selected
+    it("disables the request column when no partner is selected", () => {
+        renderModal();
+        const requestCol = screen.getByTestId("request-column");
+        expect(requestCol.className).toContain("pointer-events-none");
+    });
+
+    // 12. Close button (X) works
+    it("calls onClose when the X button is clicked", async () => {
+        const { onClose } = renderModal();
+        await user.click(screen.getByLabelText("Close trade modal"));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Closes #136
- Create TradeModal with partner selector, property offer/request, cash inputs
- Tycoon dark/cyan styling with lucide-react icons
- Accessible modal (focus trap, Escape, ARIA attributes)
- Form validation (partner required, must trade something, cash bounds)
- Add demo page at /trade-demo
- Add 12 comprehensive tests (all passing)