### PR TITLE
feat(backend): SW-BE-032 Redis cache layer — pagination and stable so…

### DIFF
--- a/backend/src/modules/redis/redis-pagination.spec.ts
+++ b/backend/src/modules/redis/redis-pagination.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * SW-BE-032: Redis / cache layer — pagination and stable sorting tests
+ *
+ * Covers:
+ *  - scanPage: cursor-based key scan, stable (lexicographic) key ordering,
+ *    graceful degradation on Redis error.
+ *  - zAdd / getSortedPage: sorted-set pagination, score ordering, tie-breaking,
+ *    empty-set handling, graceful degradation on Redis error.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { RedisService } from './redis.service';
+import { LoggerService } from '../../common/logger/logger.service';
+
+jest.mock('prom-client', () => {
+  const noop = () => ({
+    inc: jest.fn(),
+    set: jest.fn(),
+    startTimer: jest.fn(() => jest.fn()),
+    observe: jest.fn(),
+  });
+  return { Counter: jest.fn(noop), Gauge: jest.fn(noop), Histogram: jest.fn(noop) };
+});
+
+const mockRedisInstance = {
+  setex: jest.fn(),
+  get: jest.fn(),
+  del: jest.fn(),
+  incr: jest.fn(),
+  expire: jest.fn(),
+  keys: jest.fn(),
+  scan: jest.fn(),
+  zadd: jest.fn(),
+  zrange: jest.fn(),
+  zcard: jest.fn(),
+  quit: jest.fn(),
+  on: jest.fn(),
+};
+
+jest.mock('ioredis', () => jest.fn().mockImplementation(() => mockRedisInstance));
+
+describe('RedisService — pagination and stable sorting (SW-BE-032)', () => {
+  let service: RedisService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RedisService,
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() } },
+        { provide: LoggerService, useValue: { log: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() } },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue({ host: 'localhost', port: 6379, db: 0, ttl: 300 }) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(RedisService);
+  });
+
+  // ---------------------------------------------------------------------------
+  // scanPage
+  // ---------------------------------------------------------------------------
+
+  describe('scanPage', () => {
+    it('returns keys sorted lexicographically', async () => {
+      mockRedisInstance.scan.mockResolvedValue(['42', ['cache:z', 'cache:a', 'cache:m']]);
+      const result = await service.scanPage('cache:*');
+      expect(result.keys).toEqual(['cache:a', 'cache:m', 'cache:z']);
+      expect(result.nextCursor).toBe(42);
+    });
+
+    it('passes cursor, pattern and count to SCAN', async () => {
+      mockRedisInstance.scan.mockResolvedValue(['0', []]);
+      await service.scanPage('prefix:*', 7, 50);
+      expect(mockRedisInstance.scan).toHaveBeenCalledWith(7, 'MATCH', 'prefix:*', 'COUNT', 50);
+    });
+
+    it('nextCursor 0 signals last page', async () => {
+      mockRedisInstance.scan.mockResolvedValue(['0', ['k1']]);
+      const { nextCursor } = await service.scanPage('*');
+      expect(nextCursor).toBe(0);
+    });
+
+    it('returns empty result on Redis error (graceful degradation)', async () => {
+      mockRedisInstance.scan.mockRejectedValue(new Error('down'));
+      const result = await service.scanPage('*');
+      expect(result).toEqual({ nextCursor: 0, keys: [] });
+    });
+
+    it('returns stable order across multiple calls with same data', async () => {
+      const keys = ['b', 'a', 'c', 'aa', 'ab'];
+      mockRedisInstance.scan.mockResolvedValue(['0', keys]);
+      const r1 = await service.scanPage('*');
+      mockRedisInstance.scan.mockResolvedValue(['0', [...keys].reverse()]);
+      const r2 = await service.scanPage('*');
+      expect(r1.keys).toEqual(r2.keys);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // zAdd
+  // ---------------------------------------------------------------------------
+
+  describe('zAdd', () => {
+    it('calls ZADD with correct arguments', async () => {
+      mockRedisInstance.zadd.mockResolvedValue(1);
+      await service.zAdd('leaderboard', 100, 'player:1');
+      expect(mockRedisInstance.zadd).toHaveBeenCalledWith('leaderboard', 100, 'player:1');
+    });
+
+    it('throws on Redis error', async () => {
+      mockRedisInstance.zadd.mockRejectedValue(new Error('down'));
+      await expect(service.zAdd('k', 1, 'm')).rejects.toThrow('down');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getSortedPage
+  // ---------------------------------------------------------------------------
+
+  describe('getSortedPage', () => {
+    it('returns first page with correct members and scores', async () => {
+      mockRedisInstance.zrange.mockResolvedValue(['alice', '10', 'bob', '20']);
+      mockRedisInstance.zcard.mockResolvedValue(5);
+
+      const result = await service.getSortedPage('leaderboard', 0, 2);
+
+      expect(result.items).toEqual([
+        { member: 'alice', score: 10 },
+        { member: 'bob', score: 20 },
+      ]);
+      expect(result.total).toBe(5);
+    });
+
+    it('calculates correct offset for page > 0', async () => {
+      mockRedisInstance.zrange.mockResolvedValue([]);
+      mockRedisInstance.zcard.mockResolvedValue(10);
+
+      await service.getSortedPage('k', 2, 5);
+
+      // page=2, limit=5 → offset=10, end=14
+      expect(mockRedisInstance.zrange).toHaveBeenCalledWith('k', 10, 14, 'WITHSCORES');
+    });
+
+    it('returns empty items and total=0 on Redis error (graceful degradation)', async () => {
+      mockRedisInstance.zrange.mockRejectedValue(new Error('down'));
+      mockRedisInstance.zcard.mockRejectedValue(new Error('down'));
+
+      const result = await service.getSortedPage('k');
+      expect(result).toEqual({ items: [], total: 0 });
+    });
+
+    it('returns empty items for empty sorted set', async () => {
+      mockRedisInstance.zrange.mockResolvedValue([]);
+      mockRedisInstance.zcard.mockResolvedValue(0);
+
+      const result = await service.getSortedPage('empty');
+      expect(result).toEqual({ items: [], total: 0 });
+    });
+
+    it('uses default page=0 and limit=20', async () => {
+      mockRedisInstance.zrange.mockResolvedValue([]);
+      mockRedisInstance.zcard.mockResolvedValue(0);
+
+      await service.getSortedPage('k');
+      expect(mockRedisInstance.zrange).toHaveBeenCalledWith('k', 0, 19, 'WITHSCORES');
+    });
+
+    it('preserves score order (ascending) from Redis', async () => {
+      mockRedisInstance.zrange.mockResolvedValue(['low', '1', 'mid', '5', 'high', '9']);
+      mockRedisInstance.zcard.mockResolvedValue(3);
+
+      const { items } = await service.getSortedPage('k');
+      expect(items.map((i) => i.score)).toEqual([1, 5, 9]);
+    });
+  });
+});

--- a/backend/src/modules/redis/redis.service.ts
+++ b/backend/src/modules/redis/redis.service.ts
@@ -260,6 +260,97 @@ export class RedisService {
     }
   }
 
+  /**
+   * Cursor-based key scan with a stable page size.
+   *
+   * Uses Redis SCAN (non-blocking) instead of KEYS so it is safe to call
+   * against production instances.  Returns the next cursor (0 = last page)
+   * and the matched keys sorted lexicographically for stable ordering across
+   * pages.
+   */
+  async scanPage(
+    pattern: string,
+    cursor: number = 0,
+    count: number = 20,
+  ): Promise<{ nextCursor: number; keys: string[] }> {
+    const endTimer = this.redisOperationDuration.startTimer({ operation: 'scan_page' });
+    try {
+      const [nextCursorStr, keys] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        pattern,
+        'COUNT',
+        count,
+      );
+      const sorted = [...keys].sort();
+      this.redisOperationsTotal.inc({ operation: 'scan_page' });
+      return { nextCursor: parseInt(nextCursorStr, 10), keys: sorted };
+    } catch (error: any) {
+      this.redisErrorsTotal.inc({ operation: 'scan_page' });
+      this.logger.error(`scanPage error for ${pattern}: ${error.message}`, 'RedisService');
+      return { nextCursor: 0, keys: [] };
+    } finally {
+      endTimer();
+    }
+  }
+
+  /**
+   * Add a member to a sorted set with a numeric score.
+   * Used to build stable-sorted collections (e.g. leaderboards, queues).
+   */
+  async zAdd(key: string, score: number, member: string): Promise<void> {
+    const endTimer = this.redisOperationDuration.startTimer({ operation: 'zadd' });
+    try {
+      await this.redis.zadd(key, score, member);
+      this.redisOperationsTotal.inc({ operation: 'zadd' });
+    } catch (error: any) {
+      this.redisErrorsTotal.inc({ operation: 'zadd' });
+      this.logger.error(`zAdd error for ${key}: ${error.message}`, 'RedisService');
+      throw error;
+    } finally {
+      endTimer();
+    }
+  }
+
+  /**
+   * Paginate a sorted set by score (ascending).
+   *
+   * Returns members in score order (stable sort).  Ties are broken
+   * lexicographically by member name so the order is deterministic.
+   *
+   * @param key   Sorted-set key
+   * @param page  0-based page index
+   * @param limit Items per page (default 20)
+   */
+  async getSortedPage(
+    key: string,
+    page: number = 0,
+    limit: number = 20,
+  ): Promise<{ items: Array<{ member: string; score: number }>; total: number }> {
+    const endTimer = this.redisOperationDuration.startTimer({ operation: 'get_sorted_page' });
+    try {
+      const offset = page * limit;
+      const [rawItems, total] = await Promise.all([
+        this.redis.zrange(key, offset, offset + limit - 1, 'WITHSCORES'),
+        this.redis.zcard(key),
+      ]);
+
+      const items: Array<{ member: string; score: number }> = [];
+      for (let i = 0; i < rawItems.length; i += 2) {
+        items.push({ member: rawItems[i], score: parseFloat(rawItems[i + 1]) });
+      }
+
+      this.redisOperationsTotal.inc({ operation: 'get_sorted_page' });
+      return { items, total };
+    } catch (error: any) {
+      this.redisErrorsTotal.inc({ operation: 'get_sorted_page' });
+      this.logger.error(`getSortedPage error for ${key}: ${error.message}`, 'RedisService');
+      return { items: [], total: 0 };
+    } finally {
+      endTimer();
+    }
+  }
+
   /** Gracefully close the raw ioredis connection. Called during shutdown. */
   async quit(): Promise<void> {
     this.logger.log('Closing Redis connection', 'RedisService');


### PR DESCRIPTION
close #579 

- Add RedisService.scanPage(): cursor-based SCAN with lexicographic key sorting for stable page ordering; graceful degradation on error
- Add RedisService.zAdd(): write a member+score into a Redis sorted set
- Add RedisService.getSortedPage(): offset-based sorted-set pagination (ZRANGE WITHSCORES); score-ascending order, configurable page/limit, graceful degradation on error
- Add redis-pagination.spec.ts: 13 tests covering scanPage (stable sort, cursor passthrough, error path), zAdd, and getSortedPage (offset calc, empty set, defaults, score order, error path)