### PR TITLE
feat: implement POST /games endpoint with validation

### DIFF
--- a/backend/src/modules/games/dto/create-game.dto.ts
+++ b/backend/src/modules/games/dto/create-game.dto.ts
@@ -1,17 +1,35 @@
-import { IsOptional, IsString, IsInt, Min, Max, ValidateNested } from 'class-validator';
+import {
+  IsOptional,
+  IsEnum,
+  IsInt,
+  Min,
+  Max,
+  ValidateNested,
+  IsBoolean,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { CreateGameSettingsDto } from './create-game-settings.dto';
+import { GameMode } from '../entities/game.entity';
 
 export class CreateGameDto {
-  @ApiProperty({ example: 'PUBLIC' })
-  @IsString()
-  mode: string;
+  @ApiProperty({
+    example: 'PUBLIC',
+    enum: GameMode,
+    description: 'Game mode (PUBLIC or PRIVATE)',
+  })
+  @IsEnum(GameMode, { message: 'mode must be either PUBLIC or PRIVATE' })
+  mode: GameMode;
 
-  @ApiProperty({ example: 4 })
-  @IsInt()
-  @Min(2)
-  @Max(8)
+  @ApiProperty({
+    example: 4,
+    description: 'Number of players (2-8)',
+  })
+  @IsInt({ message: 'numberOfPlayers must be an integer' })
+  @Min(2, { message: 'numberOfPlayers must be at least 2' })
+  @Max(8, { message: 'numberOfPlayers cannot exceed 8' })
   numberOfPlayers: number;
 
   @ApiPropertyOptional()
@@ -19,4 +37,38 @@ export class CreateGameDto {
   @ValidateNested()
   @Type(() => CreateGameSettingsDto)
   settings?: CreateGameSettingsDto;
+
+  @ApiPropertyOptional({
+    default: false,
+    description: 'Whether the game includes AI players',
+  })
+  @IsOptional()
+  @IsBoolean({ message: 'is_ai must be a boolean' })
+  is_ai?: boolean;
+
+  @ApiPropertyOptional({
+    default: false,
+    description: 'Whether the game uses MiniPay',
+  })
+  @IsOptional()
+  @IsBoolean({ message: 'is_minipay must be a boolean' })
+  is_minipay?: boolean;
+
+  @ApiPropertyOptional({
+    example: 'ethereum',
+    description: 'Blockchain chain for the game (optional)',
+  })
+  @IsOptional()
+  @IsString({ message: 'chain must be a string' })
+  @MaxLength(255, { message: 'chain cannot exceed 255 characters' })
+  chain?: string;
+
+  @ApiPropertyOptional({
+    example: '0x123abc...',
+    description: 'Smart contract game ID (optional)',
+  })
+  @IsOptional()
+  @IsString({ message: 'contract_game_id must be a string' })
+  @MaxLength(78, { message: 'contract_game_id cannot exceed 78 characters' })
+  contract_game_id?: string;
 }

--- a/backend/src/modules/games/games.controller.ts
+++ b/backend/src/modules/games/games.controller.ts
@@ -9,6 +9,8 @@ import {
   Query,
   UseGuards,
   Req,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import type { Request } from 'express';
 import {
@@ -16,6 +18,9 @@ import {
   ApiOperation,
   ApiCreatedResponse,
   ApiOkResponse,
+  ApiBearerAuth,
+  ApiUnauthorizedResponse,
+  ApiBadRequestResponse,
 } from '@nestjs/swagger';
 import { GamePlayersService } from './game-players.service';
 import { GamesService } from './games.service';
@@ -33,10 +38,44 @@ export class GamesController {
   ) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Create a new game' })
-  @ApiCreatedResponse({ description: 'Game and settings created' })
-  async create(@Body() dto: CreateGameDto) {
-    return this.gamesService.create(dto);
+  @ApiCreatedResponse({
+    description: 'Game created successfully',
+    schema: {
+      example: {
+        id: 1,
+        code: 'ABC123',
+        mode: 'PUBLIC',
+        numberOfPlayers: 4,
+        status: 'PENDING',
+        is_ai: false,
+        is_minipay: false,
+        chain: null,
+        contract_game_id: null,
+        creator_id: 1,
+        created_at: '2024-01-01T00:00:00.000Z',
+        settings: {
+          auction: true,
+          rentInPrison: false,
+          mortgage: true,
+          evenBuild: true,
+          randomizePlayOrder: true,
+          startingCash: 1500,
+        },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'User not authenticated' })
+  @ApiBadRequestResponse({ description: 'Invalid input data' })
+  async create(
+    @Body() dto: CreateGameDto,
+    @Req() req: Request & { user: { id: number; role?: string } },
+  ) {
+    const creatorId = req.user.id;
+    return this.gamesService.create(dto, creatorId);
   }
 
   @Get(':gameId/players')

--- a/backend/src/modules/games/games.service.spec.ts
+++ b/backend/src/modules/games/games.service.spec.ts
@@ -1,0 +1,200 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GamesService } from './games.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Game, GameMode, GameStatus } from './entities/game.entity';
+import { GameSettings } from './entities/game-settings.entity';
+import { DataSource, Repository } from 'typeorm';
+import { CreateGameDto } from './dto/create-game.dto';
+
+describe('GamesService', () => {
+  let service: GamesService;
+  let gameRepository: Repository<Game>;
+  let gameSettingsRepository: Repository<GameSettings>;
+  let dataSource: DataSource;
+
+  const mockGameRepository = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockGameSettingsRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockQueryRunner = {
+    connect: jest.fn(),
+    startTransaction: jest.fn(),
+    commitTransaction: jest.fn(),
+    rollbackTransaction: jest.fn(),
+    release: jest.fn(),
+    manager: {
+      create: jest.fn(),
+      save: jest.fn(),
+    },
+  };
+
+  const mockDataSource = {
+    createQueryRunner: jest.fn(() => mockQueryRunner),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GamesService,
+        {
+          provide: getRepositoryToken(Game),
+          useValue: mockGameRepository,
+        },
+        {
+          provide: getRepositoryToken(GameSettings),
+          useValue: mockGameSettingsRepository,
+        },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+      ],
+    }).compile();
+
+    service = module.get<GamesService>(GamesService);
+    gameRepository = module.get<Repository<Game>>(getRepositoryToken(Game));
+    gameSettingsRepository = module.get<Repository<GameSettings>>(
+      getRepositoryToken(GameSettings),
+    );
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create a game with default settings', async () => {
+      const dto: CreateGameDto = {
+        mode: GameMode.PUBLIC,
+        numberOfPlayers: 4,
+      };
+      const creatorId = 1;
+
+      // Mock unique code check
+      mockGameRepository.findOne.mockResolvedValue(null);
+
+      // Mock game creation
+      const mockGame = {
+        id: 1,
+        code: 'ABC123',
+        mode: GameMode.PUBLIC,
+        number_of_players: 4,
+        creator_id: creatorId,
+        status: GameStatus.PENDING,
+        is_ai: false,
+        is_minipay: false,
+        chain: null,
+        contract_game_id: null,
+        created_at: new Date(),
+      };
+      mockQueryRunner.manager.create.mockReturnValue(mockGame);
+      mockQueryRunner.manager.save.mockResolvedValue(mockGame);
+
+      // Mock settings creation
+      const mockSettings = {
+        game_id: 1,
+        auction: true,
+        rentInPrison: false,
+        mortgage: true,
+        evenBuild: true,
+        randomizePlayOrder: true,
+        startingCash: 1500,
+      };
+      mockQueryRunner.manager.create.mockReturnValueOnce(mockGame);
+      mockQueryRunner.manager.create.mockReturnValueOnce(mockSettings);
+      mockQueryRunner.manager.save.mockResolvedValueOnce(mockGame);
+      mockQueryRunner.manager.save.mockResolvedValueOnce(mockSettings);
+
+      const result = await service.create(dto, creatorId);
+
+      expect(mockQueryRunner.connect).toHaveBeenCalled();
+      expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.release).toHaveBeenCalled();
+      expect(result).toHaveProperty('id');
+      expect(result).toHaveProperty('code');
+      expect(result.mode).toBe(GameMode.PUBLIC);
+      expect(result.numberOfPlayers).toBe(4);
+      expect(result.creator_id).toBe(creatorId);
+      expect(result.is_ai).toBe(false);
+      expect(result.is_minipay).toBe(false);
+    });
+
+    it('should create a game with AI and MiniPay flags', async () => {
+      const dto: CreateGameDto = {
+        mode: GameMode.PRIVATE,
+        numberOfPlayers: 2,
+        is_ai: true,
+        is_minipay: true,
+        chain: 'ethereum',
+        contract_game_id: '0x123abc',
+      };
+      const creatorId = 2;
+
+      mockGameRepository.findOne.mockResolvedValue(null);
+
+      const mockGame = {
+        id: 2,
+        code: 'XYZ789',
+        mode: GameMode.PRIVATE,
+        number_of_players: 2,
+        creator_id: creatorId,
+        status: GameStatus.PENDING,
+        is_ai: true,
+        is_minipay: true,
+        chain: 'ethereum',
+        contract_game_id: '0x123abc',
+        created_at: new Date(),
+      };
+      mockQueryRunner.manager.create.mockReturnValue(mockGame);
+      mockQueryRunner.manager.save.mockResolvedValue(mockGame);
+
+      const mockSettings = {
+        game_id: 2,
+        auction: true,
+        rentInPrison: false,
+        mortgage: true,
+        evenBuild: true,
+        randomizePlayOrder: true,
+        startingCash: 1500,
+      };
+      mockQueryRunner.manager.create.mockReturnValueOnce(mockGame);
+      mockQueryRunner.manager.create.mockReturnValueOnce(mockSettings);
+      mockQueryRunner.manager.save.mockResolvedValueOnce(mockGame);
+      mockQueryRunner.manager.save.mockResolvedValueOnce(mockSettings);
+
+      const result = await service.create(dto, creatorId);
+
+      expect(result.is_ai).toBe(true);
+      expect(result.is_minipay).toBe(true);
+      expect(result.chain).toBe('ethereum');
+      expect(result.contract_game_id).toBe('0x123abc');
+    });
+
+    it('should rollback transaction on error', async () => {
+      const dto: CreateGameDto = {
+        mode: GameMode.PUBLIC,
+        numberOfPlayers: 4,
+      };
+      const creatorId = 1;
+
+      mockGameRepository.findOne.mockResolvedValue(null);
+      mockQueryRunner.manager.create.mockImplementation(() => {
+        throw new Error('Database error');
+      });
+
+      await expect(service.create(dto, creatorId)).rejects.toThrow('Database error');
+
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/games/games.service.ts
+++ b/backend/src/modules/games/games.service.ts
@@ -14,6 +14,19 @@ const DEFAULT_SETTINGS = {
   startingCash: 1500,
 };
 
+/**
+ * Generate a unique game code
+ * Format: 6-character alphanumeric string (uppercase letters and numbers)
+ */
+function generateGameCode(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let code = '';
+  for (let i = 0; i < 6; i++) {
+    code += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return code;
+}
+
 @Injectable()
 export class GamesService {
   constructor(
@@ -25,14 +38,44 @@ export class GamesService {
   ) {}
 
   /**
+   * Generate a unique game code, retrying if collision occurs
+   */
+  private async generateUniqueCode(): Promise<string> {
+    let code = generateGameCode();
+    let attempts = 0;
+    const maxAttempts = 10;
+
+    while (attempts < maxAttempts) {
+      const existing = await this.gameRepository.findOne({
+        where: { code },
+      });
+
+      if (!existing) {
+        return code;
+      }
+
+      code = generateGameCode();
+      attempts++;
+    }
+
+    throw new Error('Failed to generate unique game code after multiple attempts');
+  }
+
+  /**
    * Create a game with optional settings in a single transaction.
    * Uses defaults if no settings provided. Rollback on failure.
    */
-  async create(dto: CreateGameDto): Promise<{
+  async create(dto: CreateGameDto, creatorId: number): Promise<{
     id: number;
+    code: string;
     mode: string;
     numberOfPlayers: number;
     status: string;
+    is_ai: boolean;
+    is_minipay: boolean;
+    chain: string | null;
+    contract_game_id: string | null;
+    creator_id: number;
     created_at: Date;
     settings: {
       auction: boolean;
@@ -48,10 +91,19 @@ export class GamesService {
     await queryRunner.startTransaction();
 
     try {
+      // Generate unique game code
+      const gameCode = await this.generateUniqueCode();
+
       const game = queryRunner.manager.create(Game, {
+        code: gameCode,
         mode: dto.mode as GameMode,
         number_of_players: dto.numberOfPlayers,
+        creator_id: creatorId,
         status: GameStatus.PENDING,
+        is_ai: dto.is_ai ?? false,
+        is_minipay: dto.is_minipay ?? false,
+        chain: dto.chain ?? null,
+        contract_game_id: dto.contract_game_id ?? null,
       });
       const savedGame = await queryRunner.manager.save(game);
 
@@ -75,9 +127,15 @@ export class GamesService {
 
       return {
         id: savedGame.id,
+        code: savedGame.code,
         mode: savedGame.mode,
         numberOfPlayers: savedGame.number_of_players,
         status: savedGame.status,
+        is_ai: savedGame.is_ai,
+        is_minipay: savedGame.is_minipay,
+        chain: savedGame.chain,
+        contract_game_id: savedGame.contract_game_id,
+        creator_id: savedGame.creator_id,
         created_at: savedGame.created_at,
         settings: {
           auction: settingsPayload.auction,


### PR DESCRIPTION
closes #145 

#Summary
- Enhanced CreateGameDto with enum validation for mode
- Added is_ai, is_minipay, chain, and contract_game_id fields
- Implemented auto-generated unique game code (6-char alphanumeric)
- Added JwtAuthGuard to protect the endpoint
- Creator is now attached from authenticated user
- Added comprehensive unit tests for GamesService