### PR TITLE
feature/game-settings-entity-ddl

### DIFF
--- a/backend/src/modules/games/entities/game-settings.entity.ts
+++ b/backend/src/modules/games/entities/game-settings.entity.ts
@@ -9,39 +9,54 @@ import {
 } from 'typeorm';
 import { Game } from './game.entity';
 
+/**
+ * Game settings entity matching game_settings table DDL.
+ * Stores configuration for each game. One-to-one with Game.
+ */
 @Entity({ name: 'game_settings' })
 export class GameSettings {
   @PrimaryGeneratedColumn({ type: 'int', unsigned: true })
   id: number;
 
-  @Column({ type: 'int', unsigned: true, unique: true })
+  @Column({ type: 'int', unsigned: true, name: 'game_id' })
   game_id: number;
 
   @OneToOne(() => Game, (game) => game.settings, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'game_id' })
   game: Game;
 
-  @Column({ type: 'boolean', default: true })
+  @Column({ type: 'boolean', default: false })
   auction: boolean;
 
   @Column({ type: 'boolean', default: false, name: 'rent_in_prison' })
   rentInPrison: boolean;
 
-  @Column({ type: 'boolean', default: true })
+  @Column({ type: 'boolean', default: false })
   mortgage: boolean;
 
-  @Column({ type: 'boolean', default: true, name: 'even_build' })
+  @Column({ type: 'boolean', default: false, name: 'even_build' })
   evenBuild: boolean;
 
-  @Column({ type: 'boolean', default: true, name: 'randomize_play_order' })
+  @Column({ type: 'boolean', default: false, name: 'randomize_play_order' })
   randomizePlayOrder: boolean;
 
-  @Column({ type: 'int', unsigned: true, default: 1500, name: 'starting_cash' })
+  @Column({
+    type: 'int',
+    unsigned: true,
+    default: 1500,
+    name: 'starting_cash',
+  })
   startingCash: number;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({
+    type: 'timestamp',
+    name: 'created_at',
+  })
   created_at: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
+  @UpdateDateColumn({
+    type: 'timestamp',
+    name: 'updated_at',
+  })
   updated_at: Date;
 }


### PR DESCRIPTION
# GameSettings entity – align with DDL

## Summary

Updates the `GameSettings` entity in NestJS so it matches the `game_settings` table DDL and keeps correct TypeScript types, defaults, and MySQL compatibility.

## File changed

- `src/modules/games/entities/game-settings.entity.ts`

## DDL mapping

| DDL | Entity |
|-----|--------|
| `id int unsigned NOT NULL AUTO_INCREMENT` | `@PrimaryGeneratedColumn({ type: 'int', unsigned: true })` |
| `game_id int unsigned NOT NULL` | `@Column({ type: 'int', unsigned: true, name: 'game_id' })` + `@JoinColumn` |
| `auction tinyint(1) NOT NULL DEFAULT '0'` | `@Column({ type: 'boolean', default: false })` |
| `rent_in_prison tinyint(1) NOT NULL DEFAULT '0'` | `@Column({ type: 'boolean', default: false, name: 'rent_in_prison' })` |
| `mortgage tinyint(1) NOT NULL DEFAULT '0'` | `@Column({ type: 'boolean', default: false })` |
| `even_build tinyint(1) NOT NULL DEFAULT '0'` | `@Column({ type: 'boolean', default: false, name: 'even_build' })` |
| `randomize_play_order tinyint(1) NOT NULL DEFAULT '0'` | `@Column({ type: 'boolean', default: false, name: 'randomize_play_order' })` |
| `starting_cash int unsigned NOT NULL DEFAULT '1500'` | `@Column({ type: 'int', unsigned: true, default: 1500, name: 'starting_cash' })` |
| `created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP` | `@CreateDateColumn({ type: 'timestamp', name: 'created_at' })` |
| `updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP` | `@UpdateDateColumn({ type: 'timestamp', name: 'updated_at' })` |
Closes #149 
## Acceptance criteria

- Entity matches the DDL (all columns and types).
- Boolean flags use `type: 'boolean'` with `default: false` (DDL `DEFAULT '0'`).
- Defaults applied in the entity: booleans `false`, `starting_cash` `1500`.
- Timestamps managed via `@CreateDateColumn` / `@UpdateDateColumn`.
- No nullable mismatches; all columns are required in the entity.
- One-to-one with `Game` and `onDelete: 'CASCADE'` on `game_id` kept as before.