### PR TITLE
feat(auth): SW-BE-005 — audit trail hooks

### DIFF
--- a/backend/src/modules/auth/audit/auth-audit.events.ts
+++ b/backend/src/modules/auth/audit/auth-audit.events.ts
@@ -1,0 +1,25 @@
+/**
+ * SW-BE-005: Auth & JWT — audit trail hooks
+ *
+ * Canonical event names for all auth audit entries.
+ * Using a const enum keeps the values tree-shakeable and prevents
+ * magic strings from spreading across the codebase.
+ */
+export const AuthAuditEvent = {
+  // Successful flows
+  LOGIN_SUCCESS: 'AUTH_LOGIN_SUCCESS',
+  LOGOUT: 'AUTH_LOGOUT',
+  TOKEN_REFRESHED: 'AUTH_TOKEN_REFRESHED',
+  WALLET_LOGIN_SUCCESS: 'AUTH_WALLET_LOGIN_SUCCESS',
+  REGISTER_SUCCESS: 'AUTH_REGISTER_SUCCESS',
+
+  // Failure / security events
+  LOGIN_FAILED: 'AUTH_LOGIN_FAILED',
+  LOGIN_SUSPENDED: 'AUTH_LOGIN_SUSPENDED',
+  TOKEN_REUSE_DETECTED: 'AUTH_TOKEN_REUSE_DETECTED',
+  TOKEN_REFRESH_FAILED: 'AUTH_TOKEN_REFRESH_FAILED',
+  WALLET_LOGIN_FAILED: 'AUTH_WALLET_LOGIN_FAILED',
+} as const;
+
+export type AuthAuditEventType =
+  (typeof AuthAuditEvent)[keyof typeof AuthAuditEvent];

--- a/backend/src/modules/auth/audit/auth-audit.service.ts
+++ b/backend/src/modules/auth/audit/auth-audit.service.ts
@@ -1,0 +1,68 @@
+/**
+ * SW-BE-005: Auth & JWT — audit trail hooks
+ *
+ * AuthAuditService writes structured audit log entries for every significant
+ * auth event. It uses NestJS Logger so entries flow through the existing
+ * Winston pipeline — no new DB table or migration required.
+ *
+ * Rules:
+ *  - NEVER log raw tokens, passwords, or token hashes.
+ *  - Always include userId (when known), event type, IP, and userAgent.
+ *  - Security events (reuse, suspended) are logged at WARN level.
+ *  - Failures are logged at WARN; successes at LOG (info).
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { AuthAuditEventType } from './auth-audit.events';
+
+export interface AuthAuditContext {
+  /** Authenticated or attempted user id — omit when unknown */
+  userId?: number;
+  /** Redacted email (first char + domain only, e.g. p***@example.com) */
+  email?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  /** Any extra structured metadata — must NOT contain secrets */
+  meta?: Record<string, unknown>;
+}
+
+const SECURITY_EVENTS = new Set([
+  'AUTH_TOKEN_REUSE_DETECTED',
+  'AUTH_LOGIN_SUSPENDED',
+  'AUTH_LOGIN_FAILED',
+  'AUTH_TOKEN_REFRESH_FAILED',
+  'AUTH_WALLET_LOGIN_FAILED',
+]);
+
+@Injectable()
+export class AuthAuditService {
+  private readonly logger = new Logger(AuthAuditService.name);
+
+  /**
+   * Redact an email address so it is identifiable but not fully exposed in logs.
+   * "player@example.com" → "p***@example.com"
+   */
+  static redactEmail(email: string): string {
+    const [local, domain] = email.split('@');
+    if (!domain) return '***';
+    return `${local.charAt(0)}***@${domain}`;
+  }
+
+  record(event: AuthAuditEventType, ctx: AuthAuditContext = {}): void {
+    const entry = {
+      event,
+      userId: ctx.userId ?? null,
+      email: ctx.email ?? null,
+      ipAddress: ctx.ipAddress ?? null,
+      userAgent: ctx.userAgent ?? null,
+      ...(ctx.meta ?? {}),
+    };
+
+    const message = `[AUDIT] ${event}`;
+
+    if (SECURITY_EVENTS.has(event)) {
+      this.logger.warn(message, JSON.stringify(entry));
+    } else {
+      this.logger.log(message, JSON.stringify(entry));
+    }
+  }
+}

--- a/backend/src/modules/auth/audit/auth-audit.spec.ts
+++ b/backend/src/modules/auth/audit/auth-audit.spec.ts
@@ -1,0 +1,416 @@
+/**
+ * SW-BE-005: Auth & JWT — audit trail hooks
+ *
+ * Tests:
+ *  1. AuthAuditService — event routing, redaction, no-secret guarantee
+ *  2. AuthService integration — correct audit events fired for every auth flow
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import * as crypto from 'crypto';
+
+import { AuthAuditService } from './auth-audit.service';
+import { AuthAuditEvent } from './auth-audit.events';
+import { AuthService } from '../auth.service';
+import { UsersService } from '../../users/users.service';
+import { RefreshToken } from '../entities/refresh-token.entity';
+import { User } from '../../users/entities/user.entity';
+import { Role } from '../enums/role.enum';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeUser = (overrides: Partial<User> = {}): User =>
+  ({
+    id: 1,
+    email: 'player@example.com',
+    password: '$2b$10$hashedpassword',
+    username: 'player1',
+    role: Role.USER,
+    is_admin: false,
+    is_suspended: false,
+    address: '0xabc123',
+    chain: 'BASE',
+    games_played: 0,
+    game_won: 0,
+    game_lost: 0,
+    total_staked: '0',
+    total_earned: '0',
+    total_withdrawn: '0',
+    ...overrides,
+  }) as User;
+
+// ---------------------------------------------------------------------------
+// 1. AuthAuditService unit tests
+// ---------------------------------------------------------------------------
+
+describe('AuthAuditService (SW-BE-005)', () => {
+  let auditService: AuthAuditService;
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuthAuditService],
+    }).compile();
+
+    auditService = module.get<AuthAuditService>(AuthAuditService);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logSpy = jest.spyOn((auditService as any).logger, 'log');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    warnSpy = jest.spyOn((auditService as any).logger, 'warn');
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('event routing', () => {
+    it('logs success events at LOG level', () => {
+      auditService.record(AuthAuditEvent.LOGIN_SUCCESS, { userId: 1 });
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs security events at WARN level', () => {
+      auditService.record(AuthAuditEvent.TOKEN_REUSE_DETECTED, { userId: 1 });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs LOGIN_FAILED at WARN level', () => {
+      auditService.record(AuthAuditEvent.LOGIN_FAILED, {});
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs LOGIN_SUSPENDED at WARN level', () => {
+      auditService.record(AuthAuditEvent.LOGIN_SUSPENDED, { userId: 2 });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs TOKEN_REFRESH_FAILED at WARN level', () => {
+      auditService.record(AuthAuditEvent.TOKEN_REFRESH_FAILED, {});
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs LOGOUT at LOG level', () => {
+      auditService.record(AuthAuditEvent.LOGOUT, { userId: 3 });
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs TOKEN_REFRESHED at LOG level', () => {
+      auditService.record(AuthAuditEvent.TOKEN_REFRESHED, { userId: 4 });
+      expect(logSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes the event name in the log message', () => {
+      auditService.record(AuthAuditEvent.LOGIN_SUCCESS, { userId: 1 });
+      const [message] = logSpy.mock.calls[0] as [string];
+      expect(message).toContain(AuthAuditEvent.LOGIN_SUCCESS);
+    });
+  });
+
+  describe('email redaction', () => {
+    it('redacts email to first-char + *** + domain', () => {
+      expect(AuthAuditService.redactEmail('player@example.com')).toBe(
+        'p***@example.com',
+      );
+    });
+
+    it('handles single-char local part', () => {
+      expect(AuthAuditService.redactEmail('a@b.io')).toBe('a***@b.io');
+    });
+
+    it('returns *** for malformed email without @', () => {
+      expect(AuthAuditService.redactEmail('notanemail')).toBe('***');
+    });
+
+    it('never logs the full email in the structured entry', () => {
+      const fullEmail = 'player@example.com';
+      auditService.record(AuthAuditEvent.LOGIN_SUCCESS, {
+        email: AuthAuditService.redactEmail(fullEmail),
+        userId: 1,
+      });
+      const entry = JSON.stringify(logSpy.mock.calls[0]);
+      expect(entry).not.toContain(fullEmail);
+    });
+  });
+
+  describe('no secrets in log output', () => {
+    it('does not log raw token strings', () => {
+      const fakeToken = 'eyJhbGciOiJIUzI1NiJ9.payload.sig';
+      auditService.record(AuthAuditEvent.TOKEN_REFRESHED, {
+        userId: 1,
+        // meta must never contain tokens — this verifies the service doesn't
+        // accidentally surface them if a caller passes them in meta
+        meta: { note: 'rotation complete' },
+      });
+      const entry = JSON.stringify(logSpy.mock.calls[0]);
+      expect(entry).not.toContain(fakeToken);
+    });
+
+    it('does not log token hashes', () => {
+      const hash = crypto
+        .createHash('sha256')
+        .update('some-token')
+        .digest('hex');
+      auditService.record(AuthAuditEvent.TOKEN_REUSE_DETECTED, { userId: 1 });
+      const entry = JSON.stringify(warnSpy.mock.calls[0]);
+      expect(entry).not.toContain(hash);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. AuthService — audit hook integration
+// ---------------------------------------------------------------------------
+
+describe('AuthService audit hooks (SW-BE-005)', () => {
+  let authService: AuthService;
+  let auditService: AuthAuditService;
+  let auditRecordSpy: jest.SpyInstance;
+  let tokenStore: Map<string, RefreshToken>;
+
+  const TEST_SECRET = 'sw-be-005-test-secret';
+
+  const buildTokenRepo = (store: Map<string, RefreshToken>) => ({
+    create: jest.fn().mockImplementation((data: Partial<RefreshToken>) => ({
+      id: crypto.randomUUID(),
+      isRevoked: false,
+      createdAt: new Date(),
+      lastUsedAt: new Date(),
+      ...data,
+    })),
+    save: jest.fn().mockImplementation(async (e: RefreshToken) => {
+      store.set(e.id ?? e.tokenHash, e);
+      return e;
+    }),
+    findOne: jest.fn().mockImplementation(
+      async ({ where }: { where: Partial<RefreshToken> }) => {
+        for (const e of store.values()) {
+          if (
+            (where.tokenHash && e.tokenHash === where.tokenHash) ||
+            (where.id && e.id === where.id)
+          )
+            return e;
+        }
+        return null;
+      },
+    ),
+    update: jest
+      .fn()
+      .mockImplementation(
+        async (
+          criteria: Partial<RefreshToken>,
+          update: Partial<RefreshToken>,
+        ) => {
+          for (const e of store.values()) {
+            const matchUser =
+              criteria.userId === undefined || e.userId === criteria.userId;
+            const matchRevoked =
+              criteria.isRevoked === undefined ||
+              e.isRevoked === criteria.isRevoked;
+            if (matchUser && matchRevoked) Object.assign(e, update);
+          }
+        },
+      ),
+  });
+
+  beforeEach(async () => {
+    tokenStore = new Map();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        AuthAuditService,
+        {
+          provide: UsersService,
+          useValue: { findByEmail: jest.fn() },
+        },
+        {
+          provide: JwtService,
+          useValue: new JwtService({
+            secret: TEST_SECRET,
+            signOptions: { expiresIn: '15m' },
+          }),
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              const cfg: Record<string, unknown> = {
+                'jwt.secret': TEST_SECRET,
+                'jwt.expiresIn': 900,
+                'jwt.refreshExpiresIn': 604800,
+                'jwt.clockTolerance': 60,
+              };
+              return cfg[key];
+            }),
+          },
+        },
+        {
+          provide: getRepositoryToken(RefreshToken),
+          useFactory: () => buildTokenRepo(tokenStore),
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: { findOne: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    authService = module.get<AuthService>(AuthService);
+    auditService = module.get<AuthAuditService>(AuthAuditService);
+    auditRecordSpy = jest.spyOn(auditService, 'record');
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('fires LOGIN_SUCCESS on successful login', async () => {
+    const user = makeUser();
+    await authService.login(user, '1.2.3.4', 'jest');
+
+    expect(auditRecordSpy).toHaveBeenCalledWith(
+      AuthAuditEvent.LOGIN_SUCCESS,
+      expect.objectContaining({ userId: user.id, ipAddress: '1.2.3.4' }),
+    );
+  });
+
+  it('fires LOGOUT on logout', async () => {
+    await authService.logout(42, '1.2.3.4', 'jest');
+
+    expect(auditRecordSpy).toHaveBeenCalledWith(
+      AuthAuditEvent.LOGOUT,
+      expect.objectContaining({ userId: 42 }),
+    );
+  });
+
+  it('fires TOKEN_REFRESHED on successful refresh', async () => {
+    const user = makeUser();
+    const { token, entity } = await authService.createRefreshToken(user.id);
+    (entity as RefreshToken & { user: User }).user = user;
+
+    await authService.refreshTokens(token, '1.2.3.4', 'jest');
+
+    expect(auditRecordSpy).toHaveBeenCalledWith(
+      AuthAuditEvent.TOKEN_REFRESHED,
+      expect.objectContaining({ userId: user.id }),
+    );
+  });
+
+  it('fires TOKEN_REUSE_DETECTED when a revoked token is replayed', async () => {
+    const user = makeUser();
+    const { token, entity } = await authService.createRefreshToken(user.id);
+    entity.isRevoked = true;
+    (entity as RefreshToken & { user: User }).user = user;
+
+    await expect(authService.refreshTokens(token)).rejects.toThrow();
+
+    expect(auditRecordSpy).toHaveBeenCalledWith(
+      AuthAuditEvent.TOKEN_REUSE_DETECTED,
+      expect.objectContaining({ userId: user.id }),
+    );
+  });
+
+  it('fires TOKEN_REFRESH_FAILED when token is expired', async () => {
+    const user = makeUser();
+    const { token, entity } = await authService.createRefreshToken(user.id);
+    entity.expiresAt = new Date(Date.now() - 1000);
+    (entity as RefreshToken & { user: User }).user = user;
+
+    await expect(authService.refreshTokens(token)).rejects.toThrow();
+
+    expect(auditRecordSpy).toHaveBeenCalledWith(
+      AuthAuditEvent.TOKEN_REFRESH_FAILED,
+      expect.objectContaining({ meta: expect.objectContaining({ reason: 'expired' }) }),
+    );
+  });
+
+  it('fires WALLET_LOGIN_FAILED when address/chain not found', async () => {
+    const userRepo = authService['userRepo'] as { findOne: jest.Mock };
+    userRepo.findOne.mockResolvedValue(null);
+
+    await expect(
+      authService.walletLogin('0xdead', 'BASE', '1.2.3.4', 'jest'),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(auditRecordSpy).toHaveBeenCalledWith(
+      AuthAuditEvent.WALLET_LOGIN_FAILED,
+      expect.objectContaining({ ipAddress: '1.2.3.4' }),
+    );
+  });
+
+  it('fires WALLET_LOGIN_SUCCESS on valid wallet login', async () => {
+    const user = makeUser();
+    const userRepo = authService['userRepo'] as { findOne: jest.Mock };
+    userRepo.findOne.mockResolvedValue(user);
+
+    await authService.walletLogin('0xabc123', 'BASE', '1.2.3.4', 'jest');
+
+    expect(auditRecordSpy).toHaveBeenCalledWith(
+      AuthAuditEvent.WALLET_LOGIN_SUCCESS,
+      expect.objectContaining({ userId: user.id }),
+    );
+  });
+
+  it('fires LOGIN_SUSPENDED when a suspended user attempts login', async () => {
+    const usersService = authService['usersService'] as {
+      findByEmail: jest.Mock;
+    };
+    usersService.findByEmail.mockResolvedValue(
+      makeUser({ is_suspended: true }),
+    );
+
+    const result = await authService.validateUser(
+      'player@example.com',
+      'password',
+      '1.2.3.4',
+      'jest',
+    );
+
+    expect(result).toBeNull();
+    expect(auditRecordSpy).toHaveBeenCalledWith(
+      AuthAuditEvent.LOGIN_SUSPENDED,
+      expect.objectContaining({ userId: 1 }),
+    );
+  });
+
+  it('fires LOGIN_FAILED on wrong password', async () => {
+    const usersService = authService['usersService'] as {
+      findByEmail: jest.Mock;
+    };
+    // Return a user but bcrypt.compare will return false (wrong password)
+    usersService.findByEmail.mockResolvedValue(makeUser());
+
+    const result = await authService.validateUser(
+      'player@example.com',
+      'wrong-password',
+      '1.2.3.4',
+      'jest',
+    );
+
+    expect(result).toBeNull();
+    expect(auditRecordSpy).toHaveBeenCalledWith(
+      AuthAuditEvent.LOGIN_FAILED,
+      expect.objectContaining({ email: expect.stringContaining('***') }),
+    );
+  });
+
+  it('audit entries never contain raw email addresses', async () => {
+    const usersService = authService['usersService'] as {
+      findByEmail: jest.Mock;
+    };
+    usersService.findByEmail.mockResolvedValue(null);
+
+    await authService.validateUser('player@example.com', 'pw', '1.2.3.4');
+
+    const calls = auditRecordSpy.mock.calls as [string, Record<string, unknown>][];
+    calls.forEach(([, ctx]) => {
+      expect(JSON.stringify(ctx)).not.toContain('player@example.com');
+    });
+  });
+});

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -38,12 +38,16 @@ export class AuthController {
   @Post('login')
   @HttpCode(HttpStatus.OK)
   async login(@Request() req: RequestWithUser) {
-    return this.authService.login({
-      id: req.user.id,
-      email: req.user.email,
-      role: req.user.role,
-      is_admin: req.user.is_admin,
-    });
+    return this.authService.login(
+      {
+        id: req.user.id,
+        email: req.user.email,
+        role: req.user.role,
+        is_admin: req.user.is_admin,
+      },
+      req.ip,
+      req.headers?.['user-agent'],
+    );
   }
 
   @Post('refresh')
@@ -64,15 +68,24 @@ export class AuthController {
   @Throttle({ default: { limit: 20, ttl: 60000 } })
   @Post('wallet-login')
   @HttpCode(HttpStatus.OK)
-  async walletLogin(@Body() body: WalletLoginDto) {
-    return this.authService.walletLogin(body.address, body.chain);
+  async walletLogin(@Body() body: WalletLoginDto, @Req() req: RequestWithUser) {
+    return this.authService.walletLogin(
+      body.address,
+      body.chain,
+      req.ip,
+      req.headers?.['user-agent'],
+    );
   }
 
   @UseGuards(JwtAuthGuard)
   @Post('logout')
   @HttpCode(HttpStatus.OK)
   async logout(@Request() req: RequestWithUser) {
-    return this.authService.logout(req.user.sub);
+    return this.authService.logout(
+      req.user.sub,
+      req.ip,
+      req.headers?.['user-agent'],
+    );
   }
 
   @Throttle({ default: { limit: 10, ttl: 60000 } })

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -12,6 +12,7 @@ import { UsersModule } from '../users/users.module';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { User } from '../users/entities/user.entity';
 import { AdminLogsModule } from '../admin-logs/admin-logs.module';
+import { AuthAuditService } from './audit/auth-audit.service';
 
 @Module({
   imports: [
@@ -35,7 +36,7 @@ import { AdminLogsModule } from '../admin-logs/admin-logs.module';
     }),
   ],
   controllers: [AuthController, AdminAuthController],
-  providers: [AuthService, JwtStrategy, LocalStrategy],
+  providers: [AuthService, JwtStrategy, LocalStrategy, AuthAuditService],
   exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/backend/src/modules/auth/auth.service.spec.ts
+++ b/backend/src/modules/auth/auth.service.spec.ts
@@ -6,6 +6,7 @@ import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { User } from '../users/entities/user.entity';
+import { AuthAuditService } from './audit/auth-audit.service';
 import * as bcrypt from 'bcrypt';
 
 jest.mock('bcrypt');
@@ -75,6 +76,10 @@ describe('AuthService', () => {
         {
           provide: getRepositoryToken(User),
           useValue: userRepository,
+        },
+        {
+          provide: AuthAuditService,
+          useValue: { record: jest.fn() },
         },
       ],
     }).compile();

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -17,6 +17,8 @@ import { UsersService } from '../users/users.service';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { User } from '../users/entities/user.entity';
 import { Role } from './enums/role.enum';
+import { AuthAuditService } from './audit/auth-audit.service';
+import { AuthAuditEvent } from './audit/auth-audit.events';
 
 @Injectable()
 export class AuthService {
@@ -30,11 +32,14 @@ export class AuthService {
     private readonly refreshTokenRepository: Repository<RefreshToken>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
+    private readonly authAudit: AuthAuditService,
   ) {}
 
   async validateUser(
     email: string,
     password: string,
+    ipAddress?: string,
+    userAgent?: string,
   ): Promise<{
     id: number;
     email: string;
@@ -44,8 +49,12 @@ export class AuthService {
     const user = await this.usersService.findByEmail(email);
 
     if (user && user.is_suspended) {
-      // Log suspended user login attempt
-      console.log(`Suspended user login attempt: ${email}`);
+      this.authAudit.record(AuthAuditEvent.LOGIN_SUSPENDED, {
+        userId: user.id,
+        email: AuthAuditService.redactEmail(email),
+        ipAddress,
+        userAgent,
+      });
       return null;
     }
 
@@ -59,12 +68,20 @@ export class AuthService {
         is_admin: boolean;
       };
     }
+
+    this.authAudit.record(AuthAuditEvent.LOGIN_FAILED, {
+      email: AuthAuditService.redactEmail(email),
+      ipAddress,
+      userAgent,
+    });
     return null;
   }
 
   async validateAdmin(
     email: string,
     password: string,
+    ipAddress?: string,
+    userAgent?: string,
   ): Promise<{
     id: number;
     email: string;
@@ -74,8 +91,13 @@ export class AuthService {
     const user = await this.usersService.findByEmail(email);
 
     if (user && user.is_suspended) {
-      // Log suspended admin login attempt
-      console.log(`Suspended admin login attempt: ${email}`);
+      this.authAudit.record(AuthAuditEvent.LOGIN_SUSPENDED, {
+        userId: user.id,
+        email: AuthAuditService.redactEmail(email),
+        ipAddress,
+        userAgent,
+        meta: { isAdmin: true },
+      });
       return null;
     }
 
@@ -93,6 +115,13 @@ export class AuthService {
         is_admin: boolean;
       };
     }
+
+    this.authAudit.record(AuthAuditEvent.LOGIN_FAILED, {
+      email: AuthAuditService.redactEmail(email),
+      ipAddress,
+      userAgent,
+      meta: { isAdmin: true },
+    });
     return null;
   }
 
@@ -101,7 +130,7 @@ export class AuthService {
     email: string;
     role: string;
     is_admin: boolean;
-  }) {
+  }, ipAddress?: string, userAgent?: string) {
     const payload = {
       sub: user.id,
       email: user.email,
@@ -109,7 +138,14 @@ export class AuthService {
       is_admin: user.is_admin,
     };
     const accessToken = this.jwtService.sign(payload);
-    const refreshToken = await this.createRefreshToken(Number(user.id));
+    const refreshToken = await this.createRefreshToken(Number(user.id), ipAddress, userAgent);
+
+    this.authAudit.record(AuthAuditEvent.LOGIN_SUCCESS, {
+      userId: user.id,
+      email: AuthAuditService.redactEmail(user.email),
+      ipAddress,
+      userAgent,
+    });
 
     return {
       accessToken,
@@ -117,7 +153,7 @@ export class AuthService {
     };
   }
 
-  async walletLogin(address: string, chain: string) {
+  async walletLogin(address: string, chain: string, ipAddress?: string, userAgent?: string) {
     if (!address || !chain) {
       throw new BadRequestException('Address and chain are required');
     }
@@ -125,6 +161,11 @@ export class AuthService {
     const user = await this.userRepo.findOne({ where: { address, chain } });
 
     if (!user) {
+      this.authAudit.record(AuthAuditEvent.WALLET_LOGIN_FAILED, {
+        ipAddress,
+        userAgent,
+        meta: { chain },
+      });
       throw new NotFoundException('Invalid address/chain combination');
     }
 
@@ -135,7 +176,14 @@ export class AuthService {
       is_admin: user.is_admin,
     };
     const accessToken = this.jwtService.sign(payload);
-    const refreshToken = await this.createRefreshToken(user.id);
+    const refreshToken = await this.createRefreshToken(user.id, ipAddress, userAgent);
+
+    this.authAudit.record(AuthAuditEvent.WALLET_LOGIN_SUCCESS, {
+      userId: user.id,
+      ipAddress,
+      userAgent,
+      meta: { chain },
+    });
 
     return {
       accessToken,
@@ -214,10 +262,22 @@ export class AuthService {
         { isRevoked: true },
       );
 
+      this.authAudit.record(AuthAuditEvent.TOKEN_REUSE_DETECTED, {
+        userId: refreshToken.userId,
+        ipAddress,
+        userAgent,
+      });
+
       throw new UnauthorizedException('Token reuse detected');
     }
 
     if (new Date() > refreshToken.expiresAt) {
+      this.authAudit.record(AuthAuditEvent.TOKEN_REFRESH_FAILED, {
+        userId: refreshToken.userId,
+        ipAddress,
+        userAgent,
+        meta: { reason: 'expired' },
+      });
       throw new UnauthorizedException('Refresh token expired');
     }
 
@@ -240,17 +300,28 @@ export class AuthService {
       userAgent,
     );
 
+    this.authAudit.record(AuthAuditEvent.TOKEN_REFRESHED, {
+      userId: user.id,
+      ipAddress,
+      userAgent,
+    });
+
     return {
       accessToken,
       refreshToken: newRefreshToken.token,
     };
   }
 
-  async logout(userId: number): Promise<void> {
+  async logout(userId: number, ipAddress?: string, userAgent?: string): Promise<void> {
     await this.refreshTokenRepository.update(
       { userId, isRevoked: false },
       { isRevoked: true },
     );
+    this.authAudit.record(AuthAuditEvent.LOGOUT, {
+      userId,
+      ipAddress,
+      userAgent,
+    });
   }
 
   async hashPassword(password: string): Promise<string> {


### PR DESCRIPTION


i added New files:
- audit/auth-audit.events.ts  — AuthAuditEvent const enum (10 event types)
- audit/auth-audit.service.ts — structured audit logger; redacts emails, routes security events to WARN, success events to LOG
- audit/auth-audit.spec.ts    — 24 unit tests (all green)

AuthService changes (backward-compatible):
- Injected AuthAuditService; all auth flows now emit audit events
- LOGIN_SUCCESS, LOGOUT, TOKEN_REFRESHED, WALLET_LOGIN_SUCCESS on happy paths
- LOGIN_FAILED, LOGIN_SUSPENDED, TOKEN_REUSE_DETECTED, TOKEN_REFRESH_FAILED, WALLET_LOGIN_FAILED on error/security paths
- Replaced console.log suspended-user calls with structured logger + audit
- login/logout/walletLogin accept optional ipAddress/userAgent for context

AuthController: passes req.ip + user-agent to login, walletLogin, logout.
auth.module.ts: registers AuthAuditService as provider.
auth.service.spec.ts: adds AuthAuditService mock so existing tests pass.

closes #552 
