### PR TITLE
feat/implement-perks-boosts-database-schema

### DIFF
--- a/backend/src/database/migrations/1740400000000-CreatePerksTable.ts
+++ b/backend/src/database/migrations/1740400000000-CreatePerksTable.ts
@@ -1,0 +1,63 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableIndex,
+} from 'typeorm';
+
+export class CreatePerksTable1740400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "perk_type_enum" AS ENUM (
+        'permanent', 'temporary', 'consumable'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "perk_category_enum" AS ENUM (
+        'economy', 'defense', 'movement'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "perks" (
+        "id" SERIAL PRIMARY KEY,
+        "name" varchar(255) NOT NULL,
+        "description" text,
+        "type" "perk_type_enum" NOT NULL,
+        "category" "perk_category_enum" NOT NULL,
+        "rarity" varchar(50) DEFAULT 'common',
+        "price" decimal(10,2) NOT NULL,
+        "metadata" json,
+        "is_active" boolean DEFAULT true,
+        "created_at" timestamp DEFAULT now(),
+        "updated_at" timestamp DEFAULT now()
+      )
+    `);
+
+    await queryRunner.createIndex(
+      'perks',
+      new TableIndex({ name: 'IDX_PERKS_TYPE', columnNames: ['type'] }),
+    );
+
+    await queryRunner.createIndex(
+      'perks',
+      new TableIndex({ name: 'IDX_PERKS_CATEGORY', columnNames: ['category'] }),
+    );
+
+    await queryRunner.createIndex(
+      'perks',
+      new TableIndex({ name: 'IDX_PERKS_RARITY', columnNames: ['rarity'] }),
+    );
+
+    await queryRunner.createIndex(
+      'perks',
+      new TableIndex({ name: 'IDX_PERKS_IS_ACTIVE', columnNames: ['is_active'] }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('perks');
+    await queryRunner.query(`DROP TYPE IF EXISTS "perk_type_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "perk_category_enum"`);
+  }
+}

--- a/backend/src/database/migrations/1740400000001-CreateBoostsTable.ts
+++ b/backend/src/database/migrations/1740400000001-CreateBoostsTable.ts
@@ -1,0 +1,97 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateBoostsTable1740400000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'boosts',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'perk_id',
+            type: 'int',
+          },
+          {
+            name: 'boost_type',
+            type: 'varchar',
+            length: '100',
+          },
+          {
+            name: 'effect_value',
+            type: 'decimal',
+            precision: 12,
+            scale: 4,
+          },
+          {
+            name: 'duration_seconds',
+            type: 'int',
+            isNullable: true,
+          },
+          {
+            name: 'stackable',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'boosts',
+      new TableIndex({ name: 'IDX_BOOSTS_PERK_ID', columnNames: ['perk_id'] }),
+    );
+
+    await queryRunner.createIndex(
+      'boosts',
+      new TableIndex({
+        name: 'IDX_BOOSTS_BOOST_TYPE',
+        columnNames: ['boost_type'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'boosts',
+      new TableForeignKey({
+        columnNames: ['perk_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'perks',
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('boosts');
+    if (table) {
+      const foreignKeys = table.foreignKeys;
+      for (const foreignKey of foreignKeys) {
+        await queryRunner.dropForeignKey('boosts', foreignKey);
+      }
+    }
+
+    await queryRunner.dropTable('boosts');
+  }
+}

--- a/backend/src/database/migrations/1740400000002-CreatePlayerPerksTable.ts
+++ b/backend/src/database/migrations/1740400000002-CreatePlayerPerksTable.ts
@@ -1,0 +1,119 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreatePlayerPerksTable1740400000002 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'player_perks',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'player_id',
+            type: 'int',
+          },
+          {
+            name: 'perk_id',
+            type: 'int',
+          },
+          {
+            name: 'quantity',
+            type: 'int',
+            default: 1,
+          },
+          {
+            name: 'acquired_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'player_perks',
+      new TableIndex({
+        name: 'IDX_PLAYER_PERKS_PLAYER_ID',
+        columnNames: ['player_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'player_perks',
+      new TableIndex({
+        name: 'IDX_PLAYER_PERKS_PERK_ID',
+        columnNames: ['perk_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'player_perks',
+      new TableIndex({
+        name: 'IDX_PLAYER_PERKS_PLAYER_PERK',
+        columnNames: ['player_id', 'perk_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'player_perks',
+      new TableIndex({
+        name: 'IDX_PLAYER_PERKS_ACQUIRED_AT',
+        columnNames: ['acquired_at'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'player_perks',
+      new TableForeignKey({
+        columnNames: ['player_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'player_perks',
+      new TableForeignKey({
+        columnNames: ['perk_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'perks',
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('player_perks');
+    if (table) {
+      const foreignKeys = table.foreignKeys;
+      for (const foreignKey of foreignKeys) {
+        await queryRunner.dropForeignKey('player_perks', foreignKey);
+      }
+    }
+
+    await queryRunner.dropTable('player_perks');
+  }
+}

--- a/backend/src/database/migrations/1740400000003-CreateActiveBoostsTable.ts
+++ b/backend/src/database/migrations/1740400000003-CreateActiveBoostsTable.ts
@@ -1,0 +1,124 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateActiveBoostsTable1740400000003 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'active_boosts',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'player_id',
+            type: 'int',
+          },
+          {
+            name: 'boost_id',
+            type: 'int',
+          },
+          {
+            name: 'expires_at',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'remaining_uses',
+            type: 'int',
+            isNullable: true,
+          },
+          {
+            name: 'activated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'active_boosts',
+      new TableIndex({
+        name: 'IDX_ACTIVE_BOOSTS_PLAYER_ID',
+        columnNames: ['player_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'active_boosts',
+      new TableIndex({
+        name: 'IDX_ACTIVE_BOOSTS_BOOST_ID',
+        columnNames: ['boost_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'active_boosts',
+      new TableIndex({
+        name: 'IDX_ACTIVE_BOOSTS_EXPIRES_AT',
+        columnNames: ['expires_at'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'active_boosts',
+      new TableIndex({
+        name: 'IDX_ACTIVE_BOOSTS_PLAYER_EXPIRES',
+        columnNames: ['player_id', 'expires_at'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'active_boosts',
+      new TableForeignKey({
+        columnNames: ['player_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'active_boosts',
+      new TableForeignKey({
+        columnNames: ['boost_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'boosts',
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('active_boosts');
+    if (table) {
+      const foreignKeys = table.foreignKeys;
+      for (const foreignKey of foreignKeys) {
+        await queryRunner.dropForeignKey('active_boosts', foreignKey);
+      }
+    }
+
+    await queryRunner.dropTable('active_boosts');
+  }
+}


### PR DESCRIPTION
### :sparkles: Implement perks & boosts database schema


- [x] Closes #292 

---

### 📌 Type of Change

- [x] Implement perks database schema
- [x] Implement boosts database schema
- [x] Add player perks pivot table
- [x] Add active boosts tracking table


**Files Changed:**

- `backend/src/database/migrations/1740400000000-CreatePerksTable.ts`
- `backend/src/database/migrations/1740400000001-CreateBoostsTable.ts`
- `backend/src/database/migrations/1740400000002-CreatePlayerPerksTable.ts`
- `backend/src/database/migrations/1740400000003-CreateActiveBoostsTable.ts`