### PR TITLE
feat: Add admin endpoints for paginated waitlist management with filtering, sorting, and statistics.

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -92,4 +92,4 @@ import { ShopModule } from './modules/shop/shop.module';
     },
   ],
 })
-export class AppModule { }
+export class AppModule {}

--- a/backend/src/database/migrations/1740349960000-CreateWaitlistTable.ts
+++ b/backend/src/database/migrations/1740349960000-CreateWaitlistTable.ts
@@ -1,55 +1,55 @@
 import { MigrationInterface, QueryRunner, Table } from 'typeorm';
 
 export class CreateWaitlistTable1740349960000 implements MigrationInterface {
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.createTable(
-            new Table({
-                name: 'waitlist',
-                columns: [
-                    {
-                        name: 'id',
-                        type: 'int',
-                        isPrimary: true,
-                        isGenerated: true,
-                        generationStrategy: 'increment',
-                    },
-                    {
-                        name: 'wallet_address',
-                        type: 'varchar',
-                        length: '255',
-                        isUnique: true,
-                        isNullable: true,
-                    },
-                    {
-                        name: 'email_address',
-                        type: 'varchar',
-                        length: '255',
-                        isUnique: true,
-                        isNullable: true,
-                    },
-                    {
-                        name: 'telegram_username',
-                        type: 'varchar',
-                        length: '100',
-                        isNullable: true,
-                    },
-                    {
-                        name: 'created_at',
-                        type: 'timestamp',
-                        default: 'now()',
-                    },
-                    {
-                        name: 'updated_at',
-                        type: 'timestamp',
-                        default: 'now()',
-                    },
-                ],
-            }),
-            true,
-        );
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'waitlist',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'wallet_address',
+            type: 'varchar',
+            length: '255',
+            isUnique: true,
+            isNullable: true,
+          },
+          {
+            name: 'email_address',
+            type: 'varchar',
+            length: '255',
+            isUnique: true,
+            isNullable: true,
+          },
+          {
+            name: 'telegram_username',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.dropTable('waitlist');
-    }
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('waitlist');
+  }
 }

--- a/backend/src/database/migrations/1740350960000-CreateShopItemsTable.ts
+++ b/backend/src/database/migrations/1740350960000-CreateShopItemsTable.ts
@@ -1,106 +1,107 @@
-import {
-    MigrationInterface,
-    QueryRunner,
-    Table,
-    TableIndex,
-} from 'typeorm';
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
 
 export class CreateShopItemsTable1740350960000 implements MigrationInterface {
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        // Create enum type first (PostgreSQL)
-        await queryRunner.query(`
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create enum type first (PostgreSQL)
+    await queryRunner.query(`
       CREATE TYPE "shop_item_type_enum" AS ENUM (
         'dice', 'skin', 'symbol', 'theme', 'card'
       )
     `);
 
-        await queryRunner.createTable(
-            new Table({
-                name: 'shop_items',
-                columns: [
-                    {
-                        name: 'id',
-                        type: 'int',
-                        isPrimary: true,
-                        isGenerated: true,
-                        generationStrategy: 'increment',
-                    },
-                    {
-                        name: 'name',
-                        type: 'varchar',
-                        length: '255',
-                        isUnique: true,
-                    },
-                    {
-                        name: 'description',
-                        type: 'text',
-                        isNullable: true,
-                    },
-                    {
-                        name: 'type',
-                        type: 'enum',
-                        enum: ['dice', 'skin', 'symbol', 'theme', 'card'],
-                    },
-                    {
-                        name: 'price',
-                        type: 'decimal',
-                        precision: 10,
-                        scale: 2,
-                    },
-                    {
-                        name: 'currency',
-                        type: 'varchar',
-                        length: '10',
-                        default: "'USD'",
-                    },
-                    {
-                        name: 'metadata',
-                        type: 'json',
-                        isNullable: true,
-                    },
-                    {
-                        name: 'rarity',
-                        type: 'varchar',
-                        length: '50',
-                        default: "'common'",
-                    },
-                    {
-                        name: 'active',
-                        type: 'boolean',
-                        default: true,
-                    },
-                    {
-                        name: 'created_at',
-                        type: 'timestamp',
-                        default: 'now()',
-                    },
-                    {
-                        name: 'updated_at',
-                        type: 'timestamp',
-                        default: 'now()',
-                    },
-                ],
-            }),
-            true,
-        );
+    await queryRunner.createTable(
+      new Table({
+        name: 'shop_items',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '255',
+            isUnique: true,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'type',
+            type: 'enum',
+            enum: ['dice', 'skin', 'symbol', 'theme', 'card'],
+          },
+          {
+            name: 'price',
+            type: 'decimal',
+            precision: 10,
+            scale: 2,
+          },
+          {
+            name: 'currency',
+            type: 'varchar',
+            length: '10',
+            default: "'USD'",
+          },
+          {
+            name: 'metadata',
+            type: 'json',
+            isNullable: true,
+          },
+          {
+            name: 'rarity',
+            type: 'varchar',
+            length: '50',
+            default: "'common'",
+          },
+          {
+            name: 'active',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
 
-        // Indexes for common query patterns
-        await queryRunner.createIndex(
-            'shop_items',
-            new TableIndex({ name: 'IDX_SHOP_ITEMS_TYPE', columnNames: ['type'] }),
-        );
-        await queryRunner.createIndex(
-            'shop_items',
-            new TableIndex({ name: 'IDX_SHOP_ITEMS_RARITY', columnNames: ['rarity'] }),
-        );
-        await queryRunner.createIndex(
-            'shop_items',
-            new TableIndex({ name: 'IDX_SHOP_ITEMS_ACTIVE', columnNames: ['active'] }),
-        );
-    }
+    // Indexes for common query patterns
+    await queryRunner.createIndex(
+      'shop_items',
+      new TableIndex({ name: 'IDX_SHOP_ITEMS_TYPE', columnNames: ['type'] }),
+    );
+    await queryRunner.createIndex(
+      'shop_items',
+      new TableIndex({
+        name: 'IDX_SHOP_ITEMS_RARITY',
+        columnNames: ['rarity'],
+      }),
+    );
+    await queryRunner.createIndex(
+      'shop_items',
+      new TableIndex({
+        name: 'IDX_SHOP_ITEMS_ACTIVE',
+        columnNames: ['active'],
+      }),
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.dropTable('shop_items');
-        await queryRunner.query(`DROP TYPE IF EXISTS "shop_item_type_enum"`);
-    }
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('shop_items');
+    await queryRunner.query(`DROP TYPE IF EXISTS "shop_item_type_enum"`);
+  }
 }

--- a/backend/src/modules/shop/dto/create-shop-item.dto.ts
+++ b/backend/src/modules/shop/dto/create-shop-item.dto.ts
@@ -1,81 +1,81 @@
 import {
-    IsBoolean,
-    IsEnum,
-    IsNotEmpty,
-    IsNumber,
-    IsObject,
-    IsOptional,
-    IsPositive,
-    IsString,
-    MaxLength,
-    Min,
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+  Min,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ShopItemType } from '../enums/shop-item-type.enum';
 import { Transform, Type } from 'class-transformer';
 
 export class CreateShopItemDto {
-    @ApiProperty({ description: 'Display name of the item', maxLength: 255 })
-    @IsString()
-    @IsNotEmpty()
-    @MaxLength(255)
-    name: string;
+  @ApiProperty({ description: 'Display name of the item', maxLength: 255 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  name: string;
 
-    @ApiPropertyOptional({ description: 'Item description' })
-    @IsOptional()
-    @IsString()
-    description?: string;
+  @ApiPropertyOptional({ description: 'Item description' })
+  @IsOptional()
+  @IsString()
+  description?: string;
 
-    @ApiProperty({
-        enum: ShopItemType,
-        description: 'Category of the shop item',
-    })
-    @IsEnum(ShopItemType)
-    type: ShopItemType;
+  @ApiProperty({
+    enum: ShopItemType,
+    description: 'Category of the shop item',
+  })
+  @IsEnum(ShopItemType)
+  type: ShopItemType;
 
-    @ApiProperty({ description: 'Price of the item', example: 9.99 })
-    @Type(() => Number)
-    @IsNumber({ maxDecimalPlaces: 2 })
-    @IsPositive()
-    price: number;
+  @ApiProperty({ description: 'Price of the item', example: 9.99 })
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @IsPositive()
+  price: number;
 
-    @ApiPropertyOptional({
-        description: 'Currency code',
-        default: 'USD',
-        maxLength: 10,
-    })
-    @IsOptional()
-    @IsString()
-    @MaxLength(10)
-    currency?: string;
+  @ApiPropertyOptional({
+    description: 'Currency code',
+    default: 'USD',
+    maxLength: 10,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(10)
+  currency?: string;
 
-    @ApiPropertyOptional({
-        description: 'Arbitrary extra data (textures, colors, config)',
-    })
-    @IsOptional()
-    @IsObject()
-    metadata?: Record<string, unknown>;
+  @ApiPropertyOptional({
+    description: 'Arbitrary extra data (textures, colors, config)',
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
 
-    @ApiPropertyOptional({
-        description: 'Rarity tier (common, rare, epic, legendary)',
-        default: 'common',
-        maxLength: 50,
-    })
-    @IsOptional()
-    @IsString()
-    @MaxLength(50)
-    rarity?: string;
+  @ApiPropertyOptional({
+    description: 'Rarity tier (common, rare, epic, legendary)',
+    default: 'common',
+    maxLength: 50,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  rarity?: string;
 
-    @ApiPropertyOptional({
-        description: 'Whether the item is available in the shop',
-        default: true,
-    })
-    @IsOptional()
-    @Transform(({ value }: { value: unknown }) => {
-        if (value === 'true') return true;
-        if (value === 'false') return false;
-        return value;
-    })
-    @IsBoolean()
-    active?: boolean;
+  @ApiPropertyOptional({
+    description: 'Whether the item is available in the shop',
+    default: true,
+  })
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  @IsBoolean()
+  active?: boolean;
 }

--- a/backend/src/modules/shop/dto/filter-shop-items.dto.ts
+++ b/backend/src/modules/shop/dto/filter-shop-items.dto.ts
@@ -1,61 +1,61 @@
 import {
-    IsBoolean,
-    IsEnum,
-    IsInt,
-    IsOptional,
-    IsString,
-    MaxLength,
-    Min,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ShopItemType } from '../enums/shop-item-type.enum';
 import { Transform, Type } from 'class-transformer';
 
 export class FilterShopItemsDto {
-    @ApiPropertyOptional({
-        enum: ShopItemType,
-        description: 'Filter by item type',
-    })
-    @IsOptional()
-    @IsEnum(ShopItemType)
-    type?: ShopItemType;
+  @ApiPropertyOptional({
+    enum: ShopItemType,
+    description: 'Filter by item type',
+  })
+  @IsOptional()
+  @IsEnum(ShopItemType)
+  type?: ShopItemType;
 
-    @ApiPropertyOptional({
-        description: 'Filter by rarity (e.g. common, rare, epic)',
-        maxLength: 50,
-    })
-    @IsOptional()
-    @IsString()
-    @MaxLength(50)
-    rarity?: string;
+  @ApiPropertyOptional({
+    description: 'Filter by rarity (e.g. common, rare, epic)',
+    maxLength: 50,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  rarity?: string;
 
-    @ApiPropertyOptional({
-        description: 'Filter by active status',
-        default: true,
-    })
-    @IsOptional()
-    @Transform(({ value }: { value: unknown }) => {
-        if (value === 'true') return true;
-        if (value === 'false') return false;
-        return value;
-    })
-    @IsBoolean()
-    active?: boolean;
+  @ApiPropertyOptional({
+    description: 'Filter by active status',
+    default: true,
+  })
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  @IsBoolean()
+  active?: boolean;
 
-    @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1 })
-    @IsOptional()
-    @Type(() => Number)
-    @IsInt()
-    @Min(1)
-    page?: number = 1;
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
 
-    @ApiPropertyOptional({
-        description: 'Items per page',
-        default: 20,
-    })
-    @IsOptional()
-    @Type(() => Number)
-    @IsInt()
-    @Min(1)
-    limit?: number = 20;
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    default: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
 }

--- a/backend/src/modules/shop/dto/update-shop-item.dto.ts
+++ b/backend/src/modules/shop/dto/update-shop-item.dto.ts
@@ -1,4 +1,4 @@
 import { PartialType } from '@nestjs/swagger';
 import { CreateShopItemDto } from './create-shop-item.dto';
 
-export class UpdateShopItemDto extends PartialType(CreateShopItemDto) { }
+export class UpdateShopItemDto extends PartialType(CreateShopItemDto) {}

--- a/backend/src/modules/shop/entities/shop-item.entity.ts
+++ b/backend/src/modules/shop/entities/shop-item.entity.ts
@@ -1,10 +1,10 @@
 import {
-    Entity,
-    PrimaryGeneratedColumn,
-    Column,
-    CreateDateColumn,
-    UpdateDateColumn,
-    Index,
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
 } from 'typeorm';
 import { ShopItemType } from '../enums/shop-item-type.enum';
 
@@ -13,43 +13,43 @@ import { ShopItemType } from '../enums/shop-item-type.enum';
 @Index(['rarity'])
 @Index(['active'])
 export class ShopItem {
-    @PrimaryGeneratedColumn()
-    id: number;
+  @PrimaryGeneratedColumn()
+  id: number;
 
-    @Column({ type: 'varchar', length: 255, unique: true })
-    name: string;
+  @Column({ type: 'varchar', length: 255, unique: true })
+  name: string;
 
-    @Column({ type: 'text', nullable: true })
-    description: string;
+  @Column({ type: 'text', nullable: true })
+  description: string;
 
-    @Column({
-        type: 'enum',
-        enum: ShopItemType,
-    })
-    type: ShopItemType;
+  @Column({
+    type: 'enum',
+    enum: ShopItemType,
+  })
+  type: ShopItemType;
 
-    @Column({
-        type: 'decimal',
-        precision: 10,
-        scale: 2,
-    })
-    price: string;
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 2,
+  })
+  price: string;
 
-    @Column({ type: 'varchar', length: 10, default: 'USD' })
-    currency: string;
+  @Column({ type: 'varchar', length: 10, default: 'USD' })
+  currency: string;
 
-    @Column({ type: 'json', nullable: true })
-    metadata: Record<string, unknown>;
+  @Column({ type: 'json', nullable: true })
+  metadata: Record<string, unknown>;
 
-    @Column({ type: 'varchar', length: 50, default: 'common' })
-    rarity: string;
+  @Column({ type: 'varchar', length: 50, default: 'common' })
+  rarity: string;
 
-    @Column({ type: 'boolean', default: true })
-    active: boolean;
+  @Column({ type: 'boolean', default: true })
+  active: boolean;
 
-    @CreateDateColumn({ name: 'created_at' })
-    created_at: Date;
+  @CreateDateColumn({ name: 'created_at' })
+  created_at: Date;
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updated_at: Date;
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at: Date;
 }

--- a/backend/src/modules/shop/enums/shop-item-type.enum.ts
+++ b/backend/src/modules/shop/enums/shop-item-type.enum.ts
@@ -1,7 +1,7 @@
 export enum ShopItemType {
-    DICE = 'dice',
-    SKIN = 'skin',
-    SYMBOL = 'symbol',
-    THEME = 'theme',
-    CARD = 'card',
+  DICE = 'dice',
+  SKIN = 'skin',
+  SYMBOL = 'symbol',
+  THEME = 'theme',
+  CARD = 'card',
 }

--- a/backend/src/modules/shop/shop.controller.ts
+++ b/backend/src/modules/shop/shop.controller.ts
@@ -1,22 +1,17 @@
 import {
-    Body,
-    Controller,
-    Delete,
-    Get,
-    HttpCode,
-    HttpStatus,
-    Param,
-    ParseIntPipe,
-    Patch,
-    Post,
-    Query,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
 } from '@nestjs/common';
-import {
-    ApiOperation,
-    ApiParam,
-    ApiResponse,
-    ApiTags,
-} from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ShopService, PaginatedShopItems } from './shop.service';
 import { CreateShopItemDto } from './dto/create-shop-item.dto';
 import { UpdateShopItemDto } from './dto/update-shop-item.dto';
@@ -26,88 +21,88 @@ import { ShopItem } from './entities/shop-item.entity';
 @ApiTags('shop')
 @Controller('shop/items')
 export class ShopController {
-    constructor(private readonly shopService: ShopService) { }
+  constructor(private readonly shopService: ShopService) {}
 
-    /**
-     * POST /shop/items
-     * Create a new shop item (admin use)
-     */
-    @Post()
-    @HttpCode(HttpStatus.CREATED)
-    @ApiOperation({ summary: 'Create a new shop item' })
-    @ApiResponse({
-        status: HttpStatus.CREATED,
-        description: 'Shop item created successfully.',
-        type: ShopItem,
-    })
-    create(@Body() createShopItemDto: CreateShopItemDto): Promise<ShopItem> {
-        return this.shopService.create(createShopItemDto);
-    }
+  /**
+   * POST /shop/items
+   * Create a new shop item (admin use)
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a new shop item' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Shop item created successfully.',
+    type: ShopItem,
+  })
+  create(@Body() createShopItemDto: CreateShopItemDto): Promise<ShopItem> {
+    return this.shopService.create(createShopItemDto);
+  }
 
-    /**
-     * GET /shop/items
-     * List all items with optional filters (type, rarity, active) and pagination
-     */
-    @Get()
-    @ApiOperation({ summary: 'List shop items with optional filters' })
-    @ApiResponse({
-        status: HttpStatus.OK,
-        description: 'Paginated list of shop items.',
-    })
-    findAll(@Query() filterDto: FilterShopItemsDto): Promise<PaginatedShopItems> {
-        return this.shopService.findAll(filterDto);
-    }
+  /**
+   * GET /shop/items
+   * List all items with optional filters (type, rarity, active) and pagination
+   */
+  @Get()
+  @ApiOperation({ summary: 'List shop items with optional filters' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Paginated list of shop items.',
+  })
+  findAll(@Query() filterDto: FilterShopItemsDto): Promise<PaginatedShopItems> {
+    return this.shopService.findAll(filterDto);
+  }
 
-    /**
-     * GET /shop/items/:id
-     */
-    @Get(':id')
-    @ApiOperation({ summary: 'Get a shop item by ID' })
-    @ApiParam({ name: 'id', type: Number })
-    @ApiResponse({
-        status: HttpStatus.OK,
-        description: 'Shop item found.',
-        type: ShopItem,
-    })
-    @ApiResponse({
-        status: HttpStatus.NOT_FOUND,
-        description: 'Shop item not found.',
-    })
-    findOne(@Param('id', ParseIntPipe) id: number): Promise<ShopItem> {
-        return this.shopService.findOne(id);
-    }
+  /**
+   * GET /shop/items/:id
+   */
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a shop item by ID' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Shop item found.',
+    type: ShopItem,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Shop item not found.',
+  })
+  findOne(@Param('id', ParseIntPipe) id: number): Promise<ShopItem> {
+    return this.shopService.findOne(id);
+  }
 
-    /**
-     * PATCH /shop/items/:id
-     */
-    @Patch(':id')
-    @ApiOperation({ summary: 'Update a shop item' })
-    @ApiParam({ name: 'id', type: Number })
-    @ApiResponse({
-        status: HttpStatus.OK,
-        description: 'Shop item updated.',
-        type: ShopItem,
-    })
-    update(
-        @Param('id', ParseIntPipe) id: number,
-        @Body() updateShopItemDto: UpdateShopItemDto,
-    ): Promise<ShopItem> {
-        return this.shopService.update(id, updateShopItemDto);
-    }
+  /**
+   * PATCH /shop/items/:id
+   */
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a shop item' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Shop item updated.',
+    type: ShopItem,
+  })
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateShopItemDto: UpdateShopItemDto,
+  ): Promise<ShopItem> {
+    return this.shopService.update(id, updateShopItemDto);
+  }
 
-    /**
-     * DELETE /shop/items/:id
-     * Soft-deletes by setting active = false
-     */
-    @Delete(':id')
-    @ApiOperation({ summary: 'Deactivate (soft-delete) a shop item' })
-    @ApiParam({ name: 'id', type: Number })
-    @ApiResponse({
-        status: HttpStatus.OK,
-        description: 'Shop item deactivated.',
-        type: ShopItem,
-    })
-    remove(@Param('id', ParseIntPipe) id: number): Promise<ShopItem> {
-        return this.shopService.remove(id);
-    }
+  /**
+   * DELETE /shop/items/:id
+   * Soft-deletes by setting active = false
+   */
+  @Delete(':id')
+  @ApiOperation({ summary: 'Deactivate (soft-delete) a shop item' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Shop item deactivated.',
+    type: ShopItem,
+  })
+  remove(@Param('id', ParseIntPipe) id: number): Promise<ShopItem> {
+    return this.shopService.remove(id);
+  }
 }

--- a/backend/src/modules/shop/shop.module.ts
+++ b/backend/src/modules/shop/shop.module.ts
@@ -5,9 +5,9 @@ import { ShopService } from './shop.service';
 import { ShopController } from './shop.controller';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([ShopItem])],
-    controllers: [ShopController],
-    providers: [ShopService],
-    exports: [ShopService],
+  imports: [TypeOrmModule.forFeature([ShopItem])],
+  controllers: [ShopController],
+  providers: [ShopService],
+  exports: [ShopService],
 })
-export class ShopModule { }
+export class ShopModule {}

--- a/backend/src/modules/shop/shop.service.ts
+++ b/backend/src/modules/shop/shop.service.ts
@@ -7,99 +7,102 @@ import { UpdateShopItemDto } from './dto/update-shop-item.dto';
 import { FilterShopItemsDto } from './dto/filter-shop-items.dto';
 
 export interface PaginatedShopItems {
-    data: ShopItem[];
-    meta: {
-        page: number;
-        limit: number;
-        total: number;
-        totalPages: number;
-    };
+  data: ShopItem[];
+  meta: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
 }
 
 @Injectable()
 export class ShopService {
-    constructor(
-        @InjectRepository(ShopItem)
-        private readonly shopItemRepository: Repository<ShopItem>,
-    ) { }
+  constructor(
+    @InjectRepository(ShopItem)
+    private readonly shopItemRepository: Repository<ShopItem>,
+  ) {}
 
-    /**
-     * Create a new shop item
-     */
-    async create(createShopItemDto: CreateShopItemDto): Promise<ShopItem> {
-        const item = this.shopItemRepository.create({
-            ...createShopItemDto,
-            price: String(createShopItemDto.price),
-        });
-        return this.shopItemRepository.save(item);
+  /**
+   * Create a new shop item
+   */
+  async create(createShopItemDto: CreateShopItemDto): Promise<ShopItem> {
+    const item = this.shopItemRepository.create({
+      ...createShopItemDto,
+      price: String(createShopItemDto.price),
+    });
+    return this.shopItemRepository.save(item);
+  }
+
+  /**
+   * List shop items with optional filters and pagination
+   */
+  async findAll(filterDto: FilterShopItemsDto): Promise<PaginatedShopItems> {
+    const { type, rarity, active, page = 1, limit = 20 } = filterDto;
+
+    const qb = this.shopItemRepository
+      .createQueryBuilder('item')
+      .orderBy('item.created_at', 'DESC');
+
+    if (type !== undefined) {
+      qb.andWhere('item.type = :type', { type });
     }
 
-    /**
-     * List shop items with optional filters and pagination
-     */
-    async findAll(filterDto: FilterShopItemsDto): Promise<PaginatedShopItems> {
-        const { type, rarity, active, page = 1, limit = 20 } = filterDto;
-
-        const qb = this.shopItemRepository
-            .createQueryBuilder('item')
-            .orderBy('item.created_at', 'DESC');
-
-        if (type !== undefined) {
-            qb.andWhere('item.type = :type', { type });
-        }
-
-        if (rarity !== undefined) {
-            qb.andWhere('item.rarity = :rarity', { rarity });
-        }
-
-        if (active !== undefined) {
-            qb.andWhere('item.active = :active', { active });
-        }
-
-        const total = await qb.getCount();
-        const data = await qb
-            .skip((page - 1) * limit)
-            .take(limit)
-            .getMany();
-
-        return {
-            data,
-            meta: {
-                page,
-                limit,
-                total,
-                totalPages: Math.ceil(total / limit),
-            },
-        };
+    if (rarity !== undefined) {
+      qb.andWhere('item.rarity = :rarity', { rarity });
     }
 
-    /**
-     * Get a single shop item by ID
-     */
-    async findOne(id: number): Promise<ShopItem> {
-        const item = await this.shopItemRepository.findOne({ where: { id } });
-        if (!item) {
-            throw new NotFoundException(`Shop item with ID ${id} not found`);
-        }
-        return item;
+    if (active !== undefined) {
+      qb.andWhere('item.active = :active', { active });
     }
 
-    /**
-     * Update a shop item
-     */
-    async update(id: number, updateShopItemDto: UpdateShopItemDto): Promise<ShopItem> {
-        const item = await this.findOne(id);
-        Object.assign(item, updateShopItemDto);
-        return this.shopItemRepository.save(item);
-    }
+    const total = await qb.getCount();
+    const data = await qb
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getMany();
 
-    /**
-     * Soft-delete: deactivate the item instead of destroying the DB record.
-     * This preserves referential integrity for past purchases.
-     */
-    async remove(id: number): Promise<ShopItem> {
-        const item = await this.findOne(id);
-        item.active = false;
-        return this.shopItemRepository.save(item);
+    return {
+      data,
+      meta: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * Get a single shop item by ID
+   */
+  async findOne(id: number): Promise<ShopItem> {
+    const item = await this.shopItemRepository.findOne({ where: { id } });
+    if (!item) {
+      throw new NotFoundException(`Shop item with ID ${id} not found`);
     }
+    return item;
+  }
+
+  /**
+   * Update a shop item
+   */
+  async update(
+    id: number,
+    updateShopItemDto: UpdateShopItemDto,
+  ): Promise<ShopItem> {
+    const item = await this.findOne(id);
+    Object.assign(item, updateShopItemDto);
+    return this.shopItemRepository.save(item);
+  }
+
+  /**
+   * Soft-delete: deactivate the item instead of destroying the DB record.
+   * This preserves referential integrity for past purchases.
+   */
+  async remove(id: number): Promise<ShopItem> {
+    const item = await this.findOne(id);
+    item.active = false;
+    return this.shopItemRepository.save(item);
+  }
 }

--- a/backend/src/modules/users/users.controller.spec.ts
+++ b/backend/src/modules/users/users.controller.spec.ts
@@ -69,7 +69,9 @@ describe('UsersController', () => {
 
   describe('findAll', () => {
     it('should return an array of users', async () => {
-      const result = [{ id: 1, email: 'test@example.com' }] as unknown as User[];
+      const result = [
+        { id: 1, email: 'test@example.com' },
+      ] as unknown as User[];
       (service.findAll as jest.Mock).mockResolvedValue(result);
 
       expect(await controller.findAll({ page: 1, limit: 10 })).toBe(result);

--- a/backend/src/modules/waitlist/dto/create-waitlist.dto.ts
+++ b/backend/src/modules/waitlist/dto/create-waitlist.dto.ts
@@ -1,9 +1,9 @@
 import {
-    IsEmail,
-    IsOptional,
-    IsString,
-    MaxLength,
-    Matches,
+  IsEmail,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Matches,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
@@ -11,45 +11,45 @@ import { AtLeastOneField } from '../validators/at-least-one-field.validator';
 
 @AtLeastOneField(['wallet_address', 'email_address', 'telegram_username'])
 export class CreateWaitlistDto {
-    @ApiPropertyOptional({
-        description: 'Blockchain wallet address',
-        example: '0xAbCd...1234',
-    })
-    @IsOptional()
-    @IsString()
-    @MaxLength(255)
-    @Transform(({ value }: { value: unknown }) =>
-        typeof value === 'string' ? value.trim().toLowerCase() : value,
-    )
-    wallet_address?: string;
+  @ApiPropertyOptional({
+    description: 'Blockchain wallet address',
+    example: '0xAbCd...1234',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim().toLowerCase() : value,
+  )
+  wallet_address?: string;
 
-    @ApiPropertyOptional({
-        description: 'Email address',
-        example: 'user@example.com',
-    })
-    @IsOptional()
-    @IsEmail()
-    @MaxLength(255)
-    @Transform(({ value }: { value: unknown }) =>
-        typeof value === 'string' ? value.trim().toLowerCase() : value,
-    )
-    email_address?: string;
+  @ApiPropertyOptional({
+    description: 'Email address',
+    example: 'user@example.com',
+  })
+  @IsOptional()
+  @IsEmail()
+  @MaxLength(255)
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim().toLowerCase() : value,
+  )
+  email_address?: string;
 
-    @ApiPropertyOptional({
-        description: 'Telegram username (with or without leading @)',
-        example: 'myusername',
-    })
-    @IsOptional()
-    @IsString()
-    @MaxLength(100)
-    // Telegram usernames: 5-32 chars, alphanumeric + underscores
-    @Matches(/^@?[a-zA-Z0-9_]{1,100}$/, {
-        message:
-            'telegram_username may only contain letters, numbers, and underscores',
-    })
-    @Transform(({ value }: { value: unknown }) => {
-        if (typeof value !== 'string') return value;
-        return value.trim().replace(/^@/, '').toLowerCase();
-    })
-    telegram_username?: string;
+  @ApiPropertyOptional({
+    description: 'Telegram username (with or without leading @)',
+    example: 'myusername',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  // Telegram usernames: 5-32 chars, alphanumeric + underscores
+  @Matches(/^@?[a-zA-Z0-9_]{1,100}$/, {
+    message:
+      'telegram_username may only contain letters, numbers, and underscores',
+  })
+  @Transform(({ value }: { value: unknown }) => {
+    if (typeof value !== 'string') return value;
+    return value.trim().replace(/^@/, '').toLowerCase();
+  })
+  telegram_username?: string;
 }

--- a/backend/src/modules/waitlist/dto/waitlist-pagination.dto.ts
+++ b/backend/src/modules/waitlist/dto/waitlist-pagination.dto.ts
@@ -1,0 +1,20 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationDto } from '../../../common';
+
+export class WaitlistPaginationDto extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Filter by wallet address' })
+  @IsOptional()
+  @IsString()
+  wallet?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by email address' })
+  @IsOptional()
+  @IsString()
+  email?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by telegram username' })
+  @IsOptional()
+  @IsString()
+  telegram?: string;
+}

--- a/backend/src/modules/waitlist/dto/waitlist-response.dto.ts
+++ b/backend/src/modules/waitlist/dto/waitlist-response.dto.ts
@@ -1,23 +1,23 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class WaitlistEntryDto {
-    @ApiProperty({ nullable: true })
-    wallet_address: string | null;
+  @ApiProperty({ nullable: true })
+  wallet_address: string | null;
 
-    @ApiProperty({ nullable: true })
-    email_address: string | null;
+  @ApiProperty({ nullable: true })
+  email_address: string | null;
 
-    @ApiProperty({ nullable: true })
-    telegram_username: string | null;
+  @ApiProperty({ nullable: true })
+  telegram_username: string | null;
 
-    @ApiProperty()
-    joined_at: Date;
+  @ApiProperty()
+  joined_at: Date;
 }
 
 export class WaitlistResponseDto {
-    @ApiProperty({ example: 'You have been added to the waitlist.' })
-    message: string;
+  @ApiProperty({ example: 'You have been added to the waitlist.' })
+  message: string;
 
-    @ApiProperty({ type: WaitlistEntryDto })
-    data: WaitlistEntryDto;
+  @ApiProperty({ type: WaitlistEntryDto })
+  data: WaitlistEntryDto;
 }

--- a/backend/src/modules/waitlist/entities/waitlist.entity.ts
+++ b/backend/src/modules/waitlist/entities/waitlist.entity.ts
@@ -1,28 +1,28 @@
 import {
-    Entity,
-    PrimaryGeneratedColumn,
-    Column,
-    CreateDateColumn,
-    UpdateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 
 @Entity({ name: 'waitlist' })
 export class Waitlist {
-    @PrimaryGeneratedColumn()
-    id: number;
+  @PrimaryGeneratedColumn()
+  id: number;
 
-    @Column({ type: 'varchar', length: 255, unique: true, nullable: true })
-    wallet_address: string;
+  @Column({ type: 'varchar', length: 255, unique: true, nullable: true })
+  wallet_address: string;
 
-    @Column({ type: 'varchar', length: 255, unique: true, nullable: true })
-    email_address: string;
+  @Column({ type: 'varchar', length: 255, unique: true, nullable: true })
+  email_address: string;
 
-    @Column({ type: 'varchar', length: 100, nullable: true })
-    telegram_username: string;
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  telegram_username: string;
 
-    @CreateDateColumn({ name: 'created_at' })
-    created_at: Date;
+  @CreateDateColumn({ name: 'created_at' })
+  created_at: Date;
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updated_at: Date;
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at: Date;
 }

--- a/backend/src/modules/waitlist/validators/at-least-one-field.validator.ts
+++ b/backend/src/modules/waitlist/validators/at-least-one-field.validator.ts
@@ -1,7 +1,7 @@
 import {
-    registerDecorator,
-    ValidationOptions,
-    ValidationArguments,
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
 } from 'class-validator';
 
 /**
@@ -13,35 +13,30 @@ import {
  *   export class CreateWaitlistDto { ... }
  */
 export function AtLeastOneField(
-    fields: string[],
-    validationOptions?: ValidationOptions,
+  fields: string[],
+  validationOptions?: ValidationOptions,
 ) {
-    return function (object: object) {
-        registerDecorator({
-            name: 'atLeastOneField',
-            target: (object as { constructor: Function }).constructor,
-            propertyName: fields[0],
-            constraints: fields,
-            options: {
-                message: `At least one of the following fields is required: ${fields.join(', ')}`,
-                ...validationOptions,
-            },
-            validator: {
-                validate(
-                    _value: unknown,
-                    args: ValidationArguments,
-                ): boolean {
-                    const obj = args.object as Record<string, unknown>;
-                    return args.constraints.some((field: string) => {
-                        const val = obj[field];
-                        return (
-                            val !== undefined &&
-                            val !== null &&
-                            String(val).trim().length > 0
-                        );
-                    });
-                },
-            },
-        });
-    };
+  return function (object: object) {
+    registerDecorator({
+      name: 'atLeastOneField',
+      target: (object as { constructor: Function }).constructor,
+      propertyName: fields[0],
+      constraints: fields,
+      options: {
+        message: `At least one of the following fields is required: ${fields.join(', ')}`,
+        ...validationOptions,
+      },
+      validator: {
+        validate(_value: unknown, args: ValidationArguments): boolean {
+          const obj = args.object as Record<string, unknown>;
+          return args.constraints.some((field: string) => {
+            const val = obj[field];
+            return (
+              val !== undefined && val !== null && String(val).trim().length > 0
+            );
+          });
+        },
+      },
+    });
+  };
 }

--- a/backend/src/modules/waitlist/waitlist-admin.controller.spec.ts
+++ b/backend/src/modules/waitlist/waitlist-admin.controller.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WaitlistAdminController } from './waitlist-admin.controller';
+import { WaitlistService } from './waitlist.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { RedisRateLimitGuard } from '../../common/guards/redis-rate-limit.guard';
+import { WaitlistPaginationDto } from './dto/waitlist-pagination.dto';
+
+describe('WaitlistAdminController', () => {
+  let controller: WaitlistAdminController;
+  let service: WaitlistService;
+
+  const mockWaitlistService = {
+    findAllAdmin: jest.fn(),
+    getStats: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WaitlistAdminController],
+      providers: [
+        {
+          provide: WaitlistService,
+          useValue: mockWaitlistService,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(AdminGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RedisRateLimitGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<WaitlistAdminController>(WaitlistAdminController);
+    service = module.get<WaitlistService>(WaitlistService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should return paginated results with stats', async () => {
+      const dto: WaitlistPaginationDto = { page: 1, limit: 10 };
+      const mockPaginatedResponse = {
+        data: [],
+        meta: { totalItems: 0 },
+      };
+      const mockStats = { totalItems: 10, withWallet: 5, withEmail: 5 };
+
+      mockWaitlistService.findAllAdmin.mockResolvedValue(mockPaginatedResponse);
+      mockWaitlistService.getStats.mockResolvedValue(mockStats);
+
+      const result = await controller.findAll(dto);
+
+      expect(result).toEqual({
+        ...mockPaginatedResponse,
+        stats: mockStats,
+      });
+      expect(service.findAllAdmin).toHaveBeenCalledWith(dto);
+      expect(service.getStats).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/waitlist/waitlist-admin.controller.ts
+++ b/backend/src/modules/waitlist/waitlist-admin.controller.ts
@@ -1,0 +1,48 @@
+import { Controller, Get, HttpStatus, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { WaitlistService } from './waitlist.service';
+import { WaitlistPaginationDto } from './dto/waitlist-pagination.dto';
+import { Waitlist } from './entities/waitlist.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import {
+  RedisRateLimitGuard,
+  RateLimit,
+} from '../../common/guards/redis-rate-limit.guard';
+import { PaginatedResponse } from '../../common';
+
+@ApiTags('admin-waitlist')
+@ApiBearerAuth()
+@Controller('admin/waitlist')
+@UseGuards(JwtAuthGuard, AdminGuard, RedisRateLimitGuard)
+export class WaitlistAdminController {
+  constructor(private readonly waitlistService: WaitlistService) {}
+
+  @Get()
+  @RateLimit(50, 60)
+  @ApiOperation({
+    summary: 'Retrieve all waitlist entries with pagination and filtering',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Paginated list of waitlist entries with statistics.',
+    type: [Waitlist], // Swagger might need a proper paginated wrapper for better documentation
+  })
+  async findAll(
+    @Query() paginationDto: WaitlistPaginationDto,
+  ): Promise<PaginatedResponse<Waitlist> & { stats: any }> {
+    const paginatedData =
+      await this.waitlistService.findAllAdmin(paginationDto);
+    const stats = await this.waitlistService.getStats();
+
+    return {
+      ...paginatedData,
+      stats,
+    };
+  }
+}

--- a/backend/src/modules/waitlist/waitlist.controller.ts
+++ b/backend/src/modules/waitlist/waitlist.controller.ts
@@ -1,90 +1,87 @@
 import {
-    Body,
-    Controller,
-    Get,
-    HttpCode,
-    HttpStatus,
-    Post,
-    UseGuards,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import {
-    ApiBody,
-    ApiOperation,
-    ApiResponse,
-    ApiTags,
-} from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { WaitlistService } from './waitlist.service';
 import { CreateWaitlistDto } from './dto/create-waitlist.dto';
 import { WaitlistResponseDto } from './dto/waitlist-response.dto';
 import { Waitlist } from './entities/waitlist.entity';
 import {
-    RedisRateLimitGuard,
-    RateLimit,
+  RedisRateLimitGuard,
+  RateLimit,
 } from '../../common/guards/redis-rate-limit.guard';
 
 @ApiTags('waitlist')
 @Controller('waitlist')
 export class WaitlistController {
-    constructor(private readonly waitlistService: WaitlistService) { }
+  constructor(private readonly waitlistService: WaitlistService) {}
 
-    /**
-     * POST /waitlist
-     *
-     * Public endpoint — no auth required.
-     * Rate limited to 5 requests per minute per IP (global throttler)
-     * + 10 requests per minute per IP via Redis guard.
-     *
-     * Validation:
-     *   - At least one of wallet_address, email_address, telegram_username required
-     *   - Inputs are trimmed and lowercased before persistence
-     *   - Duplicate wallet/email returns 409 with a field-specific message
-     */
-    @Post()
-    @HttpCode(HttpStatus.CREATED)
-    @Throttle({ default: { limit: 5, ttl: 60000 } })
-    @UseGuards(RedisRateLimitGuard)
-    @RateLimit(10, 60)
-    @ApiOperation({
-        summary: 'Join the waitlist',
-        description:
-            'Register interest in the product. At least one of wallet_address, email_address, or telegram_username must be provided.',
-    })
-    @ApiBody({ type: CreateWaitlistDto })
-    @ApiResponse({
-        status: HttpStatus.CREATED,
-        description: 'Successfully joined the waitlist.',
-        type: WaitlistResponseDto,
-    })
-    @ApiResponse({
-        status: HttpStatus.BAD_REQUEST,
-        description: 'Validation failed — at least one contact field is required.',
-    })
-    @ApiResponse({
-        status: HttpStatus.CONFLICT,
-        description: 'Wallet address or email is already registered.',
-    })
-    @ApiResponse({
-        status: HttpStatus.TOO_MANY_REQUESTS,
-        description: 'Rate limit exceeded. Try again later.',
-    })
-    create(@Body() createWaitlistDto: CreateWaitlistDto): Promise<WaitlistResponseDto> {
-        return this.waitlistService.create(createWaitlistDto);
-    }
+  /**
+   * POST /waitlist
+   *
+   * Public endpoint — no auth required.
+   * Rate limited to 5 requests per minute per IP (global throttler)
+   * + 10 requests per minute per IP via Redis guard.
+   *
+   * Validation:
+   *   - At least one of wallet_address, email_address, telegram_username required
+   *   - Inputs are trimmed and lowercased before persistence
+   *   - Duplicate wallet/email returns 409 with a field-specific message
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @UseGuards(RedisRateLimitGuard)
+  @RateLimit(10, 60)
+  @ApiOperation({
+    summary: 'Join the waitlist',
+    description:
+      'Register interest in the product. At least one of wallet_address, email_address, or telegram_username must be provided.',
+  })
+  @ApiBody({ type: CreateWaitlistDto })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Successfully joined the waitlist.',
+    type: WaitlistResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Validation failed — at least one contact field is required.',
+  })
+  @ApiResponse({
+    status: HttpStatus.CONFLICT,
+    description: 'Wallet address or email is already registered.',
+  })
+  @ApiResponse({
+    status: HttpStatus.TOO_MANY_REQUESTS,
+    description: 'Rate limit exceeded. Try again later.',
+  })
+  create(
+    @Body() createWaitlistDto: CreateWaitlistDto,
+  ): Promise<WaitlistResponseDto> {
+    return this.waitlistService.create(createWaitlistDto);
+  }
 
-    /**
-     * GET /waitlist
-     * Internal — returns all waitlist entries (no auth guard added here;
-     * protect via API gateway or add JwtAuthGuard when needed).
-     */
-    @Get()
-    @ApiOperation({ summary: 'Retrieve all waitlist entries (internal)' })
-    @ApiResponse({
-        status: HttpStatus.OK,
-        description: 'List of all waitlist entries.',
-        type: [Waitlist],
-    })
-    findAll(): Promise<Waitlist[]> {
-        return this.waitlistService.findAll();
-    }
+  /**
+   * GET /waitlist
+   * Internal — returns all waitlist entries (no auth guard added here;
+   * protect via API gateway or add JwtAuthGuard when needed).
+   */
+  @Get()
+  @ApiOperation({ summary: 'Retrieve all waitlist entries (internal)' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'List of all waitlist entries.',
+    type: [Waitlist],
+  })
+  findAll(): Promise<Waitlist[]> {
+    return this.waitlistService.findAll();
+  }
 }

--- a/backend/src/modules/waitlist/waitlist.module.ts
+++ b/backend/src/modules/waitlist/waitlist.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Waitlist } from './entities/waitlist.entity';
 import { WaitlistService } from './waitlist.service';
 import { WaitlistController } from './waitlist.controller';
+import { WaitlistAdminController } from './waitlist-admin.controller';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Waitlist])],
-    controllers: [WaitlistController],
-    providers: [WaitlistService],
-    exports: [WaitlistService],
+  imports: [TypeOrmModule.forFeature([Waitlist])],
+  controllers: [WaitlistController, WaitlistAdminController],
+  providers: [WaitlistService],
+  exports: [WaitlistService],
 })
-export class WaitlistModule { }
+export class WaitlistModule {}

--- a/backend/src/modules/waitlist/waitlist.service.spec.ts
+++ b/backend/src/modules/waitlist/waitlist.service.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WaitlistService } from './waitlist.service';
+import { Waitlist } from './entities/waitlist.entity';
+import { PaginationService, SortOrder } from '../../common';
+import { WaitlistPaginationDto } from './dto/waitlist-pagination.dto';
+
+describe('WaitlistService', () => {
+  let service: WaitlistService;
+  let repository: Repository<Waitlist>;
+  let paginationService: PaginationService;
+
+  const mockWaitlistRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    count: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const mockPaginationService = {
+    paginate: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WaitlistService,
+        {
+          provide: getRepositoryToken(Waitlist),
+          useValue: mockWaitlistRepository,
+        },
+        {
+          provide: PaginationService,
+          useValue: mockPaginationService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WaitlistService>(WaitlistService);
+    repository = module.get<Repository<Waitlist>>(getRepositoryToken(Waitlist));
+    paginationService = module.get<PaginationService>(PaginationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findAllAdmin', () => {
+    it('should call paginationService.paginate with correct query', async () => {
+      const dto: WaitlistPaginationDto = {
+        page: 1,
+        limit: 10,
+        wallet: '0x123',
+      };
+
+      const mockQueryBuilder: any = {
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+
+      mockWaitlistRepository.createQueryBuilder.mockReturnValue(
+        mockQueryBuilder,
+      );
+      mockPaginationService.paginate.mockResolvedValue({ data: [], meta: {} });
+
+      await service.findAllAdmin(dto);
+
+      expect(mockWaitlistRepository.createQueryBuilder).toHaveBeenCalledWith(
+        'waitlist',
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'waitlist.wallet_address ILIKE :wallet',
+        { wallet: '%0x123%' },
+      );
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQueryBuilder,
+        dto,
+      );
+    });
+
+    it('should apply sorting correctly', async () => {
+      const dto: WaitlistPaginationDto = {
+        sortBy: 'email',
+        sortOrder: SortOrder.DESC,
+      };
+
+      const mockQueryBuilder: any = {
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+
+      mockWaitlistRepository.createQueryBuilder.mockReturnValue(
+        mockQueryBuilder,
+      );
+      mockPaginationService.paginate.mockResolvedValue({ data: [], meta: {} });
+
+      await service.findAllAdmin(dto);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'waitlist.email_address',
+        SortOrder.DESC,
+      );
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return waitlist statistics', async () => {
+      mockWaitlistRepository.count.mockResolvedValueOnce(100); // total
+      mockWaitlistRepository.count.mockResolvedValueOnce(60); // withWallet
+      mockWaitlistRepository.count.mockResolvedValueOnce(40); // withEmail
+
+      const stats = await service.getStats();
+
+      expect(stats).toEqual({
+        totalItems: 100,
+        withWallet: 60,
+        withEmail: 40,
+      });
+      expect(mockWaitlistRepository.count).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/backend/src/modules/waitlist/waitlist.service.ts
+++ b/backend/src/modules/waitlist/waitlist.service.ts
@@ -1,97 +1,170 @@
 import {
-    BadRequestException,
-    ConflictException,
-    Injectable,
-    InternalServerErrorException,
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, Not, IsNull } from 'typeorm';
 import { Waitlist } from './entities/waitlist.entity';
 import { CreateWaitlistDto } from './dto/create-waitlist.dto';
 import { WaitlistResponseDto } from './dto/waitlist-response.dto';
+import { WaitlistPaginationDto } from './dto/waitlist-pagination.dto';
+import { PaginationService, PaginatedResponse, SortOrder } from '../../common';
 
 @Injectable()
 export class WaitlistService {
-    constructor(
-        @InjectRepository(Waitlist)
-        private readonly waitlistRepository: Repository<Waitlist>,
-    ) { }
+  constructor(
+    @InjectRepository(Waitlist)
+    private readonly waitlistRepository: Repository<Waitlist>,
+    private readonly paginationService: PaginationService,
+  ) {}
 
-    /**
-     * Register a new waitlist entry.
-     * Validates at least one identifier is provided, checks per-field
-     * uniqueness with precise error messages, then persists the entry.
-     */
-    async create(dto: CreateWaitlistDto): Promise<WaitlistResponseDto> {
-        const { wallet_address, email_address, telegram_username } = dto;
+  /**
+   * Register a new waitlist entry.
+   * Validates at least one identifier is provided, checks per-field
+   * uniqueness with precise error messages, then persists the entry.
+   */
+  async create(dto: CreateWaitlistDto): Promise<WaitlistResponseDto> {
+    const { wallet_address, email_address, telegram_username } = dto;
 
-        // Service-level guard (belt-and-suspenders after DTO validation)
-        if (!wallet_address && !email_address && !telegram_username) {
-            throw new BadRequestException(
-                'At least one of wallet_address, email_address, or telegram_username is required.',
-            );
-        }
-
-        // Per-field duplicate checks — gives specific, user-friendly error messages
-        if (wallet_address) {
-            const existing = await this.waitlistRepository.findOne({
-                where: { wallet_address },
-            });
-            if (existing) {
-                throw new ConflictException(
-                    'This wallet address is already on the waitlist.',
-                );
-            }
-        }
-
-        if (email_address) {
-            const existing = await this.waitlistRepository.findOne({
-                where: { email_address },
-            });
-            if (existing) {
-                throw new ConflictException(
-                    'This email address is already on the waitlist.',
-                );
-            }
-        }
-
-        try {
-            const entry = this.waitlistRepository.create(dto);
-            const saved = await this.waitlistRepository.save(entry);
-            return this.toResponseDto(saved);
-        } catch (error: unknown) {
-            const dbError = error as { code?: string };
-            // Fallback: catch any remaining unique constraint violations
-            if (dbError.code === '23505') {
-                throw new ConflictException(
-                    'This entry is already registered on the waitlist.',
-                );
-            }
-            throw new InternalServerErrorException(
-                'Failed to register for the waitlist. Please try again.',
-            );
-        }
+    // Service-level guard (belt-and-suspenders after DTO validation)
+    if (!wallet_address && !email_address && !telegram_username) {
+      throw new BadRequestException(
+        'At least one of wallet_address, email_address, or telegram_username is required.',
+      );
     }
 
-    async findAll(): Promise<Waitlist[]> {
-        return this.waitlistRepository.find({
-            order: { created_at: 'DESC' },
-        });
+    // Per-field duplicate checks — gives specific, user-friendly error messages
+    if (wallet_address) {
+      const existing = await this.waitlistRepository.findOne({
+        where: { wallet_address },
+      });
+      if (existing) {
+        throw new ConflictException(
+          'This wallet address is already on the waitlist.',
+        );
+      }
     }
 
-    // ---------------------------------------------------------------------------
-    // Private helpers
-    // ---------------------------------------------------------------------------
-
-    private toResponseDto(entry: Waitlist): WaitlistResponseDto {
-        return {
-            message: 'You have been added to the waitlist.',
-            data: {
-                wallet_address: entry.wallet_address ?? null,
-                email_address: entry.email_address ?? null,
-                telegram_username: entry.telegram_username ?? null,
-                joined_at: entry.created_at,
-            },
-        };
+    if (email_address) {
+      const existing = await this.waitlistRepository.findOne({
+        where: { email_address },
+      });
+      if (existing) {
+        throw new ConflictException(
+          'This email address is already on the waitlist.',
+        );
+      }
     }
+
+    try {
+      const entry = this.waitlistRepository.create(dto);
+      const saved = await this.waitlistRepository.save(entry);
+      return this.toResponseDto(saved);
+    } catch (error: unknown) {
+      const dbError = error as { code?: string };
+      // Fallback: catch any remaining unique constraint violations
+      if (dbError.code === '23505') {
+        throw new ConflictException(
+          'This entry is already registered on the waitlist.',
+        );
+      }
+      throw new InternalServerErrorException(
+        'Failed to register for the waitlist. Please try again.',
+      );
+    }
+  }
+
+  async findAll(): Promise<Waitlist[]> {
+    return this.waitlistRepository.find({
+      order: { created_at: SortOrder.DESC },
+    });
+  }
+
+  /**
+   * Get all waitlist entries with pagination, sorting and filtering for admin.
+   */
+  async findAllAdmin(
+    paginationDto: WaitlistPaginationDto,
+  ): Promise<PaginatedResponse<Waitlist>> {
+    const { wallet, email, telegram, sortBy, sortOrder } = paginationDto;
+
+    const queryBuilder = this.waitlistRepository.createQueryBuilder('waitlist');
+
+    // Apply filters
+    if (wallet) {
+      queryBuilder.andWhere('waitlist.wallet_address ILIKE :wallet', {
+        wallet: `%${wallet}%`,
+      });
+    }
+    if (email) {
+      queryBuilder.andWhere('waitlist.email_address ILIKE :email', {
+        email: `%${email}%`,
+      });
+    }
+    if (telegram) {
+      queryBuilder.andWhere('waitlist.telegram_username ILIKE :telegram', {
+        telegram: `%${telegram}%`,
+      });
+    }
+
+    // Apply specific sorting logic if requested
+    if (sortBy === 'newest') {
+      queryBuilder.orderBy('waitlist.created_at', sortOrder || SortOrder.DESC);
+    } else if (sortBy === 'wallet') {
+      queryBuilder.orderBy(
+        'waitlist.wallet_address',
+        sortOrder || SortOrder.ASC,
+      );
+    } else if (sortBy === 'email') {
+      queryBuilder.orderBy(
+        'waitlist.email_address',
+        sortOrder || SortOrder.ASC,
+      );
+    } else if (sortBy) {
+      // Default to entity field sorting if it's a valid field
+      queryBuilder.orderBy(`waitlist.${sortBy}`, sortOrder || SortOrder.ASC);
+    } else {
+      // Default sort
+      queryBuilder.orderBy('waitlist.created_at', SortOrder.DESC);
+    }
+
+    return await this.paginationService.paginate(queryBuilder, paginationDto);
+  }
+
+  /**
+   * Get aggregate statistics for the waitlist.
+   */
+  async getStats() {
+    const total = await this.waitlistRepository.count();
+    const withWallet = await this.waitlistRepository.count({
+      where: { wallet_address: Not(IsNull()) },
+    });
+    const withEmail = await this.waitlistRepository.count({
+      where: { email_address: Not(IsNull()) },
+    });
+
+    return {
+      totalItems: total,
+      withWallet,
+      withEmail,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private toResponseDto(entry: Waitlist): WaitlistResponseDto {
+    return {
+      message: 'You have been added to the waitlist.',
+      data: {
+        wallet_address: entry.wallet_address ?? null,
+        email_address: entry.email_address ?? null,
+        telegram_username: entry.telegram_username ?? null,
+        joined_at: entry.created_at,
+      },
+    };
+  }
 }


### PR DESCRIPTION
I have implemented the admin APIs for the waitlist module to allow administrators to view, filter, and sort waitlist entries with pagination and aggregate statistics.

Closes #245 