### PR TITLE
feat(frontend): SW-FE-007 purchase modal accessibility and focus order

### DIFF
--- a/frontend/src/components/ui/purchase-modal.tsx
+++ b/frontend/src/components/ui/purchase-modal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -35,6 +36,16 @@ export function PurchaseModal({
 
   useFocusTrap(containerRef, isOpen, onClose);
 
+  // Lock body scroll while open; restore on close/unmount
+  useEffect(() => {
+    if (!isOpen) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (
@@ -44,38 +55,75 @@ export function PurchaseModal({
       aria-modal="true"
       aria-labelledby="purchase-modal-title"
       aria-describedby="purchase-modal-description"
+      data-testid="purchase-modal"
     >
-      {/* Backdrop click closes modal */}
-      <div className="absolute inset-0" onClick={onClose} aria-hidden="true" />
+      {/* Backdrop — click closes modal */}
+      <div
+        className="absolute inset-0"
+        onClick={onClose}
+        aria-hidden="true"
+        data-testid="purchase-modal-backdrop"
+      />
 
       <div ref={containerRef} className="relative z-10 w-full max-w-md">
         <Card className="border-neutral-800 bg-neutral-900 shadow-2xl">
-          <CardHeader>
+          <CardHeader className="relative">
+            {/* ① Close (×) — first in tab order, top-right corner */}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={t('shop.close_modal', { defaultValue: 'Close' })}
+              className="absolute right-4 top-4 rounded-sm text-neutral-400 opacity-70 ring-offset-neutral-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:ring-offset-2"
+              data-testid="purchase-modal-close"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+
             <CardTitle id="purchase-modal-title" className="text-xl text-white">
-              {t('shop.confirm_purchase')}
+              {t('shop.confirm_purchase', { defaultValue: 'Confirm Purchase' })}
             </CardTitle>
-            <CardDescription id="purchase-modal-description" className="text-neutral-400">
-              {t('shop.purchase_confirmation_msg', { name: itemName })}
+            <CardDescription
+              id="purchase-modal-description"
+              className="text-neutral-400"
+            >
+              {t('shop.purchase_confirmation_msg', {
+                name: itemName,
+                defaultValue: `Are you sure you want to purchase ${itemName}?`,
+              })}
             </CardDescription>
           </CardHeader>
+
           <CardContent className="py-6 text-center">
-            <div className="text-3xl font-bold text-cyan-400">
+            {/* aria-live so screen readers announce the price in context */}
+            <div
+              className="text-3xl font-bold text-cyan-400"
+              aria-live="polite"
+              aria-atomic="true"
+              data-testid="purchase-modal-price"
+            >
               {itemPrice} {itemCurrency}
             </div>
           </CardContent>
+
+          {/* ② Cancel — second in tab order */}
+          {/* ③ Confirm — third (last) in tab order */}
           <CardFooter className="flex justify-end gap-3">
             <Button
+              type="button"
               variant="outline"
               onClick={onClose}
               className="border-neutral-700 text-neutral-300 hover:bg-neutral-800"
+              data-testid="purchase-modal-cancel"
             >
-              {t('shop.cancel')}
+              {t('shop.cancel', { defaultValue: 'Cancel' })}
             </Button>
             <Button
+              type="button"
               onClick={onConfirm}
               className="bg-cyan-500 text-black hover:bg-cyan-400"
+              data-testid="purchase-modal-confirm"
             >
-              {t('shop.purchase')}
+              {t('shop.purchase', { defaultValue: 'Purchase' })}
             </Button>
           </CardFooter>
         </Card>

--- a/frontend/test/PurchaseModal.test.tsx
+++ b/frontend/test/PurchaseModal.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PurchaseModal } from '../src/components/ui/purchase-modal';
+
+// react-i18next: return the key's defaultValue so tests are locale-independent
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, opts?: { defaultValue?: string }) =>
+      opts?.defaultValue ?? _key,
+  }),
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  itemName: 'Speed Boost',
+  itemPrice: '100.00',
+  itemCurrency: 'USD',
+};
+
+function renderModal(props: Partial<typeof defaultProps> = {}) {
+  const merged = { ...defaultProps, ...props, onClose: vi.fn(), onConfirm: vi.fn() };
+  render(<PurchaseModal {...merged} />);
+  return merged;
+}
+
+describe('PurchaseModal', () => {
+  afterEach(() => {
+    document.body.style.overflow = '';
+    vi.clearAllMocks();
+  });
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  it('renders nothing when isOpen is false', () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByTestId('purchase-modal')).toBeNull();
+  });
+
+  it('renders the modal when isOpen is true', () => {
+    renderModal();
+    expect(screen.getByTestId('purchase-modal')).toBeInTheDocument();
+    expect(screen.getByText('Confirm Purchase')).toBeInTheDocument();
+    expect(screen.getByText(/Speed Boost/)).toBeInTheDocument();
+    expect(screen.getByTestId('purchase-modal-price')).toHaveTextContent('100.00 USD');
+  });
+
+  // ── ARIA / semantics ──────────────────────────────────────────────────────
+
+  it('has role="dialog" with aria-modal="true"', () => {
+    renderModal();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('labels the dialog with aria-labelledby pointing to the title', () => {
+    renderModal();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'purchase-modal-title');
+    expect(document.getElementById('purchase-modal-title')).toHaveTextContent(
+      'Confirm Purchase',
+    );
+  });
+
+  it('describes the dialog with aria-describedby pointing to the description', () => {
+    renderModal();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-describedby', 'purchase-modal-description');
+    expect(document.getElementById('purchase-modal-description')).toHaveTextContent(
+      'Speed Boost',
+    );
+  });
+
+  it('price region has aria-live="polite" and aria-atomic="true"', () => {
+    renderModal();
+    const price = screen.getByTestId('purchase-modal-price');
+    expect(price).toHaveAttribute('aria-live', 'polite');
+    expect(price).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('close button has a descriptive aria-label', () => {
+    renderModal();
+    expect(screen.getByTestId('purchase-modal-close')).toHaveAttribute(
+      'aria-label',
+      'Close',
+    );
+  });
+
+  // ── Focus order ───────────────────────────────────────────────────────────
+
+  it('moves focus to the close (×) button on open', async () => {
+    vi.useFakeTimers();
+    renderModal();
+    // Flush all pending requestAnimationFrame callbacks
+    await act(async () => { vi.runAllTimers(); });
+    vi.useRealTimers();
+    expect(document.activeElement).toBe(screen.getByTestId('purchase-modal-close'));
+  });
+
+  it('tab order is: close → cancel → confirm', () => {
+    renderModal();
+    const close = screen.getByTestId('purchase-modal-close');
+    const cancel = screen.getByTestId('purchase-modal-cancel');
+    const confirm = screen.getByTestId('purchase-modal-confirm');
+
+    // All three must be in the DOM and focusable
+    [close, cancel, confirm].forEach((el) => {
+      expect(el).toBeInTheDocument();
+      expect(el).not.toHaveAttribute('tabindex', '-1');
+    });
+
+    // DOM order: close appears before cancel, cancel before confirm
+    const all = Array.from(
+      screen.getByTestId('purchase-modal').querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    expect(all.indexOf(close)).toBeLessThan(all.indexOf(cancel));
+    expect(all.indexOf(cancel)).toBeLessThan(all.indexOf(confirm));
+  });
+
+  // ── Keyboard ──────────────────────────────────────────────────────────────
+
+  it('calls onClose when Escape is pressed', () => {
+    const { onClose } = renderModal();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps Tab from confirm (last) back to close (first)', async () => {
+    renderModal();
+    const confirm = screen.getByTestId('purchase-modal-confirm');
+    confirm.focus();
+    fireEvent.keyDown(confirm, { key: 'Tab', shiftKey: false });
+    expect(document.activeElement).toBe(screen.getByTestId('purchase-modal-close'));
+  });
+
+  it('wraps Shift+Tab from close (first) back to confirm (last)', async () => {
+    renderModal();
+    const close = screen.getByTestId('purchase-modal-close');
+    close.focus();
+    fireEvent.keyDown(close, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(screen.getByTestId('purchase-modal-confirm'));
+  });
+
+  // ── Interactions ──────────────────────────────────────────────────────────
+
+  it('calls onClose when the × button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+    await user.click(screen.getByTestId('purchase-modal-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+    await user.click(screen.getByTestId('purchase-modal-cancel'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirm when Confirm is clicked', async () => {
+    const user = userEvent.setup();
+    const { onConfirm } = renderModal();
+    await user.click(screen.getByTestId('purchase-modal-confirm'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the backdrop is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+    await user.click(screen.getByTestId('purchase-modal-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Scroll lock ───────────────────────────────────────────────────────────
+
+  it('locks body scroll when open', () => {
+    renderModal();
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('restores body scroll when unmounted', () => {
+    const { unmount } = render(<PurchaseModal {...defaultProps} />);
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('does not lock body scroll when closed', () => {
+    renderModal({ isOpen: false });
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+});


### PR DESCRIPTION
Accessibility fixes:
- Add close (×) button as first focusable element — correct focus order: close → cancel → confirm
- useFocusTrap already moves focus to first element (close ×) on open
- Add type="button" to all buttons to prevent accidental form submission
- Add aria-live="polite" + aria-atomic="true" on price region so screen readers announce the price in context
- Add data-testid attributes: purchase-modal, purchase-modal-backdrop, purchase-modal-close, purchase-modal-cancel, purchase-modal-confirm, purchase-modal-price
- Add backdrop data-testid for reliable test targeting

Focus order:
- DOM order enforces: × close → Cancel → Confirm
- useFocusTrap wraps Tab (confirm→close) and Shift+Tab (close→confirm)
- Escape key handled by useFocusTrap

Scroll lock:
- Body overflow set to hidden while modal is open; restored on unmount

Tests (test/PurchaseModal.test.tsx — 19 tests, all passing):
- Render: open/closed states
- ARIA: role, aria-modal, aria-labelledby, aria-describedby, aria-live
- Focus order: DOM order assertion, initial focus on close button
- Keyboard: Escape, Tab wrap, Shift+Tab wrap
- Interactions: ×/Cancel/Confirm clicks, backdrop click
- Scroll lock: lock on open, restore on unmount

Refs: Stellar Wave SW-FE-007
Tests: 19/19 passing

closes #530 