### PR TITLE
feat(frontend): SW-FE-002 NEAR wallet TS strictness and null guards

### DIFF
--- a/frontend/docs/SW-FE-002-near-wallet-ts-strictness.md
+++ b/frontend/docs/SW-FE-002-near-wallet-ts-strictness.md
@@ -1,0 +1,39 @@
+# SW-FE-002 — NEAR Wallet Connect: TypeScript Strictness & Null Guards
+
+Part of the **Stellar Wave** engineering batch.
+
+## What changed
+
+| File | Change |
+|------|--------|
+| `src/lib/near/execution.ts` | `getTransactionHashFromOutcome` now returns `string \| undefined` instead of `string` (empty string was a silent bad value). `isFinalExecutionSuccess` replaces loose `!status.Failure` boolean coercion with an explicit `=== undefined \|\| === null` check. |
+| `src/lib/near/explorer.ts` | `getExplorerTransactionUrl` returns `string \| undefined` and guards against an empty hash, preventing a silently broken explorer URL. |
+| `src/components/wallet/NearWalletConnect.tsx` | `onClick` for Disconnect uses a block-body arrow function (`{ void disconnect(); }`) to satisfy `@typescript-eslint/no-misused-promises`. |
+| `test/near-execution.test.ts` | New unit tests covering all new `undefined` return paths and the tightened `Failure` check. |
+
+## No breaking changes
+
+- `NearTxRecord.hash` and `NearTxRecord.explorerUrl` were already `string | undefined` — no consumer changes needed.
+- The provider's existing `if (hash)` guard is now a proper null-guard rather than a truthiness check on a non-empty string.
+
+## Feature flag / rollout
+
+No runtime flag needed. These are pure type-level and defensive-coding changes with no behaviour difference for the happy path.
+
+1. Deploy to preview; run `npm run typecheck && npm run test`.
+2. Promote to production — no staged rollout required.
+
+## Verification
+
+```bash
+cd frontend
+npm run typecheck
+npm run test
+```
+
+## Acceptance criteria
+
+- [x] PR references Stellar Wave and issue id SW-FE-002
+- [x] `npm run typecheck` passes
+- [x] `npm run test` covers new null-guard paths
+- [x] No new heavy client dependencies added

--- a/frontend/src/components/wallet/NearWalletConnect.tsx
+++ b/frontend/src/components/wallet/NearWalletConnect.tsx
@@ -63,7 +63,7 @@ export function NearWalletConnect({
             </span>
             <button
               type="button"
-              onClick={() => void disconnect()}
+              onClick={() => { void disconnect(); }}
               className="rounded-full border border-[var(--tycoon-border)] bg-transparent px-3 py-1 text-[11px] font-dm-sans text-[var(--tycoon-text)]/80 hover:text-[var(--tycoon-accent)] transition-colors"
             >
               Disconnect NEAR

--- a/frontend/src/lib/near/execution.ts
+++ b/frontend/src/lib/near/execution.ts
@@ -2,15 +2,17 @@ import type { FinalExecutionOutcome } from "@near-wallet-selector/core";
 
 export function getTransactionHashFromOutcome(
   outcome: FinalExecutionOutcome,
-): string {
-  return outcome.transaction_outcome?.id ?? "";
+): string | undefined {
+  const id = outcome.transaction_outcome?.id;
+  return id !== undefined && id !== "" ? id : undefined;
 }
 
 export function isFinalExecutionSuccess(outcome: FinalExecutionOutcome): boolean {
   const { status } = outcome;
   if (status === "Failure") return false;
   if (typeof status === "object" && status !== null && "Failure" in status) {
-    return !status.Failure;
+    const failure = (status as { Failure?: unknown }).Failure;
+    return failure === undefined || failure === null;
   }
   return true;
 }

--- a/frontend/src/lib/near/explorer.ts
+++ b/frontend/src/lib/near/explorer.ts
@@ -8,7 +8,8 @@ const EXPLORER_BASE: Record<NetworkId, string> = {
 export function getExplorerTransactionUrl(
   networkId: NetworkId,
   transactionHash: string,
-): string {
+): string | undefined {
+  if (!transactionHash) return undefined;
   const base = EXPLORER_BASE[networkId];
   return `${base}/transactions/${encodeURIComponent(transactionHash)}`;
 }

--- a/frontend/test/near-execution.test.ts
+++ b/frontend/test/near-execution.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { FinalExecutionOutcome } from "@near-wallet-selector/core";
+import {
+  getTransactionHashFromOutcome,
+  isFinalExecutionSuccess,
+} from "@/lib/near/execution";
+import { getExplorerTransactionUrl } from "@/lib/near/explorer";
+
+function makeOutcome(
+  id: string | undefined,
+  status: FinalExecutionOutcome["status"],
+): FinalExecutionOutcome {
+  return {
+    status,
+    transaction: {} as FinalExecutionOutcome["transaction"],
+    transaction_outcome: id !== undefined ? ({ id } as FinalExecutionOutcome["transaction_outcome"]) : undefined as unknown as FinalExecutionOutcome["transaction_outcome"],
+    receipts_outcome: [],
+  };
+}
+
+describe("getTransactionHashFromOutcome", () => {
+  it("returns the transaction id when present", () => {
+    expect(getTransactionHashFromOutcome(makeOutcome("ABC123", "SuccessValue"))).toBe("ABC123");
+  });
+
+  it("returns undefined for empty string id", () => {
+    expect(getTransactionHashFromOutcome(makeOutcome("", "SuccessValue"))).toBeUndefined();
+  });
+
+  it("returns undefined when transaction_outcome is missing", () => {
+    expect(getTransactionHashFromOutcome(makeOutcome(undefined, "SuccessValue"))).toBeUndefined();
+  });
+});
+
+describe("isFinalExecutionSuccess", () => {
+  it("returns true for SuccessValue string status", () => {
+    expect(isFinalExecutionSuccess(makeOutcome("x", "SuccessValue"))).toBe(true);
+  });
+
+  it("returns false for Failure string status", () => {
+    expect(isFinalExecutionSuccess(makeOutcome("x", "Failure"))).toBe(false);
+  });
+
+  it("returns false when status object has a Failure key with a value", () => {
+    const outcome = makeOutcome("x", { Failure: { error_type: "ActionError", error_message: "oops" } } as unknown as FinalExecutionOutcome["status"]);
+    expect(isFinalExecutionSuccess(outcome)).toBe(false);
+  });
+
+  it("returns true when status object Failure is null", () => {
+    const outcome = makeOutcome("x", { Failure: null } as unknown as FinalExecutionOutcome["status"]);
+    expect(isFinalExecutionSuccess(outcome)).toBe(true);
+  });
+});
+
+describe("getExplorerTransactionUrl", () => {
+  it("builds a testnet explorer URL", () => {
+    expect(getExplorerTransactionUrl("testnet", "ABC123")).toBe(
+      "https://explorer.testnet.near.org/transactions/ABC123",
+    );
+  });
+
+  it("builds a mainnet explorer URL", () => {
+    expect(getExplorerTransactionUrl("mainnet", "XYZ")).toBe(
+      "https://explorer.near.org/transactions/XYZ",
+    );
+  });
+
+  it("returns undefined for an empty hash", () => {
+    expect(getExplorerTransactionUrl("testnet", "")).toBeUndefined();
+  });
+
+  it("encodes special characters in the hash", () => {
+    const url = getExplorerTransactionUrl("testnet", "a/b");
+    expect(url).toBe("https://explorer.testnet.near.org/transactions/a%2Fb");
+  });
+});


### PR DESCRIPTION
- getTransactionHashFromOutcome returns string|undefined (no empty-string sentinel)
- isFinalExecutionSuccess uses explicit null check instead of !status.Failure coercion
- getExplorerTransactionUrl returns string|undefined and guards empty hash
- NearWalletConnect disconnect onClick uses block-body void to satisfy no-misused-promises
- Add near-execution.test.ts covering all new undefined return paths

closes #539