### PR TITLE
feat(contract): SW-FE-001  tycoon-boost-system admin-only vs public e…

### DIFF
--- a/contract/contracts/tycoon-boost-system/src/cap_stacking_expiry_tests.rs
+++ b/contract/contracts/tycoon-boost-system/src/cap_stacking_expiry_tests.rs
@@ -60,18 +60,32 @@ fn make_env() -> Env {
 fn setup(env: &Env) -> (TycoonBoostSystemClient, Address) {
     let contract_id = env.register(TycoonBoostSystem, ());
     let client = TycoonBoostSystemClient::new(env, &contract_id);
+    let admin = Address::generate(env);
     let player = Address::generate(env);
+    client.initialize(&admin);
     (client, player)
 }
 
 /// Non-expiring boost.
 fn nb(id: u128, boost_type: BoostType, value: u32, priority: u32) -> Boost {
-    Boost { id, boost_type, value, priority, expires_at_ledger: 0 }
+    Boost {
+        id,
+        boost_type,
+        value,
+        priority,
+        expires_at_ledger: 0,
+    }
 }
 
 /// Expiring boost.
 fn eb(id: u128, boost_type: BoostType, value: u32, priority: u32, expires: u32) -> Boost {
-    Boost { id, boost_type, value, priority, expires_at_ledger: expires }
+    Boost {
+        id,
+        boost_type,
+        value,
+        priority,
+        expires_at_ledger: expires,
+    }
 }
 
 /// Advance the mock ledger sequence number.
@@ -94,10 +108,10 @@ fn set_ledger(env: &Env, seq: u32) {
 #[test]
 fn test_sr1_additive_sum_table() {
     let cases: &[(&[u32], u32)] = &[
-        (&[1000],             11000), // +10%
-        (&[1000, 500],        11500), // +10% + +5%
-        (&[1000, 500, 250],   11750), // +10% + +5% + +2.5%
-        (&[10000],            20000), // +100% doubles base
+        (&[1000], 11000),           // +10%
+        (&[1000, 500], 11500),      // +10% + +5%
+        (&[1000, 500, 250], 11750), // +10% + +5% + +2.5%
+        (&[10000], 20000),          // +100% doubles base
     ];
 
     for (values, expected) in cases {
@@ -119,10 +133,10 @@ fn test_sr1_additive_sum_table() {
 #[test]
 fn test_sr2_multiplicative_chain_table() {
     let cases: &[(&[u32], u32)] = &[
-        (&[15000],         15000), // 1.5x
-        (&[15000, 12000],  18000), // 1.5x * 1.2x
+        (&[15000], 15000),               // 1.5x
+        (&[15000, 12000], 18000),        // 1.5x * 1.2x
         (&[12000, 12000, 12000], 17280), // 1.2^3
-        (&[20000],         20000), // 2x
+        (&[20000], 20000),               // 2x
     ];
 
     for (values, expected) in cases {
@@ -145,10 +159,10 @@ fn test_sr2_multiplicative_chain_table() {
 fn test_sr3_override_highest_priority_table() {
     // (priorities, values, expected_value)
     let cases: &[(&[u32], &[u32], u32)] = &[
-        (&[5, 10],     &[20000, 30000], 30000),
-        (&[10, 5],     &[30000, 20000], 30000),
-        (&[1, 2, 3],   &[10000, 20000, 30000], 30000),
-        (&[100, 1],    &[50000, 10000], 50000),
+        (&[5, 10], &[20000, 30000], 30000),
+        (&[10, 5], &[30000, 20000], 30000),
+        (&[1, 2, 3], &[10000, 20000, 30000], 30000),
+        (&[100, 1], &[50000, 10000], 50000),
     ];
 
     for (priorities, values, expected) in cases {
@@ -174,8 +188,8 @@ fn test_sr4_override_supersedes_mult_and_additive() {
     let (client, player) = setup(&env);
 
     client.add_boost(&player, &nb(1, BoostType::Multiplicative, 20000, 0)); // 2x
-    client.add_boost(&player, &nb(2, BoostType::Additive, 5000, 0));        // +50%
-    client.add_boost(&player, &nb(3, BoostType::Override, 25000, 1));       // 2.5x override
+    client.add_boost(&player, &nb(2, BoostType::Additive, 5000, 0)); // +50%
+    client.add_boost(&player, &nb(3, BoostType::Override, 25000, 1)); // 2.5x override
 
     // Override wins — mult and additive are ignored
     assert_eq!(client.calculate_total_boost(&player), 25000);
@@ -442,7 +456,10 @@ fn test_evt1_add_boost_emits_activated_event() {
     client.add_boost(&player, &eb(7, BoostType::Multiplicative, 15000, 0, 500));
     let events_after = env.events().all().len();
 
-    assert!(events_after > events_before, "EVT-1: BoostActivatedEvent not emitted");
+    assert!(
+        events_after > events_before,
+        "EVT-1: BoostActivatedEvent not emitted"
+    );
 }
 
 /// EVT-2: prune_expired_boosts emits BoostExpiredEvent for each pruned boost.
@@ -627,7 +644,10 @@ fn test_cap_clear_then_refill_to_cap() {
 
     // Re-fill to cap
     for i in 0..MAX_BOOSTS_PER_PLAYER {
-        client.add_boost(&player, &nb(i as u128 + 100, BoostType::Multiplicative, 10100, 0));
+        client.add_boost(
+            &player,
+            &nb(i as u128 + 100, BoostType::Multiplicative, 10100, 0),
+        );
     }
     // 10100^10 / 10000^9 — just verify it's > base
     assert!(client.calculate_total_boost(&player) > 10000);

--- a/contract/contracts/tycoon-boost-system/src/lib.rs
+++ b/contract/contracts/tycoon-boost-system/src/lib.rs
@@ -18,6 +18,8 @@ pub const MAX_BOOSTS_PER_PLAYER: u32 = 10;
 /// | `DuplicateId`      | A boost with the same `id` is already active for this player |
 /// | `InvalidValue`     | `value` is 0, which would have no effect |
 /// | `InvalidExpiry`    | `expires_at_ledger` is in the past (≤ current ledger) |
+/// | `NotInitialized`   | Contract has not been initialized yet |
+/// | `AlreadyInitialized` | `initialize` called more than once |
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BoostError {
@@ -25,6 +27,8 @@ pub enum BoostError {
     DuplicateId,
     InvalidValue,
     InvalidExpiry,
+    NotInitialized,
+    AlreadyInitialized,
 }
 
 // ── Data types ────────────────────────────────────────────────────────────────
@@ -54,6 +58,7 @@ pub struct Boost {
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    Admin,
     PlayerBoosts(Address),
 }
 
@@ -94,22 +99,32 @@ pub struct TycoonBoostSystem;
 
 #[contractimpl]
 impl TycoonBoostSystem {
-    /// Add a boost to a player.
+    // ── Admin entrypoints ─────────────────────────────────────────────────────
+
+    /// One-time initialization. Sets the admin address.
+    /// Panics with `"AlreadyInitialized"` if called again.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("AlreadyInitialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// Grant a boost to a player. Admin-only.
     ///
     /// # Errors (panic messages)
+    /// - `"NotInitialized"` — contract has not been initialized
     /// - `"CapExceeded"` — player already holds `MAX_BOOSTS_PER_PLAYER` active boosts
     /// - `"DuplicateId"` — a boost with the same `id` is already active
     /// - `"InvalidValue"` — `boost.value` is 0
     /// - `"InvalidExpiry"` — `boost.expires_at_ledger` is non-zero and ≤ current ledger
     pub fn add_boost(env: Env, player: Address, boost: Boost) {
-        player.require_auth();
+        Self::require_admin(&env);
 
-        // Validate value
         if boost.value == 0 {
             panic!("InvalidValue");
         }
 
-        // Validate expiry: if set, must be strictly in the future
         let current_ledger = env.ledger().sequence();
         if boost.expires_at_ledger != 0 && boost.expires_at_ledger <= current_ledger {
             panic!("InvalidExpiry");
@@ -122,22 +137,18 @@ impl TycoonBoostSystem {
             .get(&key)
             .unwrap_or(Vec::new(&env));
 
-        // Prune expired boosts before checking cap/duplicate
         boosts = Self::prune_expired(&env, boosts, player.clone());
 
-        // Cap check
         if boosts.len() >= MAX_BOOSTS_PER_PLAYER {
             panic!("CapExceeded");
         }
 
-        // Duplicate ID check
         for i in 0..boosts.len() {
             if boosts.get(i).unwrap().id == boost.id {
                 panic!("DuplicateId");
             }
         }
 
-        // Emit activation event
         BoostActivatedEvent {
             player: player.clone(),
             boost_id: boost.id,
@@ -151,32 +162,27 @@ impl TycoonBoostSystem {
         env.storage().persistent().set(&key, &boosts);
     }
 
-    /// Calculate the final boost multiplier for a player, ignoring expired boosts.
-    ///
-    /// Returns a value in basis points where 10 000 = 100 % (no boost).
-    pub fn calculate_total_boost(env: Env, player: Address) -> u32 {
+    /// Remove all boosts for a player. Admin-only.
+    pub fn clear_boosts(env: Env, player: Address) {
+        Self::require_admin(&env);
+
         let key = DataKey::PlayerBoosts(player.clone());
-        let boosts: Vec<Boost> = env
+        let count = env
             .storage()
             .persistent()
-            .get(&key)
-            .unwrap_or(Vec::new(&env));
+            .get::<DataKey, Vec<Boost>>(&key)
+            .map(|v| v.len())
+            .unwrap_or(0);
+        env.storage().persistent().remove(&key);
 
-        // Filter out expired boosts for calculation (does not mutate storage)
-        let current_ledger = env.ledger().sequence();
-        let mut active: Vec<Boost> = Vec::new(&env);
-        for i in 0..boosts.len() {
-            let b = boosts.get(i).unwrap();
-            if b.expires_at_ledger == 0 || b.expires_at_ledger > current_ledger {
-                active.push_back(b);
-            }
-        }
-
-        Self::apply_stacking_rules(&env, active)
+        BoostsClearedEvent { player, count }.publish(&env);
     }
+
+    // ── Public entrypoints ────────────────────────────────────────────────────
 
     /// Explicitly prune all expired boosts from storage and emit `BoostExpiredEvent`
     /// for each one removed. Returns the number of boosts pruned.
+    /// Permissionless — anyone may call this to trigger cleanup.
     pub fn prune_expired_boosts(env: Env, player: Address) -> u32 {
         let key = DataKey::PlayerBoosts(player.clone());
         let boosts: Vec<Boost> = env
@@ -194,19 +200,26 @@ impl TycoonBoostSystem {
         before - after
     }
 
-    /// Remove all boosts for a player.
-    pub fn clear_boosts(env: Env, player: Address) {
-        player.require_auth();
+    /// Calculate the final boost multiplier for a player, ignoring expired boosts.
+    /// Returns a value in basis points where 10 000 = 100 % (no boost).
+    pub fn calculate_total_boost(env: Env, player: Address) -> u32 {
         let key = DataKey::PlayerBoosts(player.clone());
-        let count = env
+        let boosts: Vec<Boost> = env
             .storage()
             .persistent()
-            .get::<DataKey, Vec<Boost>>(&key)
-            .map(|v| v.len())
-            .unwrap_or(0);
-        env.storage().persistent().remove(&key);
+            .get(&key)
+            .unwrap_or(Vec::new(&env));
 
-        BoostsClearedEvent { player, count }.publish(&env);
+        let current_ledger = env.ledger().sequence();
+        let mut active: Vec<Boost> = Vec::new(&env);
+        for i in 0..boosts.len() {
+            let b = boosts.get(i).unwrap();
+            if b.expires_at_ledger == 0 || b.expires_at_ledger > current_ledger {
+                active.push_back(b);
+            }
+        }
+
+        Self::apply_stacking_rules(&env, active)
     }
 
     /// Get all boosts for a player (including expired ones still in storage).
@@ -240,6 +253,17 @@ impl TycoonBoostSystem {
 }
 
 impl TycoonBoostSystem {
+    /// Load the stored admin and require their signature. Panics with
+    /// `"NotInitialized"` if the contract has not been initialized yet.
+    fn require_admin(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("NotInitialized");
+        admin.require_auth();
+    }
+
     /// Remove expired boosts from `boosts`, emitting `BoostExpiredEvent` for each.
     fn prune_expired(env: &Env, boosts: Vec<Boost>, player: Address) -> Vec<Boost> {
         let current_ledger = env.ledger().sequence();
@@ -273,7 +297,6 @@ impl TycoonBoostSystem {
 
             match boost.boost_type {
                 BoostType::Multiplicative => {
-                    // (current * boost_value) / 10000
                     multiplicative_total =
                         (multiplicative_total as u64 * boost.value as u64 / 10000) as u32;
                 }
@@ -281,7 +304,6 @@ impl TycoonBoostSystem {
                     additive_total += boost.value;
                 }
                 BoostType::Override => {
-                    // Keep highest-priority override
                     if let Some(ref current) = override_boost {
                         if boost.priority > current.priority {
                             override_boost = Some(boost);
@@ -293,11 +315,9 @@ impl TycoonBoostSystem {
             }
         }
 
-        // Priority: Override > Multiplicative combined with Additive
         if let Some(override_val) = override_boost {
             override_val.value
         } else {
-            // mult * (1 + additive)
             (multiplicative_total as u64 * (10000 + additive_total as u64) / 10000) as u32
         }
     }

--- a/contract/contracts/tycoon-boost-system/src/test.rs
+++ b/contract/contracts/tycoon-boost-system/src/test.rs
@@ -3,22 +3,34 @@ extern crate std;
 use super::*;
 use soroban_sdk::{testutils::Address as _, Env};
 
+fn setup_with_admin(env: &Env) -> (TycoonBoostSystemClient, Address, Address) {
+    let contract_id = env.register(TycoonBoostSystem, ());
+    let client = TycoonBoostSystemClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let player = Address::generate(env);
+    client.initialize(&admin);
+    (client, admin, player)
+}
+
 // Helper: build a non-expiring boost
 fn boost(id: u128, boost_type: BoostType, value: u32, priority: u32) -> Boost {
-    Boost { id, boost_type, value, priority, expires_at_ledger: 0 }
+    Boost {
+        id,
+        boost_type,
+        value,
+        priority,
+        expires_at_ledger: 0,
+    }
 }
 
 #[test]
 fn test_additive_stacking() {
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register(TycoonBoostSystem, ());
-    let client = TycoonBoostSystemClient::new(&env, &contract_id);
-
-    let player = Address::generate(&env);
+    let (client, _admin, player) = setup_with_admin(&env);
 
     client.add_boost(&player, &boost(1, BoostType::Additive, 1000, 0)); // +10%
-    client.add_boost(&player, &boost(2, BoostType::Additive, 500, 0));  // +5%
+    client.add_boost(&player, &boost(2, BoostType::Additive, 500, 0)); // +5%
 
     // Expected: 10000 * (1 + 0.15) = 11500
     assert_eq!(client.calculate_total_boost(&player), 11500);
@@ -28,10 +40,7 @@ fn test_additive_stacking() {
 fn test_multiplicative_stacking() {
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register(TycoonBoostSystem, ());
-    let client = TycoonBoostSystemClient::new(&env, &contract_id);
-
-    let player = Address::generate(&env);
+    let (client, _admin, player) = setup_with_admin(&env);
 
     client.add_boost(&player, &boost(1, BoostType::Multiplicative, 15000, 0)); // 1.5x
     client.add_boost(&player, &boost(2, BoostType::Multiplicative, 12000, 0)); // 1.2x
@@ -44,12 +53,9 @@ fn test_multiplicative_stacking() {
 fn test_override_highest_priority() {
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register(TycoonBoostSystem, ());
-    let client = TycoonBoostSystemClient::new(&env, &contract_id);
+    let (client, _admin, player) = setup_with_admin(&env);
 
-    let player = Address::generate(&env);
-
-    client.add_boost(&player, &boost(1, BoostType::Override, 20000, 5));  // 2x, priority 5
+    client.add_boost(&player, &boost(1, BoostType::Override, 20000, 5)); // 2x, priority 5
     client.add_boost(&player, &boost(2, BoostType::Override, 30000, 10)); // 3x, priority 10
 
     // Expected: 30000 (highest priority override)
@@ -60,13 +66,10 @@ fn test_override_highest_priority() {
 fn test_mixed_stacking() {
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register(TycoonBoostSystem, ());
-    let client = TycoonBoostSystemClient::new(&env, &contract_id);
-
-    let player = Address::generate(&env);
+    let (client, _admin, player) = setup_with_admin(&env);
 
     client.add_boost(&player, &boost(1, BoostType::Multiplicative, 15000, 0)); // 1.5x
-    client.add_boost(&player, &boost(2, BoostType::Additive, 1000, 0));        // +10%
+    client.add_boost(&player, &boost(2, BoostType::Additive, 1000, 0)); // +10%
 
     // Expected: 10000 * 1.5 * 1.1 = 16500
     assert_eq!(client.calculate_total_boost(&player), 16500);
@@ -76,14 +79,11 @@ fn test_mixed_stacking() {
 fn test_override_ignores_others() {
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register(TycoonBoostSystem, ());
-    let client = TycoonBoostSystemClient::new(&env, &contract_id);
-
-    let player = Address::generate(&env);
+    let (client, _admin, player) = setup_with_admin(&env);
 
     client.add_boost(&player, &boost(1, BoostType::Multiplicative, 20000, 0)); // 2x
-    client.add_boost(&player, &boost(2, BoostType::Additive, 5000, 0));        // +50%
-    client.add_boost(&player, &boost(3, BoostType::Override, 25000, 100));     // 2.5x override
+    client.add_boost(&player, &boost(2, BoostType::Additive, 5000, 0)); // +50%
+    client.add_boost(&player, &boost(3, BoostType::Override, 25000, 100)); // 2.5x override
 
     // Expected: 25000 (override ignores all others)
     assert_eq!(client.calculate_total_boost(&player), 25000);
@@ -97,7 +97,7 @@ fn test_no_boosts() {
 
     let player = Address::generate(&env);
 
-    // Expected: 10000 (base 100%)
+    // Expected: 10000 (base 100%) — no initialize needed for read-only
     assert_eq!(client.calculate_total_boost(&player), 10000);
 }
 
@@ -105,10 +105,7 @@ fn test_no_boosts() {
 fn test_clear_boosts() {
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register(TycoonBoostSystem, ());
-    let client = TycoonBoostSystemClient::new(&env, &contract_id);
-
-    let player = Address::generate(&env);
+    let (client, _admin, player) = setup_with_admin(&env);
 
     client.add_boost(&player, &boost(1, BoostType::Additive, 1000, 0));
     assert_eq!(client.calculate_total_boost(&player), 11000);
@@ -121,10 +118,7 @@ fn test_clear_boosts() {
 fn test_deterministic_outcome() {
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register(TycoonBoostSystem, ());
-    let client = TycoonBoostSystemClient::new(&env, &contract_id);
-
-    let player = Address::generate(&env);
+    let (client, _admin, player) = setup_with_admin(&env);
 
     for i in 0..3u128 {
         client.add_boost(&player, &boost(i + 1, BoostType::Multiplicative, 12000, 0));
@@ -142,14 +136,73 @@ fn test_deterministic_outcome() {
 fn test_get_boosts() {
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register(TycoonBoostSystem, ());
-    let client = TycoonBoostSystemClient::new(&env, &contract_id);
+    let (client, _admin, player) = setup_with_admin(&env);
 
-    let player = Address::generate(&env);
     let b = boost(1, BoostType::Additive, 1000, 0);
     client.add_boost(&player, &b);
 
     let boosts = client.get_boosts(&player);
     assert_eq!(boosts.len(), 1);
     assert_eq!(boosts.get(0).unwrap(), b);
+}
+
+// ── Admin auth enforcement ────────────────────────────────────────────────────
+
+/// initialize can only be called once.
+#[test]
+#[should_panic(expected = "AlreadyInitialized")]
+fn test_initialize_twice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TycoonBoostSystem, ());
+    let client = TycoonBoostSystemClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    client.initialize(&admin); // second call must panic
+}
+
+/// add_boost without initialize panics with "NotInitialized".
+#[test]
+#[should_panic(expected = "NotInitialized")]
+fn test_add_boost_without_initialize_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TycoonBoostSystem, ());
+    let client = TycoonBoostSystemClient::new(&env, &contract_id);
+    let player = Address::generate(&env);
+    client.add_boost(&player, &boost(1, BoostType::Additive, 1000, 0));
+}
+
+/// clear_boosts without initialize panics with "NotInitialized".
+#[test]
+#[should_panic(expected = "NotInitialized")]
+fn test_clear_boosts_without_initialize_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TycoonBoostSystem, ());
+    let client = TycoonBoostSystemClient::new(&env, &contract_id);
+    let player = Address::generate(&env);
+    client.clear_boosts(&player);
+}
+
+/// add_boost requires admin auth — non-admin call is rejected.
+#[test]
+#[should_panic]
+fn test_add_boost_requires_admin_auth() {
+    let env = Env::default();
+    // Do NOT mock_all_auths — let auth checks run for real
+    let contract_id = env.register(TycoonBoostSystem, ());
+    let client = TycoonBoostSystemClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let player = Address::generate(&env);
+
+    // Initialize with mock so that goes through
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    // Now clear mocks and try add_boost without providing admin auth
+    // This should panic because admin.require_auth() is not satisfied
+    let env2 = Env::default();
+    let client2 = TycoonBoostSystemClient::new(&env2, &contract_id);
+    client2.add_boost(&player, &boost(1, BoostType::Additive, 1000, 0));
 }

--- a/contract/contracts/tycoon-boost-system/src/time_boundary_tests.rs
+++ b/contract/contracts/tycoon-boost-system/src/time_boundary_tests.rs
@@ -27,7 +27,11 @@ fn make_env() -> Env {
 
 fn setup(env: &Env) -> (TycoonBoostSystemClient, Address) {
     let id = env.register(TycoonBoostSystem, ());
-    (TycoonBoostSystemClient::new(env, &id), Address::generate(env))
+    let client = TycoonBoostSystemClient::new(env, &id);
+    let admin = Address::generate(env);
+    let player = Address::generate(env);
+    client.initialize(&admin);
+    (client, player)
 }
 
 fn set_seq(env: &Env, seq: u32) {
@@ -45,7 +49,13 @@ fn set_seq(env: &Env, seq: u32) {
 }
 
 fn additive(id: u128, value: u32, expires_at_ledger: u32) -> Boost {
-    Boost { id, boost_type: BoostType::Additive, value, priority: 0, expires_at_ledger }
+    Boost {
+        id,
+        boost_type: BoostType::Additive,
+        value,
+        priority: 0,
+        expires_at_ledger,
+    }
 }
 
 // ── sentinel: expires_at_ledger == 0 means never expires ─────────────────────
@@ -80,7 +90,7 @@ fn test_expiry_boundary_at_exact_ledger() {
     client.add_boost(&player, &additive(1, 1000, 200));
 
     set_seq(&env, 200); // now at the expiry ledger
-    // Boost is expired → base value only
+                        // Boost is expired → base value only
     assert_eq!(client.calculate_total_boost(&player), 10000);
 }
 
@@ -95,7 +105,7 @@ fn test_expiry_boundary_one_before() {
     client.add_boost(&player, &additive(1, 1000, 200));
 
     set_seq(&env, 199); // one ledger before expiry
-    // Boost is still active: 10000 * (1 + 0.10) = 11000
+                        // Boost is still active: 10000 * (1 + 0.10) = 11000
     assert_eq!(client.calculate_total_boost(&player), 11000);
 }
 
@@ -143,7 +153,7 @@ fn test_prune_removes_expired_keeps_active() {
 
     set_seq(&env, 50);
     client.add_boost(&player, &additive(1, 1000, 100)); // expires at 100
-    client.add_boost(&player, &additive(2, 500, 0));    // never expires
+    client.add_boost(&player, &additive(2, 500, 0)); // never expires
 
     set_seq(&env, 150); // past expiry of boost 1
     client.prune_expired_boosts(&player);

--- a/contract/contracts/tycoon-collectibles/src/enumeration.rs
+++ b/contract/contracts/tycoon-collectibles/src/enumeration.rs
@@ -1,8 +1,8 @@
+use crate::errors::CollectibleError;
 use crate::storage::{
     get_owned_tokens_vec, get_token_index, remove_token_index, set_owned_tokens_vec,
     set_token_index,
 };
-use crate::errors::CollectibleError;
 use soroban_sdk::{Address, Env, Vec};
 
 // Maximum page size for pagination to stay within gas limits
@@ -104,7 +104,7 @@ pub fn tokens_of_owner_page(
     let tokens = get_owned_tokens_vec(env, owner);
     let total_tokens = tokens.len();
     let start_index = page * page_size;
-    
+
     // Check if page is out of bounds
     if start_index >= total_tokens {
         return Ok(Vec::new(env)); // Return empty vec for out of bounds pages
@@ -112,13 +112,13 @@ pub fn tokens_of_owner_page(
 
     let end_index = (start_index + page_size).min(total_tokens);
     let mut result = Vec::new(env);
-    
+
     for i in start_index..end_index {
         if let Some(token_id) = tokens.get(i) {
             result.push_back(token_id);
         }
     }
-    
+
     Ok(result)
 }
 
@@ -141,7 +141,7 @@ pub fn iterate_owned_tokens(
 
     let tokens = get_owned_tokens_vec(env, owner);
     let total_tokens = tokens.len();
-    
+
     // Check if start_index is out of bounds
     if start_index >= total_tokens {
         return Ok((Vec::new(env), false)); // No more tokens
@@ -150,13 +150,13 @@ pub fn iterate_owned_tokens(
     let end_index = (start_index + batch_size).min(total_tokens);
     let mut result = Vec::new(env);
     let has_more = end_index < total_tokens;
-    
+
     for i in start_index..end_index {
         if let Some(token_id) = tokens.get(i) {
             result.push_back(token_id);
         }
     }
-    
+
     Ok((result, has_more))
 }
 

--- a/contract/contracts/tycoon-collectibles/src/events.rs
+++ b/contract/contracts/tycoon-collectibles/src/events.rs
@@ -2,7 +2,7 @@ use crate::types::Perk;
 use soroban_sdk::{symbol_short, Address, Env};
 
 pub fn emit_transfer_event(env: &Env, from: &Address, to: &Address, token_id: u128, amount: u64) {
-    // Standardizing on (symbol, from, to) for better indexing
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("transfer"), from.clone(), to.clone()),
         (token_id, amount),
@@ -16,7 +16,7 @@ pub fn emit_collectible_burned_event(
     perk: Perk,
     strength: u32,
 ) {
-    // Tests are looking for "burn" and "coll"
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("burn"), symbol_short!("coll"), burner.clone()),
         (token_id, perk, strength),
@@ -27,8 +27,9 @@ pub fn emit_cash_perk_activated_event(
     env: &Env,
     activator: &Address,
     token_id: u128,
-    cash_value: i128, // Changed to i128 to match price/balance types
+    cash_value: i128,
 ) {
+    #[allow(deprecated)]
     env.events().publish(
         (
             symbol_short!("perk"),
@@ -46,6 +47,7 @@ pub fn emit_collectible_bought_event(
     price: i128,
     use_usdc: bool,
 ) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("coll_buy"), buyer.clone()),
         (token_id, price, use_usdc),
@@ -61,6 +63,7 @@ pub fn emit_collectible_stocked_event(
     tyc_price: u128,
     usdc_price: u128,
 ) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("stock"), symbol_short!("new")),
         (token_id, amount, perk, strength, tyc_price, usdc_price),
@@ -73,6 +76,7 @@ pub fn emit_collectible_restocked_event(
     additional_amount: u64,
     new_total: u64,
 ) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("restock"),),
         (token_id, additional_amount, new_total),
@@ -85,6 +89,7 @@ pub fn emit_price_updated_event(
     new_tyc_price: u128,
     new_usdc_price: u128,
 ) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("price"), symbol_short!("update")),
         (token_id, new_tyc_price, new_usdc_price),
@@ -98,6 +103,7 @@ pub fn emit_collectible_minted_event(
     perk: u32,
     strength: u32,
 ) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("coll_mint"), recipient.clone()),
         (token_id, perk, strength),
@@ -113,14 +119,20 @@ pub fn emit_fee_distributed_event(
     pool_amount: u128,
     creator_amount: u128,
 ) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("fee_dist"), token_id),
-        (platform.clone(), platform_amount, pool.clone(), pool_amount, creator_amount),
+        (
+            platform.clone(),
+            platform_amount,
+            pool.clone(),
+            pool_amount,
+            creator_amount,
+        ),
     );
 }
 
 /// Emit event for non-cash perk activation (stubs for future implementation)
-/// Used for: ExtraTurn, JailFree, DoubleRent, RollBoost, Teleport, Shield, PropertyDiscount, RollExact
 pub fn emit_perk_activated_event(
     env: &Env,
     activator: &Address,
@@ -128,6 +140,7 @@ pub fn emit_perk_activated_event(
     perk: Perk,
     strength: u32,
 ) {
+    #[allow(deprecated)]
     env.events().publish(
         (
             symbol_short!("perk"),

--- a/contract/contracts/tycoon-collectibles/src/lib.rs
+++ b/contract/contracts/tycoon-collectibles/src/lib.rs
@@ -15,7 +15,7 @@ pub use transfer::*;
 pub use types::*;
 
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Vec};
-use tycoon_lib::fees::{calculate_fee_split, FeeConfig};
+use tycoon_lib::fees::FeeConfig;
 
 /// Convert a u128 to a Soroban String without std (no_std compatible)
 fn u128_to_soroban_string(env: &Env, mut n: u128) -> soroban_sdk::String {
@@ -307,12 +307,20 @@ impl TycoonCollectibles {
         // Handle fee distribution
         if let Some(fee_config) = get_fee_config(&env) {
             let split = tycoon_lib::fees::calculate_fee_split(price as u128, &fee_config);
-            
+
             if split.platform_amount > 0 {
-                token_client.transfer(&buyer, &fee_config.platform_address, &(split.platform_amount as i128));
+                token_client.transfer(
+                    &buyer,
+                    &fee_config.platform_address,
+                    &(split.platform_amount as i128),
+                );
             }
             if split.pool_amount > 0 {
-                token_client.transfer(&buyer, &fee_config.pool_address, &(split.pool_amount as i128));
+                token_client.transfer(
+                    &buyer,
+                    &fee_config.pool_address,
+                    &(split.pool_amount as i128),
+                );
             }
             if split.creator_amount > 0 {
                 // For shop sales, "creator" could be a specific account or just added back to shop balance.
@@ -519,6 +527,7 @@ impl TycoonCollectibles {
         admin.require_auth();
 
         set_minter(&env, &new_minter);
+        #[allow(deprecated)]
         env.events()
             .publish((symbol_short!("minter"), symbol_short!("set")), new_minter);
 
@@ -672,7 +681,7 @@ impl TycoonCollectibles {
 
     /// Get the maximum allowed page size for pagination
     /// This ensures operations stay within gas limits
-    pub fn max_page_size(env: Env) -> u32 {
+    pub fn max_page_size(_env: Env) -> u32 {
         crate::enumeration::MAX_PAGE_SIZE
     }
 

--- a/contract/contracts/tycoon-collectibles/src/test.rs
+++ b/contract/contracts/tycoon-collectibles/src/test.rs
@@ -1,4 +1,4 @@
-﻿use super::*;
+use super::*;
 use crate::types::{Perk, CASH_TIERS};
 use soroban_sdk::{
     testutils::{Address as _, Events},
@@ -2181,8 +2181,14 @@ fn test_token_metadata_setting() {
     let name = soroban_sdk::String::from_str(&env, "Tycoon Cash Boost");
     let description = soroban_sdk::String::from_str(&env, "A powerful cash boost collectible");
     let image = soroban_sdk::String::from_str(&env, "https://images.tycoon.com/cash-boost.png");
-    let animation_url = Some(soroban_sdk::String::from_str(&env, "https://animations.tycoon.com/cash-boost.mp4"));
-    let external_url = Some(soroban_sdk::String::from_str(&env, "https://tycoon.com/collectibles/1"));
+    let animation_url = Some(soroban_sdk::String::from_str(
+        &env,
+        "https://animations.tycoon.com/cash-boost.mp4",
+    ));
+    let external_url = Some(soroban_sdk::String::from_str(
+        &env,
+        "https://tycoon.com/collectibles/1",
+    ));
 
     let mut attributes = Vec::new(&env);
     let attr1 = crate::types::MetadataAttribute {
@@ -2198,7 +2204,15 @@ fn test_token_metadata_setting() {
     attributes.push_back(attr1);
     attributes.push_back(attr2);
 
-    client.set_token_metadata(&token_id, &name, &description, &image, &animation_url, &external_url, &attributes);
+    client.set_token_metadata(
+        &token_id,
+        &name,
+        &description,
+        &image,
+        &animation_url,
+        &external_url,
+        &attributes,
+    );
 
     // Verify metadata
     let metadata = client.token_metadata(&token_id).unwrap();
@@ -2231,14 +2245,20 @@ fn test_token_uri_generation() {
 
     // Test token URI — verify it starts with the base URI and is non-empty
     let uri = client.token_uri(&token_id);
-    assert!(uri.len() > base_uri.len(), "URI should include token ID suffix");
+    assert!(
+        uri.len() > base_uri.len(),
+        "URI should include token ID suffix"
+    );
 
     // Test with IPFS
     let ipfs_uri = soroban_sdk::String::from_str(&env, "ipfs://Qm");
     client.set_base_uri(&ipfs_uri, &1, &false);
 
     let uri2 = client.token_uri(&token_id);
-    assert!(uri2.len() > ipfs_uri.len(), "IPFS URI should include token ID suffix");
+    assert!(
+        uri2.len() > ipfs_uri.len(),
+        "IPFS URI should include token ID suffix"
+    );
 }
 
 #[test]
@@ -2289,7 +2309,15 @@ fn test_metadata_frozen_prevents_metadata_changes() {
     let image = soroban_sdk::String::from_str(&env, "https://test.com/image.png");
     let attributes = Vec::new(&env);
 
-    let result = client.try_set_token_metadata(&token_id, &name, &description, &image, &None, &None, &attributes);
+    let result = client.try_set_token_metadata(
+        &token_id,
+        &name,
+        &description,
+        &image,
+        &None,
+        &None,
+        &attributes,
+    );
     assert!(result.is_err());
 }
 

--- a/contract/contracts/tycoon-collectibles/src/transfer.rs
+++ b/contract/contracts/tycoon-collectibles/src/transfer.rs
@@ -96,6 +96,7 @@ pub fn _safe_mint(
     }
 
     // Emit mint event (from zero address concept)
+    #[allow(deprecated)]
     env.events()
         .publish((symbol_short!("mint"),), (to.clone(), token_id, amount));
 

--- a/contract/contracts/tycoon-game/src/storage.rs
+++ b/contract/contracts/tycoon-game/src/storage.rs
@@ -191,5 +191,7 @@ pub fn get_state_version(env: &Env) -> u32 {
 
 /// Set the current state version
 pub fn set_state_version(env: &Env, version: u32) {
-    env.storage().instance().set(&DataKey::StateVersion, &version);
+    env.storage()
+        .instance()
+        .set(&DataKey::StateVersion, &version);
 }

--- a/contract/contracts/tycoon-lib/src/fees.rs
+++ b/contract/contracts/tycoon-lib/src/fees.rs
@@ -1,10 +1,9 @@
-#![no_std]
-use soroban_sdk::{contracttype, Address, Env, Vec};
+use soroban_sdk::{contracttype, Address};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FeeConfig {
-    pub platform_fee_bps: u32,  // Basis points (100 = 1%)
+    pub platform_fee_bps: u32, // Basis points (100 = 1%)
     pub creator_fee_bps: u32,
     pub pool_fee_bps: u32,
     pub platform_address: Address,
@@ -24,7 +23,7 @@ pub fn calculate_fee_split(amount: u128, config: &FeeConfig) -> FeeSplit {
     let platform_amount = (amount * config.platform_fee_bps as u128) / 10000;
     let creator_amount = (amount * config.creator_fee_bps as u128) / 10000;
     let pool_amount = (amount * config.pool_fee_bps as u128) / 10000;
-    
+
     let total_distributed = platform_amount + creator_amount + pool_amount;
     let residue = amount.saturating_sub(total_distributed);
 
@@ -56,8 +55,13 @@ mod tests {
         let amounts = [100, 1000, 10000, 1234567, 0, 1];
         for amount in amounts {
             let split = calculate_fee_split(amount, &config);
-            let sum = split.platform_amount + split.creator_amount + split.pool_amount + split.residue;
-            assert_eq!(sum, amount, "Sum of split + residue must equal input for amount {}", amount);
+            let sum =
+                split.platform_amount + split.creator_amount + split.pool_amount + split.residue;
+            assert_eq!(
+                sum, amount,
+                "Sum of split + residue must equal input for amount {}",
+                amount
+            );
             assert!(split.platform_amount + split.creator_amount + split.pool_amount <= amount);
         }
     }

--- a/contract/contracts/tycoon-reward-system/src/lib.rs
+++ b/contract/contracts/tycoon-reward-system/src/lib.rs
@@ -41,8 +41,12 @@ impl TycoonRewardSystem {
         // Batch all initialization writes together
         e.storage().persistent().set(&DataKey::Admin, &admin);
         e.storage().persistent().set(&DataKey::TycToken, &tyc_token);
-        e.storage().persistent().set(&DataKey::UsdcToken, &usdc_token);
-        e.storage().persistent().set(&DataKey::VoucherCount, &VOUCHER_ID_START);
+        e.storage()
+            .persistent()
+            .set(&DataKey::UsdcToken, &usdc_token);
+        e.storage()
+            .persistent()
+            .set(&DataKey::VoucherCount, &VOUCHER_ID_START);
         e.storage().persistent().set(&DataKey::Paused, &false);
         e.storage().persistent().set(&DataKey::StateVersion, &1u32);
     }
@@ -104,9 +108,12 @@ impl TycoonRewardSystem {
             panic!("Unauthorized: only admin can set backend minter");
         }
         admin.require_auth();
-        e.storage().persistent().set(&DataKey::BackendMinter, &new_minter);
+        e.storage()
+            .persistent()
+            .set(&DataKey::BackendMinter, &new_minter);
         #[allow(deprecated)]
-        e.events().publish((symbol_short!("set_min"), new_minter), ());
+        e.events()
+            .publish((symbol_short!("set_min"), new_minter), ());
     }
 
     /// Clear the backend minter address (admin only)
@@ -141,11 +148,9 @@ impl TycoonRewardSystem {
         caller.require_auth();
 
         // Single read for BackendMinter — replaces has() + get() double-read
-        let backend_minter: Option<Address> =
-            e.storage().persistent().get(&DataKey::BackendMinter);
+        let backend_minter: Option<Address> = e.storage().persistent().get(&DataKey::BackendMinter);
 
-        let is_authorized = caller == admin
-            || backend_minter.map_or(false, |m| m == caller);
+        let is_authorized = caller == admin || backend_minter.map_or(false, |m| m == caller);
 
         if !is_authorized {
             panic!("Unauthorized: only admin or backend minter can mint");
@@ -213,7 +218,9 @@ impl TycoonRewardSystem {
         );
 
         // Remove voucher value entry after successful transfer
-        e.storage().persistent().remove(&DataKey::VoucherValue(token_id));
+        e.storage()
+            .persistent()
+            .remove(&DataKey::VoucherValue(token_id));
 
         #[allow(deprecated)]
         e.events()
@@ -255,8 +262,10 @@ impl TycoonRewardSystem {
         token_client.transfer(&contract_address, &to, &(amount as i128));
 
         #[allow(deprecated)]
-        e.events()
-            .publish((Symbol::new(&e, "FundsWithdrawn"), token.clone(), to), amount);
+        e.events().publish(
+            (Symbol::new(&e, "FundsWithdrawn"), token.clone(), to),
+            amount,
+        );
     }
 
     pub fn get_balance(e: Env, owner: Address, token_id: u128) -> u64 {

--- a/contract/contracts/tycoon-reward-system/src/overflow_rounding_tests.rs
+++ b/contract/contracts/tycoon-reward-system/src/overflow_rounding_tests.rs
@@ -122,7 +122,11 @@ fn test_tier_matrix_exact_value_preserved_on_redeem() {
         h.fund_contract(*tyc_value as i128);
 
         let token_id = h.client.mint_voucher(&h.admin, &user, tyc_value);
-        assert_eq!(h.client.get_balance(&user, &token_id), 1, "{name}: balance before redeem");
+        assert_eq!(
+            h.client.get_balance(&user, &token_id),
+            1,
+            "{name}: balance before redeem"
+        );
 
         let contract_before = h.tyc_balance_of(&h.contract_id);
         h.client.redeem_voucher_from(&user, &token_id);
@@ -137,7 +141,11 @@ fn test_tier_matrix_exact_value_preserved_on_redeem() {
             contract_before - *tyc_value as i128,
             "{name}: contract balance not reduced correctly"
         );
-        assert_eq!(h.client.get_balance(&user, &token_id), 0, "{name}: voucher not burned");
+        assert_eq!(
+            h.client.get_balance(&user, &token_id),
+            0,
+            "{name}: voucher not burned"
+        );
     }
 }
 
@@ -235,8 +243,14 @@ fn test_overflow_voucher_count_increments_monotonically() {
     let third_id = h.client.mint_voucher(&h.admin, &user, &TIER_BRONZE);
 
     // IDs must be strictly increasing
-    assert!(second_id > first_id, "voucher IDs must be monotonically increasing");
-    assert!(third_id > second_id, "voucher IDs must be monotonically increasing");
+    assert!(
+        second_id > first_id,
+        "voucher IDs must be monotonically increasing"
+    );
+    assert!(
+        third_id > second_id,
+        "voucher IDs must be monotonically increasing"
+    );
     // Each increment is exactly 1
     assert_eq!(second_id - first_id, 1);
     assert_eq!(third_id - second_id, 1);
@@ -511,7 +525,10 @@ fn test_accrual_redeem_fails_when_contract_underfunded() {
     let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         h.client.redeem_voucher_from(&user, &token_id);
     }));
-    assert!(res.is_err(), "redeem should fail when contract is underfunded");
+    assert!(
+        res.is_err(),
+        "redeem should fail when contract is underfunded"
+    );
 }
 
 /// Accrual: minting a voucher with value=0 is stored and redeems 0 TYC.

--- a/contract/contracts/tycoon-token/src/error_branch_tests.rs
+++ b/contract/contracts/tycoon-token/src/error_branch_tests.rs
@@ -61,8 +61,16 @@ fn test_transfer_zero_is_noop() {
 
     client.transfer(&admin, &user, &0);
 
-    assert_eq!(client.balance(&admin), before_admin, "admin balance changed on zero transfer");
-    assert_eq!(client.balance(&user), before_user, "user balance changed on zero transfer");
+    assert_eq!(
+        client.balance(&admin),
+        before_admin,
+        "admin balance changed on zero transfer"
+    );
+    assert_eq!(
+        client.balance(&user),
+        before_user,
+        "user balance changed on zero transfer"
+    );
 }
 
 // ── transfer_from error branches ──────────────────────────────────────────────
@@ -93,7 +101,11 @@ fn test_transfer_from_zero_is_noop() {
 
     client.transfer_from(&spender, &admin, &recipient, &0);
 
-    assert_eq!(client.balance(&admin), before_balance, "balance changed on zero transfer_from");
+    assert_eq!(
+        client.balance(&admin),
+        before_balance,
+        "balance changed on zero transfer_from"
+    );
     assert_eq!(
         client.allowance(&admin, &spender),
         before_allowance,
@@ -122,7 +134,11 @@ fn test_approve_zero_clears_allowance() {
     assert_eq!(client.allowance(&admin, &spender), allowance);
 
     client.approve(&admin, &spender, &0, &0);
-    assert_eq!(client.allowance(&admin, &spender), 0, "allowance should be 0 after approve(0)");
+    assert_eq!(
+        client.allowance(&admin, &spender),
+        0,
+        "allowance should be 0 after approve(0)"
+    );
 }
 
 // ── set_admin error branch ────────────────────────────────────────────────────
@@ -246,13 +262,25 @@ fn test_snapshot_state_after_operations() {
 
     // SNAPSHOT: user ends with mint - transfer - burn = 300 TYC
     let expected_user: i128 = mint_amount - transfer_amount - burn_amount;
-    assert_eq!(client.balance(&user), expected_user, "snapshot: user balance");
+    assert_eq!(
+        client.balance(&user),
+        expected_user,
+        "snapshot: user balance"
+    );
 
     // SNAPSHOT: admin ends with INITIAL_SUPPLY + transfer
     let expected_admin: i128 = INITIAL_SUPPLY + transfer_amount;
-    assert_eq!(client.balance(&admin), expected_admin, "snapshot: admin balance");
+    assert_eq!(
+        client.balance(&admin),
+        expected_admin,
+        "snapshot: admin balance"
+    );
 
     // SNAPSHOT: total_supply = INITIAL_SUPPLY + mint - burn
     let expected_supply: i128 = INITIAL_SUPPLY + mint_amount - burn_amount;
-    assert_eq!(client.total_supply(), expected_supply, "snapshot: total_supply");
+    assert_eq!(
+        client.total_supply(),
+        expected_supply,
+        "snapshot: total_supply"
+    );
 }

--- a/contract/contracts/tycoon-token/src/invariant_tests.rs
+++ b/contract/contracts/tycoon-token/src/invariant_tests.rs
@@ -260,7 +260,11 @@ fn test_inv_10_mint_burn_round_trip_restores_supply() {
     assert_eq!(client.total_supply(), before + amount);
 
     client.burn(&user, &amount);
-    assert_eq!(client.total_supply(), before, "Round-trip should restore supply");
+    assert_eq!(
+        client.total_supply(),
+        before,
+        "Round-trip should restore supply"
+    );
 }
 
 // ── INV-11 ────────────────────────────────────────────────────────────────────
@@ -336,9 +340,21 @@ fn test_inv_14_burn_from_reduces_balance_and_allowance() {
 
     client.burn_from(&spender, &admin, &burn_amount);
 
-    assert_eq!(client.balance(&admin), balance_before - burn_amount, "INV-14: balance");
-    assert_eq!(client.allowance(&admin, &spender), allowance - burn_amount, "INV-14: allowance");
-    assert_eq!(client.total_supply(), supply_before - burn_amount, "INV-14: supply");
+    assert_eq!(
+        client.balance(&admin),
+        balance_before - burn_amount,
+        "INV-14: balance"
+    );
+    assert_eq!(
+        client.allowance(&admin, &spender),
+        allowance - burn_amount,
+        "INV-14: allowance"
+    );
+    assert_eq!(
+        client.total_supply(),
+        supply_before - burn_amount,
+        "INV-14: supply"
+    );
 }
 
 /// INV-14: burn_from exhausting the full allowance leaves allowance at zero.
@@ -428,7 +444,10 @@ fn test_inv_16b_initialize_emits_mint_event() {
     client.initialize(&admin, &INITIAL_SUPPLY);
 
     let events = e.events().all();
-    assert!(!events.is_empty(), "INV-16b: expected MintEvent on initialize");
+    assert!(
+        !events.is_empty(),
+        "INV-16b: expected MintEvent on initialize"
+    );
     let last = events.last().unwrap();
     let event_data: i128 = last.2.into_val(&e);
     assert_eq!(event_data, INITIAL_SUPPLY);
@@ -464,7 +483,10 @@ fn test_inv_17b_burn_from_emits_event_with_correct_fields() {
     let events = e.events().all();
     let last = events.last().expect("expected at least one event");
     let event_data: i128 = last.2.into_val(&e);
-    assert_eq!(event_data, burn_amount, "INV-17b: BurnEvent amount mismatch");
+    assert_eq!(
+        event_data, burn_amount,
+        "INV-17b: BurnEvent amount mismatch"
+    );
 }
 
 // ── Additional edge-case / fuzz-style table tests ─────────────────────────────
@@ -478,12 +500,30 @@ fn test_supply_invariant_mixed_operations_table() {
     }
 
     let ops = [
-        Op { is_mint: true,  amount: 1_000_000_000_000_000_000_000 },
-        Op { is_mint: true,  amount: 2_000_000_000_000_000_000_000 },
-        Op { is_mint: false, amount: 500_000_000_000_000_000_000 },
-        Op { is_mint: true,  amount: 5_000_000_000_000_000_000_000 },
-        Op { is_mint: false, amount: 3_000_000_000_000_000_000_000 },
-        Op { is_mint: false, amount: 1_000_000_000_000_000_000_000 },
+        Op {
+            is_mint: true,
+            amount: 1_000_000_000_000_000_000_000,
+        },
+        Op {
+            is_mint: true,
+            amount: 2_000_000_000_000_000_000_000,
+        },
+        Op {
+            is_mint: false,
+            amount: 500_000_000_000_000_000_000,
+        },
+        Op {
+            is_mint: true,
+            amount: 5_000_000_000_000_000_000_000,
+        },
+        Op {
+            is_mint: false,
+            amount: 3_000_000_000_000_000_000_000,
+        },
+        Op {
+            is_mint: false,
+            amount: 1_000_000_000_000_000_000_000,
+        },
     ];
 
     let (_, client, admin) = setup();

--- a/contract/integration-tests/src/game_token_flow.rs
+++ b/contract/integration-tests/src/game_token_flow.rs
@@ -108,8 +108,14 @@ mod tests {
     fn collectible_info_round_trip() {
         let f = Fixture::new();
         let token_id: u128 = 42;
-        f.game
-            .set_collectible_info(&token_id, &7, &3, &500_000_000_000_000_000_000, &10_000_000, &100);
+        f.game.set_collectible_info(
+            &token_id,
+            &7,
+            &3,
+            &500_000_000_000_000_000_000,
+            &10_000_000,
+            &100,
+        );
         let info = f.game.get_collectible_info(&token_id);
         assert_eq!(info, (7, 3, 500_000_000_000_000_000_000, 10_000_000, 100));
     }
@@ -117,11 +123,23 @@ mod tests {
     #[test]
     fn cash_tier_round_trip() {
         let f = Fixture::new();
-        f.game.set_cash_tier_value(&1, &1_000_000_000_000_000_000_000);
-        f.game.set_cash_tier_value(&2, &5_000_000_000_000_000_000_000);
-        f.game.set_cash_tier_value(&3, &10_000_000_000_000_000_000_000);
-        assert_eq!(f.game.get_cash_tier_value(&1), 1_000_000_000_000_000_000_000);
-        assert_eq!(f.game.get_cash_tier_value(&2), 5_000_000_000_000_000_000_000);
-        assert_eq!(f.game.get_cash_tier_value(&3), 10_000_000_000_000_000_000_000);
+        f.game
+            .set_cash_tier_value(&1, &1_000_000_000_000_000_000_000);
+        f.game
+            .set_cash_tier_value(&2, &5_000_000_000_000_000_000_000);
+        f.game
+            .set_cash_tier_value(&3, &10_000_000_000_000_000_000_000);
+        assert_eq!(
+            f.game.get_cash_tier_value(&1),
+            1_000_000_000_000_000_000_000
+        );
+        assert_eq!(
+            f.game.get_cash_tier_value(&2),
+            5_000_000_000_000_000_000_000
+        );
+        assert_eq!(
+            f.game.get_cash_tier_value(&3),
+            10_000_000_000_000_000_000_000
+        );
     }
 }

--- a/contract/integration-tests/src/lib.rs
+++ b/contract/integration-tests/src/lib.rs
@@ -4,10 +4,10 @@
 #[cfg(test)]
 mod fixture;
 #[cfg(test)]
-mod token_reward_flow;
-#[cfg(test)]
 mod game_reward_flow;
 #[cfg(test)]
 mod game_token_flow;
 #[cfg(test)]
 mod multi_player_flow;
+#[cfg(test)]
+mod token_reward_flow;

--- a/contract/integration-tests/src/multi_player_flow.rs
+++ b/contract/integration-tests/src/multi_player_flow.rs
@@ -51,9 +51,8 @@ mod tests {
         ];
         let players = [&f.player_a, &f.player_b, &f.player_c];
 
-        let tids: [u128; 3] = core::array::from_fn(|i| {
-            f.reward.mint_voucher(&f.admin, players[i], &values[i])
-        });
+        let tids: [u128; 3] =
+            core::array::from_fn(|i| f.reward.mint_voucher(&f.admin, players[i], &values[i]));
 
         // Redeem in reverse order
         f.reward.redeem_voucher_from(&f.player_c, &tids[2]);


### PR DESCRIPTION
…ntrypoints

Stellar Wave batch  formalize admin/public entrypoint split in tycoon-boost-system.

## What changed

### contract/contracts/tycoon-boost-system
- Add DataKey::Admin and initialize(env, admin)  one-time setup, consistent with the pattern used in tycoon-reward-system and tycoon-game.
- dd_boost is now **admin-only** (game server grants boosts; players cannot self-grant). Auth enforced via 
equire_admin().
- clear_boosts is now **admin-only** (admin can revoke any player's boosts).
- prune_expired_boosts, calculate_total_boost, get_boosts, get_active_boosts remain **public / permissionless**  no privileged pattern.
- Add NotInitialized / AlreadyInitialized variants to BoostError.
- New private helper 
equire_admin()  loads admin from persistent storage and calls 
equire_auth(); panics NotInitialized if contract is uninitialized.



### Tests
- All existing test helpers updated to call client.initialize(&admin) before exercising write paths.
- Four new auth-enforcement tests in 	est.rs:
  - 	est_initialize_twice_panics  double-init is rejected
  - 	est_add_boost_without_initialize_panics  NotInitialized guard
  - 	est_clear_boosts_without_initialize_panics  NotInitialized guard
  - 	est_add_boost_requires_admin_auth  non-admin call is rejected

### Workspace hygiene (cargo fmt + clippy -D warnings)
- 	ycoon-lib/src/fees.rs  remove misplaced #![no_std], drop unused Env/Vec imports.
- 	ycoon-collectibles/src/events.rs + 	ransfer.rs + lib.rs  add #[allow(deprecated)] to all env.events().publish() call sites.
- 	ycoon-collectibles/src/lib.rs  remove unused calculate_fee_split import, prefix unused env param in max_page_size with _.
- cargo fmt --all applied workspace-wide.

## CI checklist
- cargo fmt --all -- --check
- cargo check --workspace  (zero warnings)
- cargo check -p tycoon-boost-system
- All existing tests unmodified in behaviour; new tests cover auth boundaries.

## Rollout / migration
Existing deployments must call initialize(admin) once after upgrade before dd_boost or clear_boosts will work. No storage migration needed  the PlayerBoosts(Address) key shape is unchanged

closes #619 