### PR TITLE
feat(frontend): implement useCardModal defining explicit Chance and C…

### DIFF
--- a/frontend/src/hooks/useCardModal.ts
+++ b/frontend/src/hooks/useCardModal.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react';
+
+export type CardType = 'chance' | 'community';
+
+export interface CardData {
+    type: CardType;
+    text: string;
+}
+
+export interface UseCardModalReturn {
+    isOpen: boolean;
+    card: CardData | null;
+    openCard: (card: CardData) => void;
+    close: () => void;
+}
+
+export function useCardModal(): UseCardModalReturn {
+    const [isOpen, setIsOpen] = useState(false);
+    const [card, setCard] = useState<CardData | null>(null);
+
+    const openCard = useCallback((cardData: CardData) => {
+        setCard(cardData);
+        setIsOpen(true);
+    }, []);
+
+    const close = useCallback(() => {
+        setIsOpen(false);
+        // Explicitly clean state upon closing guaranteeing sterile conditions.
+        setCard(null);
+    }, []);
+
+    return { isOpen, card, openCard, close };
+}

--- a/frontend/test/useCardModal.test.tsx
+++ b/frontend/test/useCardModal.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useCardModal } from '../src/hooks/useCardModal';
+
+describe('useCardModal', () => {
+    it('should initialize with default closed state', () => {
+        const { result } = renderHook(() => useCardModal());
+        expect(result.current.isOpen).toBe(false);
+        expect(result.current.card).toBeNull();
+    });
+
+    it('should open the modal and set card data', () => {
+        const { result } = renderHook(() => useCardModal());
+
+        act(() => {
+            result.current.openCard({ type: 'chance', text: 'Go directly to Jail' });
+        });
+
+        expect(result.current.isOpen).toBe(true);
+        expect(result.current.card).toEqual({ type: 'chance', text: 'Go directly to Jail' });
+    });
+
+    it('should close the modal and clear state cleanly mapped', () => {
+        const { result } = renderHook(() => useCardModal());
+
+        act(() => {
+            result.current.openCard({ type: 'community', text: 'Bank error in your favor' });
+        });
+
+        expect(result.current.isOpen).toBe(true);
+        expect(result.current.card).not.toBeNull();
+
+        act(() => {
+            result.current.close();
+        });
+
+        expect(result.current.isOpen).toBe(false);
+        expect(result.current.card).toBeNull();
+    });
+});


### PR DESCRIPTION
I have completed Issue #124 (Create useCardModal hook) in the Tycoon-Monorepo and successfully pushed the changes!

Here is what was completed locally:

Created useCardModal Hook: Deployed to frontend/src/hooks/useCardModal.ts, implementing standard state mechanisms supporting { isOpen, card, openCard, close }.
Explicit Typings: Strictly mapped the CardData types matching {'chance' | 'community'} to resolve precise structural bounds.
Graceful Lifecycle Resets: Engineered the close function to drop CardData state to null, ensuring memory stays completely sterile when the modal shuts.
Unit Testing: Placed structural tests targeting Vitest into frontend/test/useCardModal.test.tsx checking state lifecycles reliably.

Closes #124 