### PR TITLE
Implement Update Game API

### DIFF
--- a/backend/src/modules/games/dto/update-game.dto.ts
+++ b/backend/src/modules/games/dto/update-game.dto.ts
@@ -1,0 +1,66 @@
+import {
+  IsOptional,
+  IsEnum,
+  IsInt,
+  IsObject,
+  IsString,
+  MaxLength,
+  IsDateString,
+  Min,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { GameStatus } from '../entities/game.entity';
+import type { GamePlacements } from '../entities/game.entity';
+
+export class UpdateGameDto {
+  @ApiPropertyOptional({
+    enum: GameStatus,
+    description: 'Game status (PENDING, RUNNING, FINISHED, CANCELLED)',
+  })
+  @IsOptional()
+  @IsEnum(GameStatus, {
+    message: 'status must be one of PENDING, RUNNING, FINISHED, CANCELLED',
+  })
+  status?: GameStatus;
+
+  @ApiPropertyOptional({
+    description: 'ID of the player whose turn is next',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  nextPlayerId?: number;
+
+  @ApiPropertyOptional({
+    description: 'ID of the winning player (when game is finished)',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  winnerId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Placements map: playerId -> placement rank (1-based)',
+    example: { 1: 2, 2: 1, 3: 3 },
+  })
+  @IsOptional()
+  @IsObject()
+  placements?: GamePlacements;
+
+  @ApiPropertyOptional({
+    description: 'Smart contract game ID',
+    maxLength: 78,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(78, { message: 'contract_game_id cannot exceed 78 characters' })
+  contract_game_id?: string;
+
+  @ApiPropertyOptional({
+    description: 'When the game started (ISO 8601)',
+    example: '2024-01-15T10:30:00.000Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  startTime?: string;
+}


### PR DESCRIPTION
# PATCH /games/:id – Partial game updates

## Summary

Adds `PATCH /games/:id` to support partial updates of a game with validation, illegal status transition guards, and role-based access.

## Endpoint

- **Method:** `PATCH`
- **Path:** `/games/:id`
- **Auth:** Bearer JWT required

## Updatable fields

| Field | Type | Description |
|-------|------|-------------|
| `status` | `GameStatus` | PENDING, RUNNING, FINISHED, CANCELLED |
| `nextPlayerId` | number | ID of the player whose turn is next |
| `winnerId` | number | ID of the winning player (when finished) |
| `placements` | object | Map of playerId → placement rank (1-based) |
| `contract_game_id` | string | Smart contract game ID (max 78 chars) |
| `startTime` | string | ISO 8601 date (mapped to `started_at`) |

All fields are optional; only provided fields are updated.
Closes #148 
## Acceptance criteria

- **Partial updates** – Request body can include any subset of the fields above.
- **Validation** – Input validated via `UpdateGameDto` (class-validator); invalid payloads return `400`.
- **Illegal transitions** – Transitions from `FINISHED` or `CANCELLED` to `RUNNING` are rejected with `400 Bad Request`.
- **Role-based permissions** – Only the **game creator** or an **admin** can update a game; others receive `403 Forbidden`.

## Changes

- **New:** `dto/update-game.dto.ts` – DTO with optional, validated fields.
- **Updated:** `games.controller.ts` – New `PATCH :id` handler with JWT guard and Swagger docs.
- **Updated:** `games.service.ts` – New `update(id, dto, userId, userRole)` with permission check and status transition validation.

## Example request

PATCH /games/1
Authorization: Bearer <token>
Content-Type: application/json

{
  "status": "RUNNING",
  "nextPlayerId": 2,
  "startTime": "2024-01-15T10:30:00.000Z"
}
