### PR TITLE
docs(backend): Redis cache operational runbook (Stellar Wave SW-BE-007)

### DIFF
--- a/backend/docs/REDIS_CACHE_RUNBOOK.md
+++ b/backend/docs/REDIS_CACHE_RUNBOOK.md
@@ -1,0 +1,154 @@
+# Redis & cache layer — operational runbook
+
+**Stellar Wave batch · SW-BE-007**
+
+Covers the global Redis client and Nest `CacheModule` wiring under `backend/src/modules/redis/`, `backend/src/config/redis.config.ts`, and Redis-related keys in `backend/src/config/env.validation.ts`.
+
+---
+
+## Table of contents
+
+1. [Architecture overview](#1-architecture-overview)
+2. [Environment variables](#2-environment-variables)
+3. [Feature flag: cache audit trail](#3-feature-flag-cache-audit-trail)
+4. [Rollout & migration](#4-rollout--migration)
+5. [Normal operations](#5-normal-operations)
+6. [Incident playbooks](#6-incident-playbooks)
+7. [Logging & secrets](#7-logging--secrets)
+8. [Monitoring](#8-monitoring)
+9. [Rollback](#9-rollback)
+
+---
+
+## 1. Architecture overview
+
+| Component | Role |
+|-----------|------|
+| `RedisModule` (`@Global`) | Registers `cache-manager` with `cache-manager-ioredis-yet` (same host/db/password as app config). Exports `RedisService`, idempotency helpers, and `CacheModule`. |
+| `RedisService` | Direct `ioredis` client for tokens, rate limits, sorted sets, `KEYS`/`SCAN` helpers; uses `CACHE_MANAGER` for cache-manager get/set/del. |
+| `redis.config.ts` | `ConfigFactory` for `ConfigService.get('redis')`. |
+| `env.validation.ts` | Joi schema: single source of truth for allowed env shapes and defaults for Redis-related variables. |
+| `GET /health/redis` | Smoke test: cache set/get for key `health-check` (short TTL). Routed **outside** the versioned API prefix (see `configureApiVersioning` exclusions). |
+
+**Important:** `delByPattern` uses Redis `KEYS`, which can block a large instance. Prefer `scanPage` for wide keyspaces in production maintenance unless you know the pattern is narrow.
+
+---
+
+## 2. Environment variables
+
+Validated at process startup via `validationSchema` in `src/config/env.validation.ts` (loaded by `ConfigModule` in `app.module.ts`).
+
+| Variable | Default | Required in prod | Purpose |
+|----------|---------|------------------|---------|
+| `REDIS_HOST` | `localhost` | yes (real hostname) | Redis host |
+| `REDIS_PORT` | `6379` | no | Redis port |
+| `REDIS_PASSWORD` | _(empty allowed)_ | if Redis ACL/password enabled | Auth string — **never log** |
+| `REDIS_DB` | `0` | no | Logical database index |
+| `REDIS_TTL` | `300` | no | Default TTL (seconds) for cache-manager store registration |
+| `CACHE_AUDIT_ENABLED` | `false` | no | When `true`, successful `set` / `del` / `delByPattern` emit `AuditTrailService` actions `CACHE_SET`, `CACHE_DEL`, `CACHE_INVALIDATE` |
+
+`redis.config.ts` maps `CACHE_AUDIT_ENABLED` to `cacheAuditEnabled` using the string `true` (lowercase) for parity with typical `.env` files. Joi accepts standard truthy/falsy strings and coerces to boolean for validation output; the Nest `registerAs` factory still reads `process.env` directly for this flag.
+
+---
+
+## 3. Feature flag: cache audit trail
+
+- **Enable:** set `CACHE_AUDIT_ENABLED=true`, deploy, confirm DB volume for `audit_trails` and application error rate (audit writes are best-effort; failures are logged, not thrown from cache callers).
+- **Disable:** set `CACHE_AUDIT_ENABLED=false` or unset, deploy. Cache behavior is unchanged; only audit emissions stop.
+- **Dependency:** `RedisModule` imports `AuditTrailModule`. If the audit table is unavailable, audit `log()` rejections are caught inside `RedisService`; cache operations still succeed.
+
+---
+
+## 4. Rollout & migration
+
+- **Schema:** New `AuditAction` enum string values (`CACHE_SET`, `CACHE_DEL`, `CACHE_INVALIDATE`) are stored in `audit_trails.action` (`varchar(50)`). No Alembic/TypeORM migration is required for length; existing rows are unchanged.
+- **Order of operations:** Deploy application code first (backward compatible). Then optionally enable `CACHE_AUDIT_ENABLED` per environment.
+- **Redis version:** No minimum version bump required for this runbook; follow your platform standard (e.g. Redis 6+ for TLS if used outside this repo).
+
+---
+
+## 5. Normal operations
+
+### Health check
+
+```bash
+curl -sS "https://<host>/health/redis" | jq .
+```
+
+Expect `status: "healthy"` and `redis: "connected"` when Redis and cache-manager store are reachable.
+
+### Connectivity from an app pod (read-only)
+
+```bash
+redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" ${REDIS_PASSWORD:+-a "$REDIS_PASSWORD"} PING
+```
+
+Do **not** paste `REDIS_PASSWORD` into tickets, chat, or CI logs.
+
+---
+
+## 6. Incident playbooks
+
+### 6.1 Redis down / connection refused
+
+**Symptoms:** `GET /health/redis` returns `unhealthy`, logs show `Redis connection error`, elevated `tycoon_redis_errors_total`.
+
+**Steps:**
+
+1. Confirm network policy / security group from API to Redis.
+2. Verify `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB` match the instance (use secrets manager, not logs).
+3. Restart Redis or failover per infra runbook; API degrades gracefully for some paths (e.g. cache get returns `undefined`) but features depending on strong consistency will fail.
+
+### 6.2 Elevated latency on admin cache invalidation
+
+**Symptoms:** Spikes when calling APIs that run `delByPattern` with broad patterns.
+
+**Steps:**
+
+1. Narrow invalidation patterns or move to `scanPage` + batched `del` for large keyspaces.
+2. Review slowlog on Redis during the window.
+
+### 6.3 Audit table pressure after enabling `CACHE_AUDIT_ENABLED`
+
+**Symptoms:** DB CPU up, slower requests.
+
+**Steps:**
+
+1. Turn flag off temporarily.
+2. Add retention/archival policy for `audit_trails` (product decision).
+3. Re-enable with lower traffic or async batching if introduced in a future change.
+
+---
+
+## 7. Logging & secrets
+
+- **Do not** log `REDIS_PASSWORD`, full Redis URLs with auth, or refresh token values. `RedisService` logs keys at **debug** for cache hit/miss and identifiers like `userId` for token operations — keep production `LOG_LEVEL` at `info` or higher unless troubleshooting.
+- Error messages include Redis/ioredis `message` only (no password).
+
+---
+
+## 8. Monitoring
+
+Prometheus metrics (non-exhaustive):
+
+- `tycoon_redis_operations_total{operation="..."}`
+- `tycoon_redis_errors_total`
+- `tycoon_cache_hits_total` / `tycoon_cache_misses_total`
+- `tycoon_redis_operation_duration_seconds`
+
+Alert on sustained error rate and on `health/redis` failing synthetic checks.
+
+---
+
+## 9. Rollback
+
+1. Revert or redeploy previous image.
+2. If audit volume was the issue, set `CACHE_AUDIT_ENABLED=false` without reverting code.
+3. No data migration rollback is required for audit enum strings.
+
+---
+
+## Related docs
+
+- `docs/AUTH_JWT_RUNBOOK.md` — refresh tokens also use Redis-backed flows in auth.
+- `docs/webhooks-runbook.md` — webhook idempotency uses Redis.

--- a/backend/src/config/env.validation.redis.spec.ts
+++ b/backend/src/config/env.validation.redis.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * SW-BE-007 — Redis / cache env validation regression tests.
+ * Keeps Joi defaults for REDIS_* and CACHE_AUDIT_ENABLED aligned with redis.config.ts expectations.
+ */
+import { validationSchema } from './env.validation';
+
+/** Minimal valid payload for development-shaped validation (required DB + JWT defaults). */
+function minimalDevEnv(overrides: Record<string, unknown> = {}) {
+  return {
+    NODE_ENV: 'development',
+    DB_USERNAME: 'tycoon',
+    DB_PASSWORD: 'tycoon',
+    DB_DATABASE: 'tycoon',
+    ...overrides,
+  };
+}
+
+describe('env.validation — Redis (SW-BE-007)', () => {
+  it('applies Redis defaults when vars are omitted', () => {
+    const { error, value } = validationSchema.validate(minimalDevEnv(), {
+      abortEarly: false,
+    });
+    expect(error).toBeUndefined();
+    expect(value.REDIS_HOST).toBe('localhost');
+    expect(value.REDIS_PORT).toBe(6379);
+    expect(value.REDIS_DB).toBe(0);
+    expect(value.REDIS_TTL).toBe(300);
+    expect(value.CACHE_AUDIT_ENABLED).toBe(false);
+  });
+
+  it('accepts explicit Redis connection settings', () => {
+    const { error, value } = validationSchema.validate(
+      minimalDevEnv({
+        REDIS_HOST: 'redis.internal',
+        REDIS_PORT: 6380,
+        REDIS_DB: 2,
+        REDIS_TTL: 120,
+        REDIS_PASSWORD: 'not-for-logs',
+      }),
+    );
+    expect(error).toBeUndefined();
+    expect(value.REDIS_HOST).toBe('redis.internal');
+    expect(value.REDIS_PORT).toBe(6380);
+    expect(value.REDIS_DB).toBe(2);
+    expect(value.REDIS_TTL).toBe(120);
+    expect(value.REDIS_PASSWORD).toBe('not-for-logs');
+  });
+
+  it('coerces CACHE_AUDIT_ENABLED from string true', () => {
+    const { error, value } = validationSchema.validate(
+      minimalDevEnv({ CACHE_AUDIT_ENABLED: 'true' }),
+    );
+    expect(error).toBeUndefined();
+    expect(value.CACHE_AUDIT_ENABLED).toBe(true);
+  });
+
+  it('rejects invalid REDIS_PORT', () => {
+    const { error } = validationSchema.validate(
+      minimalDevEnv({ REDIS_PORT: 'not-a-port' }),
+      { abortEarly: false },
+    );
+    expect(error).toBeDefined();
+    expect(error?.message).toMatch(/REDIS_PORT/i);
+  });
+});

--- a/backend/src/modules/audit-trail/entities/audit-trail.entity.ts
+++ b/backend/src/modules/audit-trail/entities/audit-trail.entity.ts
@@ -7,6 +7,12 @@ import {
 } from 'typeorm';
 
 export enum AuditAction {
+    /** Emitted when RedisService cache set succeeds (gated by CACHE_AUDIT_ENABLED). */
+    CACHE_SET = 'CACHE_SET',
+    /** Emitted when RedisService cache del succeeds (gated by CACHE_AUDIT_ENABLED). */
+    CACHE_DEL = 'CACHE_DEL',
+    /** Emitted when RedisService delByPattern removes one or more keys (gated by CACHE_AUDIT_ENABLED). */
+    CACHE_INVALIDATE = 'CACHE_INVALIDATE',
     USER_CREATED = 'USER_CREATED',
     USER_UPDATED = 'USER_UPDATED',
     USER_SOFT_DELETED = 'USER_SOFT_DELETED',

--- a/backend/src/modules/redis/redis-audit.service.spec.ts
+++ b/backend/src/modules/redis/redis-audit.service.spec.ts
@@ -11,6 +11,7 @@ import { ConfigService } from '@nestjs/config';
 import { RedisService } from './redis.service';
 import { AuditTrailService } from '../audit-trail/audit-trail.service';
 import { AuditAction } from '../audit-trail/entities/audit-trail.entity';
+import { LoggerService } from '../../common/logger/logger.service';
 
 // Minimal ioredis stub — only the methods RedisService actually calls
 jest.mock('ioredis', () => {
@@ -42,6 +43,14 @@ const makeConfigService = (auditEnabled: boolean) =>
 const makeAuditService = () =>
   ({ log: jest.fn().mockResolvedValue({}) }) as unknown as AuditTrailService;
 
+const makeLoggerService = () =>
+  ({
+    log: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }) as unknown as LoggerService;
+
 async function buildService(
   auditEnabled: boolean,
   auditService?: AuditTrailService,
@@ -51,6 +60,7 @@ async function buildService(
       RedisService,
       { provide: CACHE_MANAGER, useValue: makeCacheManager() },
       { provide: ConfigService, useValue: makeConfigService(auditEnabled) },
+      { provide: LoggerService, useValue: makeLoggerService() },
       ...(auditService
         ? [{ provide: AuditTrailService, useValue: auditService }]
         : []),

--- a/backend/src/modules/redis/redis.module.ts
+++ b/backend/src/modules/redis/redis.module.ts
@@ -6,6 +6,7 @@ import { RedisService } from './redis.service';
 import { IdempotencyService } from './idempotency.service';
 import { IdempotencyInterceptor } from './idempotency.interceptor';
 import { LoggerModule } from '../../common/logger/logger.module';
+import { AuditTrailModule } from '../audit-trail/audit-trail.module';
 
 @Global()
 @Module({

--- a/backend/src/modules/redis/redis.service.ts
+++ b/backend/src/modules/redis/redis.service.ts
@@ -1,14 +1,17 @@
-import { Injectable, Inject, Logger, Optional } from '@nestjs/common';
+import { Injectable, Inject, Optional } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { Counter, Gauge, Histogram } from 'prom-client';
 import Redis from 'ioredis';
 import { ConfigService } from '@nestjs/config';
 import { LoggerService } from '../../common/logger/logger.service';
+import { AuditTrailService } from '../audit-trail/audit-trail.service';
+import { AuditAction } from '../audit-trail/entities/audit-trail.entity';
 
 @Injectable()
 export class RedisService {
   private readonly logger: LoggerService;
+  private readonly auditEnabled: boolean;
   private redis: Redis;
 
   // Prometheus metrics
@@ -23,6 +26,7 @@ export class RedisService {
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private configService: ConfigService,
     loggerService: LoggerService,
+    @Optional() private readonly auditTrailService?: AuditTrailService,
   ) {
     this.logger = loggerService;
 
@@ -36,7 +40,7 @@ export class RedisService {
     if (!redisConfig) {
       throw new Error('Redis configuration not found');
     }
-    this.auditEnabled = redisConfig.cacheAuditEnabled ?? false;
+    this.auditEnabled = redisConfig.cacheAuditEnabled === true;
     this.redis = new Redis({
       host: redisConfig.host,
       port: redisConfig.port,
@@ -208,6 +212,10 @@ export class RedisService {
       await this.cacheManager.set(key, value, ttl);
       this.redisOperationsTotal.inc({ operation: 'cache_set' });
       this.logger.debug(`Cache SET: ${key}`, 'RedisService');
+      this.emitAudit(AuditAction.CACHE_SET, {
+        key,
+        ...(ttl !== undefined ? { ttl } : {}),
+      });
     } catch (error: any) {
       this.redisErrorsTotal.inc({ operation: 'cache_set' });
       this.logger.error(`Cache SET error for ${key}: ${error.message}`, 'RedisService');
@@ -223,6 +231,7 @@ export class RedisService {
       await this.cacheManager.del(key);
       this.redisOperationsTotal.inc({ operation: 'cache_del' });
       this.logger.debug(`Cache DEL: ${key}`, 'RedisService');
+      this.emitAudit(AuditAction.CACHE_DEL, { key });
     } catch (error: any) {
       this.redisErrorsTotal.inc({ operation: 'cache_del' });
       this.logger.error(`Cache DEL error for ${key}: ${error.message}`, 'RedisService');


### PR DESCRIPTION
## Stellar Wave · SW-BE-007

Improves the NestJS Redis/cache layer with an **operational runbook** and small, backward-compatible code + test updates.

### Summary
- New runbook: `backend/docs/REDIS_CACHE_RUNBOOK.md` (env, health, incidents, metrics, logging / secrets).
- `RedisService` cache audit events (`CACHE_SET`, `CACHE_DEL`, `CACHE_INVALIDATE`) when `CACHE_AUDIT_ENABLED=true`; optional `AuditTrailService`; `RedisModule` imports `AuditTrailModule`.
- `AuditAction` enum extended with cache-related values (string storage only).
- Jest: `env.validation.redis.spec.ts` (Redis-related Joi regression); `redis-audit.service.spec.ts` updated with `LoggerService` mock.

### Rollout / feature flag
1. Deploy application (no env change required).
2. Optionally set `CACHE_AUDIT_ENABLED=true` per environment to emit cache audit rows; default remains off.
3. Monitor DB load on `audit_trails` if enabling in high-traffic envs.

### Migration
- **No schema migration** required: new `AuditAction` values fit existing `varchar(50)` `action` column.

### CI
- Run backend tests (e.g. affected specs: `redis-audit`, `env.validation.redis`, `redis.service.spec`).
- Full `nest build` may still report **pre-existing** errors in `src/modules/uploads/idempotency/` (unchanged in this PR).

### References
- Stellar Wave — Backend  
- Issue / ticket: **SW-BE-007**

closes #583 