### PR TITLE
feature/patch-game-settings

### DIFF
--- a/backend/src/modules/games/dto/update-game-settings.dto.ts
+++ b/backend/src/modules/games/dto/update-game-settings.dto.ts
@@ -1,0 +1,35 @@
+import { IsOptional, IsBoolean, IsInt, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateGameSettingsDto {
+  @ApiPropertyOptional({ description: 'Whether auction is enabled' })
+  @IsOptional()
+  @IsBoolean()
+  auction?: boolean;
+
+  @ApiPropertyOptional({ description: 'Whether rent in prison is enabled' })
+  @IsOptional()
+  @IsBoolean()
+  rentInPrison?: boolean;
+
+  @ApiPropertyOptional({ description: 'Whether mortgage is enabled' })
+  @IsOptional()
+  @IsBoolean()
+  mortgage?: boolean;
+
+  @ApiPropertyOptional({ description: 'Whether even build is enabled' })
+  @IsOptional()
+  @IsBoolean()
+  evenBuild?: boolean;
+
+  @ApiPropertyOptional({ description: 'Whether to randomize play order' })
+  @IsOptional()
+  @IsBoolean()
+  randomizePlayOrder?: boolean;
+
+  @ApiPropertyOptional({ description: 'Starting cash per player', minimum: 100 })
+  @IsOptional()
+  @IsInt()
+  @Min(100)
+  startingCash?: number;
+}

--- a/backend/src/modules/games/games.controller.ts
+++ b/backend/src/modules/games/games.controller.ts
@@ -30,6 +30,7 @@ import { GamesService } from './games.service';
 import { UpdateGamePlayerDto } from './dto/update-game-player.dto';
 import { CreateGameDto } from './dto/create-game.dto';
 import { UpdateGameDto } from './dto/update-game.dto';
+import { UpdateGameSettingsDto } from './dto/update-game-settings.dto';
 import { GetGamePlayersDto } from './dto/get-game-players.dto';
 import { GetGamesDto } from './dto/get-games.dto';
 import { RollDiceDto } from './dto/roll-dice.dto';
@@ -156,6 +157,44 @@ export class GamesController {
   @ApiNotFoundResponse({ description: 'Game not found' })
   async findById(@Param('id', ParseIntPipe) id: number) {
     return this.gamesService.findById(id);
+  }
+
+  @Patch(':id/settings')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update game settings (creator only, PENDING only)' })
+  @ApiOkResponse({
+    description: 'Game settings updated successfully',
+    schema: {
+      example: {
+        id: 1,
+        code: 'ABC123',
+        status: 'PENDING',
+        settings: {
+          auction: true,
+          rentInPrison: false,
+          mortgage: true,
+          evenBuild: true,
+          randomizePlayOrder: true,
+          startingCash: 1500,
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'Cannot update settings after game has started',
+  })
+  @ApiForbiddenResponse({
+    description: 'Only the game creator can update settings',
+  })
+  @ApiNotFoundResponse({ description: 'Game or settings not found' })
+  @ApiUnauthorizedResponse({ description: 'User not authenticated' })
+  async updateSettings(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateGameSettingsDto,
+    @Req() req: Request & { user: { id: number } },
+  ) {
+    return this.gamesService.updateSettings(id, dto, req.user.id);
   }
 
   @Patch(':id')


### PR DESCRIPTION
# PATCH /games/:id/settings – Update game settings (creator, PENDING only)

## Summary

Adds `PATCH /games/:id/settings` so the game creator can update game settings before the game starts. Only the creator can call this endpoint, and only when the game status is `PENDING`.

## Endpoint

- **Method:** `PATCH`
- **Path:** `/games/:id/settings`
- **Auth:** Bearer JWT required

## Rules

- **Only creator can update** – Non-creator receives `403 Forbidden`.
- **Only when game is PENDING** – If status is not `PENDING`, returns `400 Bad Request` with message: *"Cannot update settings after the game has started"*.

## Request body (all optional, partial updates)

| Field | Type | Validation |
|-------|------|------------|
| `auction` | boolean | optional |
| `rentInPrison` | boolean | optional |
| `mortgage` | boolean | optional |
| `evenBuild` | boolean | optional |
| `randomizePlayOrder` | boolean | optional |
| `startingCash` | number | optional, min 100 |
closes #154 
## Acceptance criteria

- **Validation enforced** – DTO validated via `UpdateGameSettingsDto` and global `ValidationPipe`; invalid payloads return `400`.
- **Partial updates allowed** – Only fields sent in the body are updated; others are unchanged.
- **Prevent update after game starts** – If `game.status !== PENDING`, endpoint returns `400` and does not update settings.

## Changes

- **New:** `dto/update-game-settings.dto.ts` – Optional, validated fields for partial settings update.
- **Updated:** `games.service.ts` – New `updateSettings(gameId, dto, userId)` with creator check, PENDING check, and partial update of `game_settings`.
- **Updated:** `games.controller.ts` – New `PATCH :id/settings` handler (registered before `PATCH :id`) with JWT guard and Swagger docs.

## Example request

PATCH /games/1/settings
Authorization: Bearer <token>
Content-Type: application/json

{
  "auction": false,
  "startingCash": 2000
}
