### PR TITLE
fix(frontend): SW-FE-001 landing hero — accessibility and focus order

### DIFF
--- a/frontend/docs/SW-FE-001-landing-hero-rollout.md
+++ b/frontend/docs/SW-FE-001-landing-hero-rollout.md
@@ -1,22 +1,43 @@
-# SW-FE-001 - Landing Hero CLS/LCP Rollout
-This change is part of the Stellar Wave frontend batch and targets home page hero performance.
+# SW-FE-001 - Landing Hero Rollout
+This change is part of the Stellar Wave frontend batch and targets home page hero performance and accessibility.
+
 ## Scope
 - Eager render the above-the-fold hero on `/`.
 - Defer below-the-fold sections with lightweight placeholders.
 - Stabilize animated hero copy to reduce layout movement.
+- **Accessibility (SW-FE-001):** Fix heading hierarchy, landmark labels, button names, and decorative element hiding in `HeroSection`.
+
+## Accessibility Changes
+| Issue | Fix |
+|---|---|
+| Two `<h1>` elements (decorative bg + real title) | Decorative bg `<h1>` changed to `<p>` with `aria-hidden="true"` |
+| `<section>` had no accessible name | Added `aria-label="Hero"` |
+| Buttons had no accessible names | Added `aria-label` to all 4 CTA buttons |
+| Decorative background `<div>` exposed to AT | Added `aria-hidden="true"` |
+| Decorative SVG shapes inside buttons exposed to AT | Added `aria-hidden="true"` on each `<svg>` |
+| Decorative inner `<span>` labels inside buttons | Added `aria-hidden="true"` (button `aria-label` carries the name) |
+| Decorative `?` span in title | Added `aria-hidden="true"` |
+
+Focus order is now: section landmark → welcome text → animated tagline → `<h1>` title → description → CTA buttons (top to bottom). No focusable decorative elements remain in the tab sequence.
+
 ## Feature Flag Plan
 No runtime flag is added in this patch to keep bundle/runtime complexity low.
 Use a staged rollout instead:
 1. Deploy to preview and compare Core Web Vitals (LCP/CLS) vs baseline.
 2. Deploy to a low-traffic environment first (internal/canary).
 3. Promote to full production once no regressions are observed.
-If rollback is needed, revert this single patch set touching `HomeClient` and hero components.
+
+If rollback is needed, revert this single patch set touching `HeroSection` and its test file.
+
 ## Migration Notes
 - No API changes.
 - No schema/data migration.
 - No user action required.
+- `HeroSectionMobile` already had correct `aria-label` attributes; no changes needed there.
+
 ## Verification Checklist
 - `npm run typecheck`
 - `npm run test`
 - Confirm home route renders primary CTA and title immediately on first paint.
+- Verify with a screen reader (or axe DevTools) that only one `h1` is announced and all buttons have meaningful names.
 - Monitor LCP and CLS in production telemetry after deploy.

--- a/frontend/src/components/guest/HeroSection.tsx
+++ b/frontend/src/components/guest/HeroSection.tsx
@@ -36,20 +36,24 @@ const HeroSection: React.FC = () => {
   }
 
   return (
-    <section className="z-0 w-full lg:h-screen md:h-[calc(100vh-87px)] h-screen relative overflow-x-hidden md:mb-20 mb-10 bg-[#010F10]">
+    <section
+      aria-label="Hero"
+      className="z-0 w-full lg:h-screen md:h-[calc(100vh-87px)] h-screen relative overflow-x-hidden md:mb-20 mb-10 bg-[#010F10]"
+    >
       {/* Background gradient */}
       <div
+        aria-hidden="true"
         className="w-full h-full overflow-hidden bg-cover bg-center"
         style={{
           background: "linear-gradient(135deg, #010F10 0%, #0a2a2d 50%, #010F10 100%)",
         }}
       />
 
-      {/* Large Background TYCOON Text */}
-      <div className="w-full h-auto absolute top-0 left-0 flex items-center justify-center">
-        <h1 className="text-center uppercase font-kronaOne font-normal text-transparent big-hero-text w-full text-[40px] sm:text-[40px] md:text-[80px] lg:text-[135px] relative before:absolute before:content-[''] before:w-full before:h-full before:bg-gradient-to-b before:from-transparent lg:before:via-[#010F10]/80 before:to-[#010F10] before:top-0 before:left-0 before:z-1">
+      {/* Large Background TYCOON Text — decorative only */}
+      <div aria-hidden="true" className="w-full h-auto absolute top-0 left-0 flex items-center justify-center">
+        <p className="text-center uppercase font-kronaOne font-normal text-transparent big-hero-text w-full text-[40px] sm:text-[40px] md:text-[80px] lg:text-[135px] relative before:absolute before:content-[''] before:w-full before:h-full before:bg-gradient-to-b before:from-transparent lg:before:via-[#010F10]/80 before:to-[#010F10] before:top-0 before:left-0 before:z-1">
           TYCOON
-        </h1>
+        </p>
       </div>
 
       <div className="absolute left-0 top-0 z-2 flex h-full w-full flex-col items-center gap-1 bg-transparent lg:justify-center">
@@ -85,13 +89,16 @@ const HeroSection: React.FC = () => {
           />
         </div>
 
-        {/* Main Title */}
+        {/* Main Title — single h1 on this page */}
         <h1
           data-testid="hero-main-title"
           className="block-text font-[900] font-orbitron lg:text-[116px] md:text-[98px] text-[54px] lg:leading-[120px] md:leading-[100px] leading-[60px] tracking-[-0.02em] uppercase text-[#17ffff] relative"
         >
           TYCOON
-          <span className={`absolute top-0 left-[69%] text-[#0FF0FC] font-dmSans font-[700] md:text-[27px] text-[18px] rotate-12 ${!prefersReducedMotion ? "animate-pulse" : ""}`}>
+          <span
+            aria-hidden="true"
+            className={`absolute top-0 left-[69%] text-[#0FF0FC] font-dmSans font-[700] md:text-[27px] text-[18px] rotate-12 ${!prefersReducedMotion ? "animate-pulse" : ""}`}
+          >
             ?
           </span>
         </h1>
@@ -132,10 +139,12 @@ const HeroSection: React.FC = () => {
           {/* Continue Game */}
           <button
             data-testid="hero-primary-cta"
+            aria-label="Continue game"
             onClick={() => handleTrackedNavigation("continue_game_click", "/game-settings")}
             className="relative group w-[300px] h-[56px] bg-transparent border-none p-0 overflow-hidden cursor-pointer transition-transform group-hover:scale-105"
           >
             <svg
+              aria-hidden="true"
               width="300"
               height="56"
               viewBox="0 0 300 56"
@@ -150,7 +159,7 @@ const HeroSection: React.FC = () => {
                 strokeWidth={2}
               />
             </svg>
-            <span className="absolute inset-0 flex items-center justify-center text-[#010F10] text-[20px] font-orbitron font-[700] z-2">
+            <span aria-hidden="true" className="absolute inset-0 flex items-center justify-center text-[#010F10] text-[20px] font-orbitron font-[700] z-2">
               <Gamepad2 className="mr-2 w-7 h-7" />
               Continue Game
             </span>
@@ -158,10 +167,12 @@ const HeroSection: React.FC = () => {
 
           {/* Multiplayer */}
           <button
+            aria-label="Multiplayer"
             onClick={() => handleTrackedNavigation("multiplayer_click", "/game-settings")}
             className="relative group w-[227px] h-[40px] bg-transparent border-none p-0 overflow-hidden cursor-pointer"
           >
             <svg
+              aria-hidden="true"
               width="227"
               height="40"
               viewBox="0 0 227 40"
@@ -177,7 +188,7 @@ const HeroSection: React.FC = () => {
                 className={`${!prefersReducedMotion ? "group-hover:stroke-[#00F0FF] transition-all duration-300" : ""}`}
               />
             </svg>
-            <span className="absolute inset-0 flex items-center justify-center text-[#00F0FF] capitalize text-[12px] font-dmSans font-medium z-2">
+            <span aria-hidden="true" className="absolute inset-0 flex items-center justify-center text-[#00F0FF] capitalize text-[12px] font-dmSans font-medium z-2">
               <Gamepad2 className="mr-1.5 w-[16px] h-[16px]" />
               Multiplayer
             </span>
@@ -185,10 +196,12 @@ const HeroSection: React.FC = () => {
 
           {/* Join Room */}
           <button
+            aria-label="Join room"
             onClick={() => handleTrackedNavigation("join_room_click", "/join-room")}
             className="relative group w-[140px] h-[40px] bg-transparent border-none p-0 overflow-hidden cursor-pointer"
           >
             <svg
+              aria-hidden="true"
               width="140"
               height="40"
               viewBox="0 0 140 40"
@@ -204,7 +217,7 @@ const HeroSection: React.FC = () => {
                 className={`${!prefersReducedMotion ? "group-hover:stroke-[#00F0FF] transition-all duration-300" : ""}`}
               />
             </svg>
-            <span className="absolute inset-0 flex items-center justify-center text-[#0FF0FC] capitalize text-[12px] font-dmSans font-medium z-2">
+            <span aria-hidden="true" className="absolute inset-0 flex items-center justify-center text-[#0FF0FC] capitalize text-[12px] font-dmSans font-medium z-2">
               <Dices className="mr-1.5 w-[16px] h-[16px]" />
               Join Room
             </span>
@@ -212,10 +225,12 @@ const HeroSection: React.FC = () => {
 
           {/* Challenge AI */}
           <button
+            aria-label="Challenge AI"
             onClick={() => handleTrackedNavigation("play_ai_click", "/play-ai")}
             className="relative group w-[260px] h-[52px] bg-transparent border-none p-0 overflow-hidden cursor-pointer transition-transform duration-300 group-hover:scale-105"
           >
             <svg
+              aria-hidden="true"
               width="260"
               height="52"
               viewBox="0 0 260 52"
@@ -230,7 +245,7 @@ const HeroSection: React.FC = () => {
                 strokeWidth={1}
               />
             </svg>
-            <span className="absolute inset-0 flex items-center justify-center text-[#010F10] uppercase text-[16px] -tracking-[2%] font-orbitron font-[700] z-2">
+            <span aria-hidden="true" className="absolute inset-0 flex items-center justify-center text-[#010F10] uppercase text-[16px] -tracking-[2%] font-orbitron font-[700] z-2">
               Challenge AI!
             </span>
           </button>

--- a/frontend/test/HeroSection.performance.test.tsx
+++ b/frontend/test/HeroSection.performance.test.tsx
@@ -47,3 +47,39 @@ describe("HeroSection performance guardrails", () => {
   });
 });
 
+describe("HeroSection accessibility", () => {
+  beforeEach(() => {
+    animationProps.length = 0;
+    mockPush.mockClear();
+    mockTrack.mockClear();
+  });
+
+  it("has a single h1 in the hero section", () => {
+    render(<HeroSection />);
+    const headings = document.querySelectorAll("h1");
+    expect(headings).toHaveLength(1);
+  });
+
+  it("section has aria-label", () => {
+    render(<HeroSection />);
+    expect(screen.getByRole("region", { name: "Hero" })).toBeInTheDocument();
+  });
+
+  it("all CTA buttons have accessible names", () => {
+    render(<HeroSection />);
+    const buttons = screen.getAllByRole("button");
+    for (const btn of buttons) {
+      expect(btn).toHaveAttribute("aria-label");
+    }
+  });
+
+  it("decorative background elements are hidden from assistive technology", () => {
+    const { container } = render(<HeroSection />);
+    // The decorative wrapper div (background gradient) must be aria-hidden
+    const decorativeBg = container.querySelector<HTMLElement>(
+      "section > div[aria-hidden='true']",
+    );
+    expect(decorativeBg).not.toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Stellar Wave · SW-FE-001

Closes #506

### What changed
- `<section>` gets `aria-label="Hero"` (landmark now has an accessible name)
- Decorative background `<h1>` replaced with `<p aria-hidden="true">` — page now has a single `<h1>`
- Decorative background `<div>`, all button `<svg>` shapes, inner `<span>` labels, and the `?` span all get `aria-hidden="true"`
- All 4 CTA buttons get explicit `aria-label` (`Continue game`, `Multiplayer`, `Join room`, `Challenge AI`)
- Focus order: section landmark → welcome text → animated tagline → `<h1>` → description → CTAs (top-to-bottom DOM order, no decorative stops)

### Tests
Added `HeroSection accessibility` describe block in `HeroSection.performance.test.tsx`:
- single `<h1>` in hero
- section has `role="region"` with name `"Hero"`
- all buttons have `aria-label`
- decorative background is `aria-hidden`

### Rollout / migration
No feature flag, no API/schema changes. See `frontend/docs/SW-FE-001-landing-hero-rollout.md` for staged rollout steps and verification checklist.

### Checklist
- [ ] `npm run typecheck`
- [ ] `npm run test`