### PR TITLE
feature/unique-game-player-constraint

### DIFF
--- a/backend/src/modules/games/entities/game-player.entity.ts
+++ b/backend/src/modules/games/entities/game-player.entity.ts
@@ -15,7 +15,7 @@ import { User } from '../../users/entities/user.entity';
 @Entity({ name: 'game_players' })
 @Index(['game_id'])
 @Index(['user_id'])
-@Index(['game_id', 'user_id'])
+@Index(['game_id', 'user_id'], { unique: true })
 @Index(['game_id', 'in_jail'])
 @Index(['user_id', 'in_jail'])
 export class GamePlayer {


### PR DESCRIPTION
# Enforce one user per game: unique (game_id, user_id)

## Summary

Ensures a user can only join a game once by adding a composite unique constraint on `(game_id, user_id)` and validating at the service layer before any insert.
# closes #158 
## Changes

### 1. DB constraint

**File:** `src/modules/games/entities/game-player.entity.ts`

- Replaced `@Index(['game_id', 'user_id'])` with:
  - `@Index(['game_id', 'user_id'], { unique: true })`
- Database enforces uniqueness of `(game_id, user_id)` on `game_players` (via unique index when schema is synced or migrated).

### 2. Service-level validation

**File:** `src/modules/games/game-players.service.ts`

- **`findByGameAndUser(gameId, userId)`**  
  Returns the existing `GamePlayer` for that game and user, or `null`.

- **`assertUserNotInGame(gameId, userId)`**  
  Throws `ConflictException` with message *"User is already a player in this game (duplicate join not allowed)"* if a row exists. To be used before any insert that adds a user to a game.

- **`addPlayerToGame(gameId, userId, options?)`**  
  Single validated entry point for adding a player:
  - Ensures game exists and is `PENDING`.
  - Calls `assertUserNotInGame` (blocks duplicate join).
  - Creates and saves a `GamePlayer` with `game_id`, `user_id`, `balance` from game settings (or 1500), and optional `address`.

Any other code that inserts a user into a game should either use `addPlayerToGame` or call `assertUserNotInGame` before inserting.

## Acceptance criteria

- **Duplicate player join blocked** – Service throws `ConflictException` when the user is already in the game; `addPlayerToGame` always checks before insert.
- **DB constraint enforced** – Unique index on `(game_id, user_id)` so the database also rejects duplicate joins.