### PR TITLE
feat(backend): SW-BE-033 Redis idempotency service, interceptor, and …

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "7": "^0.0.1",
         "@aws-sdk/client-s3": "^3.1019.0",
         "@aws-sdk/s3-request-presigner": "^3.1019.0",
         "@keyv/redis": "^5.1.6",
@@ -5814,12 +5813,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/7": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/7/-/7-0.0.1.tgz",
-      "integrity": "sha512-o9Q7is0K/9DsIRFke4wkUu3f9mVNC+n1wZHG71FAo1U1vhsj7WrUpRfHHrMR11o7jC22xH/6jd5KND/8rhDRlQ==",
-      "license": "mit"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",

--- a/backend/src/modules/redis/idempotency.interceptor.spec.ts
+++ b/backend/src/modules/redis/idempotency.interceptor.spec.ts
@@ -1,0 +1,132 @@
+import { ExecutionContext, ConflictException } from '@nestjs/common';
+import { of, throwError, lastValueFrom } from 'rxjs';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+import { IdempotencyService } from './idempotency.service';
+
+const makeCtx = (method: string, headers: Record<string, string> = {}) => {
+  const res = { setHeader: jest.fn() };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ method, headers }),
+      getResponse: () => res,
+    }),
+    res,
+  } as unknown as ExecutionContext & { res: typeof res };
+};
+
+const makeHandler = (value: unknown = { id: 1 }) => ({
+  handle: () => of(value),
+});
+
+describe('IdempotencyInterceptor', () => {
+  let interceptor: IdempotencyInterceptor;
+  let idempotency: jest.Mocked<IdempotencyService>;
+
+  beforeEach(() => {
+    idempotency = {
+      get: jest.fn(),
+      markProcessing: jest.fn().mockResolvedValue(undefined),
+      markComplete: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<IdempotencyService>;
+    interceptor = new IdempotencyInterceptor(idempotency);
+  });
+
+  describe('non-mutating methods', () => {
+    it.each(['GET', 'HEAD', 'OPTIONS'])('%s passes through without idempotency check', async (method) => {
+      const ctx = makeCtx(method);
+      const handler = makeHandler();
+      const obs = await interceptor.intercept(ctx, handler);
+      const result = await lastValueFrom(obs);
+      expect(result).toEqual({ id: 1 });
+      expect(idempotency.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('mutating methods without idempotency-key header', () => {
+    it('passes through when no header is present', async () => {
+      const ctx = makeCtx('POST');
+      const obs = await interceptor.intercept(ctx, makeHandler());
+      expect(await lastValueFrom(obs)).toEqual({ id: 1 });
+      expect(idempotency.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('first request (no existing record)', () => {
+    it('marks processing, executes handler, marks complete', async () => {
+      idempotency.get.mockResolvedValue(undefined);
+      const ctx = makeCtx('POST', { 'idempotency-key': 'key-abc' });
+      const obs = await interceptor.intercept(ctx, makeHandler({ created: true }));
+      const result = await lastValueFrom(obs);
+
+      expect(result).toEqual({ created: true });
+      expect(idempotency.markProcessing).toHaveBeenCalledWith('key-abc');
+      expect(idempotency.markComplete).toHaveBeenCalledWith('key-abc', { created: true });
+    });
+  });
+
+  describe('replay — complete record exists', () => {
+    it('returns cached response and sets replay header', async () => {
+      idempotency.get.mockResolvedValue({
+        status: 'complete',
+        response: { id: 99 },
+        createdAt: Date.now(),
+      });
+      const ctx = makeCtx('POST', { 'idempotency-key': 'key-abc' });
+      const obs = await interceptor.intercept(ctx, makeHandler());
+      const result = await lastValueFrom(obs);
+
+      expect(result).toEqual({ id: 99 });
+      expect(ctx.res.setHeader).toHaveBeenCalledWith('x-idempotency-replayed', 'true');
+      expect(idempotency.markProcessing).not.toHaveBeenCalled();
+    });
+
+    it('does not call the handler on replay', async () => {
+      idempotency.get.mockResolvedValue({
+        status: 'complete',
+        response: { replayed: true },
+        createdAt: Date.now(),
+      });
+      const handler = { handle: jest.fn().mockReturnValue(of({})) };
+      const ctx = makeCtx('PUT', { 'idempotency-key': 'key-xyz' });
+      await interceptor.intercept(ctx, handler);
+      expect(handler.handle).not.toHaveBeenCalled();
+    });
+
+    it.each(['POST', 'PUT', 'PATCH', 'DELETE'])('%s replays correctly', async (method) => {
+      idempotency.get.mockResolvedValue({
+        status: 'complete',
+        response: { method },
+        createdAt: Date.now(),
+      });
+      const ctx = makeCtx(method, { 'idempotency-key': 'k' });
+      const obs = await interceptor.intercept(ctx, makeHandler());
+      expect(await lastValueFrom(obs)).toEqual({ method });
+    });
+  });
+
+  describe('in-flight — processing record exists', () => {
+    it('throws ConflictException', async () => {
+      idempotency.get.mockResolvedValue({ status: 'processing', createdAt: Date.now() });
+      const ctx = makeCtx('POST', { 'idempotency-key': 'key-abc' });
+      await expect(interceptor.intercept(ctx, makeHandler())).rejects.toBeInstanceOf(ConflictException);
+    });
+  });
+
+  describe('error path', () => {
+    it('deletes the key when the handler throws', async () => {
+      idempotency.get.mockResolvedValue(undefined);
+      const ctx = makeCtx('POST', { 'idempotency-key': 'key-err' });
+      const handler = { handle: () => throwError(() => new Error('boom')) };
+
+      try {
+        const obs = await interceptor.intercept(ctx, handler as any);
+        await lastValueFrom(obs);
+      } catch {
+        // expected
+      }
+
+      expect(idempotency.delete).toHaveBeenCalledWith('key-err');
+    });
+  });
+});

--- a/backend/src/modules/redis/idempotency.interceptor.ts
+++ b/backend/src/modules/redis/idempotency.interceptor.ts
@@ -1,0 +1,68 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  ConflictException,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Observable, throwError } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+import { IdempotencyService } from './idempotency.service';
+
+const IDEMPOTENCY_HEADER = 'idempotency-key';
+const REPLAY_HEADER = 'x-idempotency-replayed';
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  constructor(private readonly idempotency: IdempotencyService) {}
+
+  async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<unknown>> {
+    const req = context.switchToHttp().getRequest<{
+      method: string;
+      headers: Record<string, string | undefined>;
+    }>();
+    const res = context.switchToHttp().getResponse<{
+      setHeader: (name: string, value: string) => void;
+    }>();
+
+    if (!MUTATING_METHODS.has(req.method)) {
+      return next.handle();
+    }
+
+    const idempotencyKey = req.headers[IDEMPOTENCY_HEADER];
+    if (!idempotencyKey) {
+      return next.handle();
+    }
+
+    const existing = await this.idempotency.get(idempotencyKey);
+
+    if (existing?.status === 'processing') {
+      throw new ConflictException('Request is still being processed');
+    }
+
+    if (existing?.status === 'complete') {
+      res.setHeader(REPLAY_HEADER, 'true');
+      return new Observable((subscriber) => {
+        subscriber.next(existing.response);
+        subscriber.complete();
+      });
+    }
+
+    await this.idempotency.markProcessing(idempotencyKey);
+
+    return next.handle().pipe(
+      tap(async (response: unknown) => {
+        await this.idempotency.markComplete(idempotencyKey, response);
+      }),
+      catchError((err: unknown) => {
+        void this.idempotency.delete(idempotencyKey);
+        return throwError(() => err instanceof HttpException
+          ? err
+          : new HttpException('Internal server error', HttpStatus.INTERNAL_SERVER_ERROR));
+      }),
+    );
+  }
+}

--- a/backend/src/modules/redis/idempotency.service.spec.ts
+++ b/backend/src/modules/redis/idempotency.service.spec.ts
@@ -1,0 +1,83 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IdempotencyService, IdempotencyRecord } from './idempotency.service';
+import { RedisService } from './redis.service';
+
+const mockRedis = () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+});
+
+describe('IdempotencyService', () => {
+  let service: IdempotencyService;
+  let redis: ReturnType<typeof mockRedis>;
+
+  beforeEach(async () => {
+    redis = mockRedis();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IdempotencyService,
+        { provide: RedisService, useValue: redis },
+      ],
+    }).compile();
+    service = module.get(IdempotencyService);
+  });
+
+  it('is defined', () => expect(service).toBeDefined());
+
+  describe('get', () => {
+    it('returns undefined when key does not exist', async () => {
+      redis.get.mockResolvedValue(undefined);
+      expect(await service.get('k1')).toBeUndefined();
+      expect(redis.get).toHaveBeenCalledWith('idempotency:k1');
+    });
+
+    it('returns the stored record', async () => {
+      const record: IdempotencyRecord = { status: 'complete', response: { id: 1 }, createdAt: 1000 };
+      redis.get.mockResolvedValue(record);
+      expect(await service.get('k1')).toEqual(record);
+    });
+  });
+
+  describe('markProcessing', () => {
+    it('stores a processing record with default TTL', async () => {
+      redis.set.mockResolvedValue(undefined);
+      await service.markProcessing('k1');
+      expect(redis.set).toHaveBeenCalledWith(
+        'idempotency:k1',
+        expect.objectContaining({ status: 'processing' }),
+        86_400 * 1000,
+      );
+    });
+
+    it('respects a custom TTL', async () => {
+      redis.set.mockResolvedValue(undefined);
+      await service.markProcessing('k1', 60);
+      expect(redis.set).toHaveBeenCalledWith(
+        'idempotency:k1',
+        expect.objectContaining({ status: 'processing' }),
+        60_000,
+      );
+    });
+  });
+
+  describe('markComplete', () => {
+    it('stores a complete record with the response payload', async () => {
+      redis.set.mockResolvedValue(undefined);
+      await service.markComplete('k1', { ok: true });
+      expect(redis.set).toHaveBeenCalledWith(
+        'idempotency:k1',
+        expect.objectContaining({ status: 'complete', response: { ok: true } }),
+        86_400 * 1000,
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the key', async () => {
+      redis.del.mockResolvedValue(undefined);
+      await service.delete('k1');
+      expect(redis.del).toHaveBeenCalledWith('idempotency:k1');
+    });
+  });
+});

--- a/backend/src/modules/redis/idempotency.service.ts
+++ b/backend/src/modules/redis/idempotency.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { RedisService } from './redis.service';
+
+export interface IdempotencyRecord {
+  status: 'processing' | 'complete';
+  response?: unknown;
+  createdAt: number;
+}
+
+const DEFAULT_TTL = 86_400; // 24 h
+
+@Injectable()
+export class IdempotencyService {
+  constructor(private readonly redis: RedisService) {}
+
+  private key(idempotencyKey: string): string {
+    return `idempotency:${idempotencyKey}`;
+  }
+
+  async get(idempotencyKey: string): Promise<IdempotencyRecord | undefined> {
+    return this.redis.get<IdempotencyRecord>(this.key(idempotencyKey));
+  }
+
+  async markProcessing(idempotencyKey: string, ttl = DEFAULT_TTL): Promise<void> {
+    const record: IdempotencyRecord = { status: 'processing', createdAt: Date.now() };
+    await this.redis.set(this.key(idempotencyKey), record, ttl * 1000);
+  }
+
+  async markComplete(
+    idempotencyKey: string,
+    response: unknown,
+    ttl = DEFAULT_TTL,
+  ): Promise<void> {
+    const record: IdempotencyRecord = {
+      status: 'complete',
+      response,
+      createdAt: Date.now(),
+    };
+    await this.redis.set(this.key(idempotencyKey), record, ttl * 1000);
+  }
+
+  async delete(idempotencyKey: string): Promise<void> {
+    await this.redis.del(this.key(idempotencyKey));
+  }
+}

--- a/backend/src/modules/redis/redis.module.ts
+++ b/backend/src/modules/redis/redis.module.ts
@@ -3,6 +3,8 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { redisStore } from 'cache-manager-ioredis-yet';
 import { RedisService } from './redis.service';
+import { IdempotencyService } from './idempotency.service';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
 import { LoggerModule } from '../../common/logger/logger.module';
 
 @Global()
@@ -34,7 +36,7 @@ import { LoggerModule } from '../../common/logger/logger.module';
       },
     }),
   ],
-  providers: [RedisService],
-  exports: [CacheModule, RedisService],
+  providers: [RedisService, IdempotencyService, IdempotencyInterceptor],
+  exports: [CacheModule, RedisService, IdempotencyService, IdempotencyInterceptor],
 })
 export class RedisModule {}

--- a/backend/src/modules/redis/redis.service.spec.ts
+++ b/backend/src/modules/redis/redis.service.spec.ts
@@ -1,134 +1,151 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { RedisService } from './redis.service';
 import { LoggerService } from '../../common/logger/logger.service';
 
+// Prevent duplicate Prometheus metric registration across test runs
+jest.mock('prom-client', () => {
+  const noop = () => ({ inc: jest.fn(), set: jest.fn(), startTimer: jest.fn(() => jest.fn()), observe: jest.fn() });
+  return { Counter: jest.fn(noop), Gauge: jest.fn(noop), Histogram: jest.fn(noop) };
+});
+
+const mockRedisInstance = {
+  setex: jest.fn(),
+  get: jest.fn(),
+  del: jest.fn(),
+  incr: jest.fn(),
+  expire: jest.fn(),
+  keys: jest.fn(),
+  quit: jest.fn(),
+  on: jest.fn(),
+};
+
+jest.mock('ioredis', () => jest.fn().mockImplementation(() => mockRedisInstance));
+
 describe('RedisService', () => {
   let service: RedisService;
+  let cacheManager: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
   let loggerService: jest.Mocked<LoggerService>;
 
   beforeEach(async () => {
-    const mockLoggerService = {
-      log: jest.fn(),
-      error: jest.fn(),
-      warn: jest.fn(),
-      debug: jest.fn(),
-    };
+    jest.clearAllMocks();
 
-    const mockCacheManager = {
-      get: jest.fn(),
-      set: jest.fn(),
-      del: jest.fn(),
-    };
-
-    const mockRedis = {
-      setex: jest.fn(),
-      get: jest.fn(),
-      del: jest.fn(),
-      incr: jest.fn(),
-      expire: jest.fn(),
-      keys: jest.fn(),
-      quit: jest.fn(),
-      on: jest.fn(),
-    };
+    cacheManager = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
+    loggerService = { log: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() } as any;
 
     const module: TestingModule = await Test.createTestingModule({
-      imports: [ConfigModule],
       providers: [
         RedisService,
+        { provide: CACHE_MANAGER, useValue: cacheManager },
+        { provide: LoggerService, useValue: loggerService },
         {
-          provide: LoggerService,
-          useValue: mockLoggerService,
-        },
-        {
-          provide: 'CACHE_MANAGER',
-          useValue: mockCacheManager,
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue({ host: 'localhost', port: 6379, db: 0, ttl: 300 }) },
         },
       ],
     }).compile();
 
-    service = module.get<RedisService>(RedisService);
-    loggerService = module.get(LoggerService);
-
-    // Mock the Redis instance
-    (service as any).redis = mockRedis;
+    service = module.get(RedisService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
+  it('should be defined', () => expect(service).toBeDefined());
 
   describe('Session management', () => {
-    it('should set refresh token successfully', async () => {
-      (service as any).redis.setex.mockResolvedValue('OK');
-
-      await service.setRefreshToken('user123', 'token456');
-
-      expect((service as any).redis.setex).toHaveBeenCalledWith('refresh_token:user123', 604800, 'token456');
-      expect(loggerService.debug).toHaveBeenCalledWith('Set refresh token for user user123', 'RedisService');
+    it('sets refresh token', async () => {
+      mockRedisInstance.setex.mockResolvedValue('OK');
+      await service.setRefreshToken('u1', 'tok');
+      expect(mockRedisInstance.setex).toHaveBeenCalledWith('refresh_token:u1', 604800, 'tok');
     });
 
-    it('should handle set refresh token error', async () => {
-      (service as any).redis.setex.mockRejectedValue(new Error('Redis error'));
-
-      await expect(service.setRefreshToken('user123', 'token456')).rejects.toThrow('Redis error');
-      expect(loggerService.error).toHaveBeenCalledWith(
-        'Failed to set refresh token for user user123: Redis error',
-        'RedisService'
-      );
+    it('throws on set refresh token error', async () => {
+      mockRedisInstance.setex.mockRejectedValue(new Error('down'));
+      await expect(service.setRefreshToken('u1', 'tok')).rejects.toThrow('down');
     });
 
-    it('should get refresh token successfully', async () => {
-      (service as any).redis.get.mockResolvedValue('token456');
-
-      const result = await service.getRefreshToken('user123');
-
-      expect(result).toBe('token456');
-      expect(loggerService.debug).toHaveBeenCalledWith('Retrieved refresh token for user user123', 'RedisService');
+    it('gets refresh token', async () => {
+      mockRedisInstance.get.mockResolvedValue('tok');
+      expect(await service.getRefreshToken('u1')).toBe('tok');
     });
 
-    it('should return null on get refresh token error', async () => {
-      (service as any).redis.get.mockRejectedValue(new Error('Redis error'));
+    it('returns null on get refresh token error', async () => {
+      mockRedisInstance.get.mockRejectedValue(new Error('down'));
+      expect(await service.getRefreshToken('u1')).toBeNull();
+    });
 
-      const result = await service.getRefreshToken('user123');
-
-      expect(result).toBeNull();
-      expect(loggerService.error).toHaveBeenCalledWith(
-        'Failed to get refresh token for user user123: Redis error',
-        'RedisService'
-      );
+    it('deletes refresh token', async () => {
+      mockRedisInstance.del.mockResolvedValue(1);
+      await service.deleteRefreshToken('u1');
+      expect(mockRedisInstance.del).toHaveBeenCalledWith('refresh_token:u1');
     });
   });
 
   describe('Cache operations', () => {
-    it('should handle cache hit', async () => {
-      const mockCacheManager = (service as any).cacheManager;
-      mockCacheManager.get.mockResolvedValue('cached_value');
-
-      const result = await service.get('test_key');
-
-      expect(result).toBe('cached_value');
-      expect(loggerService.debug).toHaveBeenCalledWith('Cache HIT: test_key', 'RedisService');
+    it('cache hit', async () => {
+      cacheManager.get.mockResolvedValue('val');
+      expect(await service.get('k')).toBe('val');
+      expect(loggerService.debug).toHaveBeenCalledWith('Cache HIT: k', 'RedisService');
     });
 
-    it('should handle cache miss', async () => {
-      const mockCacheManager = (service as any).cacheManager;
-      mockCacheManager.get.mockResolvedValue(undefined);
-
-      const result = await service.get('test_key');
-
-      expect(result).toBeUndefined();
-      expect(loggerService.debug).toHaveBeenCalledWith('Cache MISS: test_key', 'RedisService');
+    it('cache miss', async () => {
+      cacheManager.get.mockResolvedValue(undefined);
+      expect(await service.get('k')).toBeUndefined();
+      expect(loggerService.debug).toHaveBeenCalledWith('Cache MISS: k', 'RedisService');
     });
 
-    it('should set cache value', async () => {
-      const mockCacheManager = (service as any).cacheManager;
-      mockCacheManager.set.mockResolvedValue(undefined);
+    it('sets cache value', async () => {
+      cacheManager.set.mockResolvedValue(undefined);
+      await service.set('k', 'v', 300);
+      expect(cacheManager.set).toHaveBeenCalledWith('k', 'v', 300);
+    });
 
-      await service.set('test_key', 'test_value', 300);
+    it('deletes cache key', async () => {
+      cacheManager.del.mockResolvedValue(undefined);
+      await service.del('k');
+      expect(cacheManager.del).toHaveBeenCalledWith('k');
+    });
+  });
 
-      expect(mockCacheManager.set).toHaveBeenCalledWith('test_key', 'test_value', 300);
-      expect(loggerService.debug).toHaveBeenCalledWith('Cache SET: test_key', 'RedisService');
+  describe('Rate limiting', () => {
+    it('increments and sets TTL on first call', async () => {
+      mockRedisInstance.incr.mockResolvedValue(1);
+      mockRedisInstance.expire.mockResolvedValue(1);
+      expect(await service.incrementRateLimit('rl:u1')).toBe(1);
+      expect(mockRedisInstance.expire).toHaveBeenCalledWith('rl:u1', 60);
+    });
+
+    it('does not reset TTL on subsequent calls', async () => {
+      mockRedisInstance.incr.mockResolvedValue(5);
+      await service.incrementRateLimit('rl:u1');
+      expect(mockRedisInstance.expire).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 on Redis error (graceful degradation)', async () => {
+      mockRedisInstance.incr.mockRejectedValue(new Error('down'));
+      expect(await service.incrementRateLimit('rl:u1')).toBe(0);
+    });
+  });
+
+  describe('delByPattern', () => {
+    it('deletes matched keys', async () => {
+      mockRedisInstance.keys.mockResolvedValue(['a', 'b']);
+      mockRedisInstance.del.mockResolvedValue(2);
+      await service.delByPattern('prefix:*');
+      expect(mockRedisInstance.del).toHaveBeenCalledWith('a', 'b');
+    });
+
+    it('no-ops when no keys match', async () => {
+      mockRedisInstance.keys.mockResolvedValue([]);
+      await service.delByPattern('prefix:*');
+      expect(mockRedisInstance.del).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('quit', () => {
+    it('closes the Redis connection', async () => {
+      mockRedisInstance.quit.mockResolvedValue('OK');
+      await service.quit();
+      expect(mockRedisInstance.quit).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
close #580 

- Add IdempotencyService: stores processing/complete records in Redis with TTL
- Add IdempotencyInterceptor: deduplicates mutating requests via idempotency-key header, replays cached responses with x-idempotency-replayed header
- Add IdempotencyService and IdempotencyInterceptor unit specs (20 tests)
- Fix RedisService spec: mock ioredis and prom-client to avoid config/metric-registration errors; expand coverage to rate-limiting, delByPattern, and quit (16 tests)
- Export IdempotencyService and IdempotencyInterceptor from RedisModule