### PR TITLE
[BE] Implement turn management logic

### DIFF
--- a/backend/src/modules/games/game-players.service.spec.ts
+++ b/backend/src/modules/games/game-players.service.spec.ts
@@ -1,0 +1,269 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { GamePlayersService } from './game-players.service';
+import { Game } from './entities/game.entity';
+import { GamePlayer } from './entities/game-player.entity';
+import { PaginationService } from '../../common/services/pagination.service';
+
+describe('GamePlayersService', () => {
+  let service: GamePlayersService;
+  let gameRepository: Repository<Game>;
+  let gamePlayerRepository: Repository<GamePlayer>;
+
+  const mockGameRepository = {
+    findOne: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockGamePlayerRepository = {
+    find: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockPaginationService = {
+    paginate: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GamePlayersService,
+        {
+          provide: getRepositoryToken(Game),
+          useValue: mockGameRepository,
+        },
+        {
+          provide: getRepositoryToken(GamePlayer),
+          useValue: mockGamePlayerRepository,
+        },
+        {
+          provide: PaginationService,
+          useValue: mockPaginationService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<GamePlayersService>(GamePlayersService);
+    gameRepository = module.get<Repository<Game>>(getRepositoryToken(Game));
+    gamePlayerRepository = module.get<Repository<GamePlayer>>(
+      getRepositoryToken(GamePlayer),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('advanceTurn', () => {
+    it('rotates to the next non-jailed player and updates next_player_id', async () => {
+      const game: Game = {
+        id: 1,
+        code: 'ABC123',
+        mode: null,
+        creator_id: 1,
+        status: null,
+        winner_id: null,
+        number_of_players: 3,
+        next_player_id: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+        is_ai: false,
+        is_minipay: false,
+        chain: null,
+        duration: null,
+        started_at: null,
+        contract_game_id: null,
+        placements: null,
+        creator: null,
+        winner: null,
+        nextPlayer: null,
+      } as unknown as Game;
+
+      const players: GamePlayer[] = [
+        {
+          id: 1,
+          game_id: 1,
+          user_id: 1,
+          symbol: 'A',
+          position: 0,
+          balance: 0,
+          in_jail: false,
+          in_jail_rolls: 0,
+          circle: 0,
+          turn_order: 1,
+          turn_start: '100',
+          consecutive_timeouts: 0,
+          turn_count: 0,
+          last_timeout_turn_start: null,
+          trade_locked_balance: '0.00',
+          rolled: null,
+          address: null,
+        } as unknown as GamePlayer,
+        {
+          id: 2,
+          game_id: 1,
+          user_id: 2,
+          symbol: 'B',
+          position: 0,
+          balance: 0,
+          in_jail: true,
+          in_jail_rolls: 0,
+          circle: 0,
+          turn_order: 2,
+          turn_start: null,
+          consecutive_timeouts: 0,
+          turn_count: 0,
+          last_timeout_turn_start: null,
+          trade_locked_balance: '0.00',
+          rolled: null,
+          address: null,
+        } as unknown as GamePlayer,
+        {
+          id: 3,
+          game_id: 1,
+          user_id: 3,
+          symbol: 'C',
+          position: 0,
+          balance: 0,
+          in_jail: false,
+          in_jail_rolls: 0,
+          circle: 0,
+          turn_order: 3,
+          turn_start: null,
+          consecutive_timeouts: 0,
+          turn_count: 0,
+          last_timeout_turn_start: null,
+          trade_locked_balance: '0.00',
+          rolled: null,
+          address: null,
+        } as unknown as GamePlayer,
+      ];
+
+      mockGameRepository.findOne.mockResolvedValue(game);
+      mockGameRepository.save.mockImplementation(async (g) => g);
+      mockGamePlayerRepository.find.mockResolvedValue(players);
+      mockGamePlayerRepository.save.mockImplementation(
+        async (entities) => entities,
+      );
+
+      await service.advanceTurn(1, 1, { isTimeout: false, now: '200' });
+
+      expect(gamePlayerRepository.find).toHaveBeenCalledWith({
+        where: { game_id: 1 },
+        order: { turn_order: 'ASC' },
+      });
+
+      expect(gamePlayerRepository.save).toHaveBeenCalledTimes(1);
+      const savedArgs = (gamePlayerRepository.save as jest.Mock).mock
+        .calls[0][0];
+      const [savedCurrent, savedNext] = savedArgs as GamePlayer[];
+
+      expect(savedCurrent.user_id).toBe(1);
+      expect(savedCurrent.turn_start).toBeNull();
+      expect(savedCurrent.consecutive_timeouts).toBe(0);
+
+      expect(savedNext.user_id).toBe(3);
+      expect(savedNext.turn_start).toBe('200');
+      expect(savedNext.turn_count).toBe(1);
+      expect(savedNext.consecutive_timeouts).toBe(0);
+      expect(savedNext.rolled).toBe(0);
+
+      expect(gameRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 1,
+          next_player_id: 3,
+        }),
+      );
+    });
+
+    it('increments consecutive_timeouts on timeout', async () => {
+      const game: Game = {
+        id: 1,
+        code: 'ABC123',
+        mode: null,
+        creator_id: 1,
+        status: null,
+        winner_id: null,
+        number_of_players: 2,
+        next_player_id: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+        is_ai: false,
+        is_minipay: false,
+        chain: null,
+        duration: null,
+        started_at: null,
+        contract_game_id: null,
+        placements: null,
+        creator: null,
+        winner: null,
+        nextPlayer: null,
+      } as unknown as Game;
+
+      const players: GamePlayer[] = [
+        {
+          id: 1,
+          game_id: 1,
+          user_id: 1,
+          symbol: 'A',
+          position: 0,
+          balance: 0,
+          in_jail: false,
+          in_jail_rolls: 0,
+          circle: 0,
+          turn_order: 1,
+          turn_start: '100',
+          consecutive_timeouts: 1,
+          turn_count: 0,
+          last_timeout_turn_start: null,
+          trade_locked_balance: '0.00',
+          rolled: null,
+          address: null,
+        } as unknown as GamePlayer,
+        {
+          id: 2,
+          game_id: 1,
+          user_id: 2,
+          symbol: 'B',
+          position: 0,
+          balance: 0,
+          in_jail: false,
+          in_jail_rolls: 0,
+          circle: 0,
+          turn_order: 2,
+          turn_start: null,
+          consecutive_timeouts: 0,
+          turn_count: 0,
+          last_timeout_turn_start: null,
+          trade_locked_balance: '0.00',
+          rolled: null,
+          address: null,
+        } as unknown as GamePlayer,
+      ];
+
+      mockGameRepository.findOne.mockResolvedValue(game);
+      mockGameRepository.save.mockImplementation(async (g) => g);
+      mockGamePlayerRepository.find.mockResolvedValue(players);
+      mockGamePlayerRepository.save.mockImplementation(
+        async (entities) => entities,
+      );
+
+      await service.advanceTurn(1, 1, { isTimeout: true, now: '200' });
+
+      const savedArgs = (gamePlayerRepository.save as jest.Mock).mock
+        .calls[0][0];
+      const [savedCurrent, savedNext] = savedArgs as GamePlayer[];
+
+      expect(savedCurrent.user_id).toBe(1);
+      expect(savedCurrent.consecutive_timeouts).toBe(2);
+      expect(savedCurrent.last_timeout_turn_start).toBe('100');
+      expect(savedCurrent.turn_start).toBeNull();
+
+      expect(savedNext.user_id).toBe(2);
+      expect(savedNext.turn_start).toBe('200');
+      expect(savedNext.turn_count).toBe(1);
+      expect(savedNext.rolled).toBe(0);
+    });
+  });
+});

--- a/backend/src/modules/games/game-players.service.ts
+++ b/backend/src/modules/games/game-players.service.ts
@@ -67,7 +67,9 @@ export class GamePlayersService {
         `Cannot unlock ${amount}: locked balance is ${currentLocked}`,
       );
     }
-    player.trade_locked_balance = Math.max(0, currentLocked - amount).toFixed(2);
+    player.trade_locked_balance = Math.max(0, currentLocked - amount).toFixed(
+      2,
+    );
     return this.gamePlayerRepository.save(player);
   }
 
@@ -97,7 +99,9 @@ export class GamePlayersService {
   private async isGameStarted(gameId: number): Promise<boolean> {
     const game = await this.gameRepository.findOne({ where: { id: gameId } });
     if (!game) return false;
-    return game.status === GameStatus.RUNNING || game.status === GameStatus.FINISHED;
+    return (
+      game.status === GameStatus.RUNNING || game.status === GameStatus.FINISHED
+    );
   }
 
   async update(
@@ -193,5 +197,66 @@ export class GamePlayersService {
     }
 
     return this.paginationService.paginate(qb, dto, []);
+  }
+
+  async advanceTurn(
+    gameId: number,
+    currentUserId: number,
+    options?: { isTimeout?: boolean; now?: string },
+  ): Promise<void> {
+    const game = await this.gameRepository.findOne({ where: { id: gameId } });
+    if (!game) {
+      throw new NotFoundException(`Game ${gameId} not found`);
+    }
+
+    const players = await this.gamePlayerRepository.find({
+      where: { game_id: gameId },
+      order: { turn_order: 'ASC' },
+    });
+
+    if (players.length === 0) {
+      throw new BadRequestException('No players found for this game');
+    }
+
+    const currentIndex = players.findIndex(
+      (player) => player.user_id === currentUserId,
+    );
+
+    if (currentIndex === -1) {
+      throw new NotFoundException(
+        `User ${currentUserId} is not a player in game ${gameId}`,
+      );
+    }
+
+    const currentPlayer = players[currentIndex];
+    const isTimeout = options?.isTimeout ?? false;
+    const now = options?.now ?? Date.now().toString();
+
+    if (isTimeout) {
+      currentPlayer.consecutive_timeouts += 1;
+      currentPlayer.last_timeout_turn_start = currentPlayer.turn_start;
+    } else {
+      currentPlayer.consecutive_timeouts = 0;
+    }
+    currentPlayer.turn_start = null;
+
+    let nextPlayer = currentPlayer;
+    for (let offset = 1; offset <= players.length; offset++) {
+      const index = (currentIndex + offset) % players.length;
+      const candidate = players[index];
+      if (!candidate.in_jail) {
+        nextPlayer = candidate;
+        break;
+      }
+    }
+
+    nextPlayer.turn_start = now;
+    nextPlayer.turn_count += 1;
+    nextPlayer.consecutive_timeouts = 0;
+    nextPlayer.rolled = 0;
+
+    await this.gamePlayerRepository.save([currentPlayer, nextPlayer]);
+    game.next_player_id = nextPlayer.user_id;
+    await this.gameRepository.save(game);
   }
 }


### PR DESCRIPTION
This pull request implements the backend turn management logic for Issue #163.

Turn management behavior

- Advances the turn to the next player in turn order.
- Skips players who are currently in jail when selecting the next player.
- Tracks per-player turn_count.
- Tracks consecutive_timeouts and last_timeout_turn_start when a turn ends due to timeout.
- Sets a new turn_start timestamp for the next active player.
- Resets rolled state for the next player so that dice rolling can be tracked per turn.
- Updates next_player_id on the Game entity to match the selected next player.

Implementation details

- Service: GamePlayersService
  - Added advanceTurn(gameId, currentUserId, options)
    - Looks up the Game and validates that it exists.
    - Loads all GamePlayer records for that game ordered by turn_order.
    - Locates the current player by user id.
    - On timeout, increments consecutive_timeouts and stores the previous turn_start into last_timeout_turn_start.
    - Clears the current player turn_start.
    - Chooses the next player by stepping through turn_order and skipping jailed players (in_jail = true). If all players are jailed, the current player retains the turn.
    - For the chosen next player, sets turn_start to the provided timestamp, increments turn_count, resets consecutive_timeouts, and sets rolled to 0.
    - Persists updated GamePlayer rows and sets Game.next_player_id to the next player user id.

Tests

- Added unit tests in game-players.service.spec.ts that cover:
  - Rotating to the next non-jailed player and updating next_player_id.
  - Incrementing consecutive_timeouts on timeouts and copying the previous turn_start into last_timeout_turn_start.

Link to issue

Closes #163.~