### PR TITLE
feat(frontend): SW-FE-006 shop grid MSW fixtures parity with API

### DIFF
--- a/frontend/src/components/game/ShopGrid.test.tsx
+++ b/frontend/src/components/game/ShopGrid.test.tsx
@@ -6,26 +6,35 @@ import { ShopItemData } from "./ShopItem";
 describe("ShopGrid", () => {
   const mockItems: ShopItemData[] = [
     {
-      id: "item-1",
+      id: 1,
       name: "Golden House",
       description: "Upgrade your property",
-      price: 100,
+      price: "100.00",
+      type: "skin",
+      currency: "USD",
+      active: true,
       icon: "🏠",
       rarity: "rare",
     },
     {
-      id: "item-2",
+      id: 2,
       name: "Lucky Dice",
       description: "Increase your luck",
-      price: 50,
+      price: "50.00",
+      type: "dice",
+      currency: "USD",
+      active: true,
       icon: "🎲",
       rarity: "common",
     },
     {
-      id: "item-3",
+      id: 3,
       name: "Legendary Card",
       description: "Rare collectible",
-      price: 500,
+      price: "500.00",
+      type: "card",
+      currency: "USD",
+      active: true,
       icon: "🎴",
       rarity: "legendary",
     },
@@ -113,7 +122,7 @@ describe("ShopGrid", () => {
 
     test("renders correct number of items", () => {
       render(<ShopGrid items={mockItems} />);
-      const items = screen.getAllByTestId(/^shop-item-item-/);
+      const items = screen.getAllByTestId(/^shop-item-\d+$/);
       expect(items).toHaveLength(mockItems.length);
     });
 
@@ -121,22 +130,22 @@ describe("ShopGrid", () => {
       const onPurchase = vi.fn();
       render(<ShopGrid items={mockItems} onPurchase={onPurchase} />);
 
-      const buyButton = screen.getByTestId("shop-item-buy-item-1");
+      const buyButton = screen.getByTestId("shop-item-buy-1");
       fireEvent.click(buyButton);
 
-      expect(onPurchase).toHaveBeenCalledWith("item-1");
+      expect(onPurchase).toHaveBeenCalledWith("1");
     });
 
     test("calls onPurchase for each item independently", () => {
       const onPurchase = vi.fn();
       render(<ShopGrid items={mockItems} onPurchase={onPurchase} />);
 
-      fireEvent.click(screen.getByTestId("shop-item-buy-item-1"));
-      fireEvent.click(screen.getByTestId("shop-item-buy-item-2"));
+      fireEvent.click(screen.getByTestId("shop-item-buy-1"));
+      fireEvent.click(screen.getByTestId("shop-item-buy-2"));
 
       expect(onPurchase).toHaveBeenCalledTimes(2);
-      expect(onPurchase).toHaveBeenNthCalledWith(1, "item-1");
-      expect(onPurchase).toHaveBeenNthCalledWith(2, "item-2");
+      expect(onPurchase).toHaveBeenNthCalledWith(1, "1");
+      expect(onPurchase).toHaveBeenNthCalledWith(2, "2");
     });
   });
 

--- a/frontend/src/components/game/ShopItem.tsx
+++ b/frontend/src/components/game/ShopItem.tsx
@@ -6,12 +6,15 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export interface ShopItemData {
-  id: string;
+  id: number | string;
   name: string;
-  description: string;
-  price: number;
+  description: string | null;
+  price: number | string;
+  type?: string;
+  currency?: string;
+  active?: boolean;
   icon?: string;
-  rarity?: "common" | "rare" | "epic" | "legendary";
+  rarity?: string;
   onPurchase?: (itemId: string) => void;
   disabled?: boolean;
 }
@@ -40,25 +43,29 @@ export const ShopItem: React.FC<ShopItemData> = ({
   onPurchase,
   disabled = false,
 }) => {
+  const itemId = String(id);
+  const displayPrice =
+    typeof price === "string" ? parseFloat(price).toFixed(2) : price;
+
   return (
     <div
       className={cn(
         "flex flex-col rounded-lg border-2 p-4 transition-all duration-200",
-        rarityColors[rarity],
+        rarityColors[rarity] ?? rarityColors.common,
         disabled && "opacity-50 cursor-not-allowed"
       )}
-      data-testid={`shop-item-${id}`}
+      data-testid={`shop-item-${itemId}`}
     >
       {/* Icon and Rarity Badge */}
       <div className="flex items-start justify-between mb-3">
         <span className="text-3xl" aria-hidden>
           {icon}
         </span>
-        {rarity !== "common" && (
+        {rarity && rarity !== "common" && (
           <span
             className={cn(
               "text-xs font-semibold px-2 py-1 rounded capitalize",
-              rarityBadgeColors[rarity]
+              rarityBadgeColors[rarity] ?? ""
             )}
           >
             {rarity}
@@ -71,21 +78,21 @@ export const ShopItem: React.FC<ShopItemData> = ({
 
       {/* Description */}
       <p className="text-xs text-gray-600 dark:text-gray-400 mb-3 line-clamp-2">
-        {description}
+        {description ?? ""}
       </p>
 
       {/* Price and Button */}
       <div className="mt-auto flex items-center justify-between gap-2">
         <span className="font-bold text-lg text-gray-900 dark:text-white">
-          ${price}
+          ${displayPrice}
         </span>
         <Button
           size="sm"
           variant={disabled ? "outline" : "default"}
-          onClick={() => onPurchase?.(id)}
+          onClick={() => onPurchase?.(itemId)}
           disabled={disabled}
           className="gap-1"
-          data-testid={`shop-item-buy-${id}`}
+          data-testid={`shop-item-buy-${itemId}`}
         >
           <ShoppingCart className="w-3 h-3" />
           <span className="hidden sm:inline">Buy</span>

--- a/frontend/src/lib/api/types/dto.ts
+++ b/frontend/src/lib/api/types/dto.ts
@@ -156,6 +156,55 @@ export interface UpdateGamePlayerDto {
   symbol?: GamePlayerSymbol;
 }
 
+// ─── Shop ────────────────────────────────────────────────────────────────────
+
+export type ShopItemType = 'dice' | 'skin' | 'symbol' | 'theme' | 'card';
+
+export interface ShopItemResponse {
+  id: number;
+  name: string;
+  description: string | null;
+  type: ShopItemType;
+  price: string;
+  currency: string;
+  metadata: Record<string, unknown> | null;
+  rarity: string;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserInventoryResponse {
+  id: number;
+  user_id: number;
+  shop_item_id: number;
+  shop_item: ShopItemResponse;
+  quantity: number;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PurchaseResponse {
+  id: number;
+  user_id: number;
+  shop_item_id: number;
+  shop_item?: ShopItemResponse;
+  quantity: number;
+  unit_price: string;
+  total_price: string;
+  original_price: string;
+  discount_amount: string;
+  final_price: string;
+  coupon_code: string | null;
+  currency: string;
+  payment_method: string;
+  transaction_id: string | null;
+  status: string;
+  is_gift: boolean;
+  created_at: string;
+}
+
 // ─── Game Responses ───────────────────────────────────────────────────────────
 
 export interface GamePlayerResponse {

--- a/frontend/src/mocks/fixtures/shop.ts
+++ b/frontend/src/mocks/fixtures/shop.ts
@@ -1,56 +1,86 @@
-export const mockShopItems = [
+import type { ShopItemResponse, UserInventoryResponse, PurchaseResponse } from '@/lib/api/types/dto';
+
+export const mockShopItems: ShopItemResponse[] = [
   {
     id: 1,
     name: 'Speed Boost',
     description: 'Move 2 spaces forward',
-    price: 100,
+    type: 'dice',
+    price: '100.00',
+    currency: 'USD',
+    metadata: { imageUrl: '/game/boost-speed.svg' },
     rarity: 'common',
-    type: 'boost',
     active: true,
-    imageUrl: '/game/boost-speed.svg'
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
   },
   {
     id: 2,
     name: 'Get Out of Jail Free',
     description: 'Escape jail without paying',
-    price: 500,
-    rarity: 'rare',
     type: 'card',
+    price: '500.00',
+    currency: 'USD',
+    metadata: { imageUrl: '/game/gotojail.svg' },
+    rarity: 'rare',
     active: true,
-    imageUrl: '/game/gotojail.svg'
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
   },
   {
     id: 3,
     name: 'Roll Again',
     description: 'Roll dice again',
-    price: 200,
+    type: 'dice',
+    price: '200.00',
+    currency: 'USD',
+    metadata: null,
     rarity: 'common',
-    type: 'boost',
-    active: true
-  }
+    active: true,
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+  },
 ];
 
-export const mockInventory = [
+export const mockInventory: UserInventoryResponse[] = [
   {
     id: 1,
-    itemId: 1,
+    user_id: 1,
+    shop_item_id: 1,
+    shop_item: mockShopItems[0],
     quantity: 3,
-    expiresAt: null
+    expires_at: null,
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
   },
   {
     id: 2,
-    itemId: 2,
+    user_id: 1,
+    shop_item_id: 2,
+    shop_item: mockShopItems[1],
     quantity: 1,
-    expiresAt: '2025-12-31T23:59:59Z'
-  }
+    expires_at: '2025-12-31T23:59:59.000Z',
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+  },
 ];
 
-export const mockPurchase = {
+export const mockPurchase: PurchaseResponse = {
   id: 99,
-  userId: 1,
-  itemId: 1,
+  user_id: 1,
+  shop_item_id: 1,
+  shop_item: mockShopItems[0],
   quantity: 1,
-  totalPrice: 100,
+  unit_price: '100.00',
+  total_price: '100.00',
+  original_price: '100.00',
+  discount_amount: '0.00',
+  final_price: '100.00',
+  coupon_code: null,
+  currency: 'USD',
+  payment_method: 'balance',
+  transaction_id: null,
   status: 'completed',
-  createdAt: new Date().toISOString()
+  is_gift: false,
+  created_at: new Date().toISOString(),
 };

--- a/frontend/src/mocks/handlers/shop.ts
+++ b/frontend/src/mocks/handlers/shop.ts
@@ -1,19 +1,21 @@
-import { http, HttpResponse } from "msw";
-import { mockInventory, mockPurchase, mockShopItems } from "../fixtures/shop";
+import { http, HttpResponse } from 'msw';
+import { mockInventory, mockPurchase, mockShopItems } from '../fixtures/shop';
+
+const LIMIT = 20;
 
 export const shopHandlers = [
   http.get(/\/api\/shop\/items(\?.*)?$/, () => {
     return HttpResponse.json({
       data: mockShopItems,
-      page: 1,
-      totalPages: 1,
       total: mockShopItems.length,
+      page: 1,
+      limit: LIMIT,
     });
   }),
   http.get(/\/api\/shop\/inventory/, () => {
-    return HttpResponse.json({ data: mockInventory });
+    return HttpResponse.json(mockInventory);
   }),
   http.post(/\/api\/shop\/purchase/, () => {
-    return HttpResponse.json(mockPurchase);
+    return HttpResponse.json(mockPurchase, { status: 201 });
   }),
 ];


### PR DESCRIPTION
- Add ShopItemResponse, UserInventoryResponse, PurchaseResponse types to dto.ts
- Align MSW fixtures (shop.ts) to match backend entity shapes:
  - numeric id, string price, snake_case fields, ShopItemType enum
  - UserInventory: shop_item_id, expires_at, shop_item relation
  - Purchase: unit_price, total_price, final_price, discount_amount
- Fix MSW handler paginated envelope: totalPages -> limit (PaginatedResponse<T>)
- Widen ShopItemData: numeric|string id, string|number price, nullable description, type/currency/active fields
- ShopItem: stringify id for callbacks/testids, parse string price for display
- Update ShopGrid tests: numeric ids, string prices, updated testid selectors

Refs: Stellar Wave SW-FE-006
Tests: 23/23 passing

closes #529 