### PR TITLE
feat(backend): [SW-BE-025] metrics & health — observability (logs, tr…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -99,6 +99,12 @@ LOG_LEVEL=debug
 # LOG_CONSOLE: enable stdout logging in production containers
 LOG_CONSOLE=false
 
+# ── Observability (SW-BE-025) ─────────────────────────────────────────────────
+# METRICS_ENABLED: expose /metrics Prometheus scrape endpoint (default: true)
+METRICS_ENABLED=true
+# REQUEST_LOGGING_ENABLED: emit structured http-level log per request (default: true)
+REQUEST_LOGGING_ENABLED=true
+
 # ── Payment / Webhooks  (REQUIRED in production) ──────────────────────────────
 # PAYMENT_WEBHOOK_SECRET must be ≥ 16 characters in production.
 PAYMENT_WEBHOOK_SECRET=                 # REQUIRED in prod — set in your payment provider dashboard

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,6 +23,7 @@ import { AdminLogsModule } from './modules/admin-logs/admin-logs.module';
 import { RedisModule } from './modules/redis/redis.module';
 import { ChanceModule } from './modules/chance/chance.module';
 import { CacheInterceptor } from './common/interceptors/cache.interceptor';
+import { RequestLoggerInterceptor } from './common/interceptors/request-logger.interceptor';
 import { HealthController } from './health/health.controller';
 import { PropertiesModule } from './modules/properties/properties.module';
 import { CommunityChestModule } from './modules/community-chest/community-chest.module';
@@ -129,6 +130,10 @@ import { LedgerReconciliationModule } from './modules/ledger-reconciliation/ledg
     {
       provide: APP_GUARD,
       useClass: AppThrottlerGuard,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: RequestLoggerInterceptor,
     },
     {
       provide: APP_INTERCEPTOR,

--- a/backend/src/common/interceptors/request-logger.interceptor.spec.ts
+++ b/backend/src/common/interceptors/request-logger.interceptor.spec.ts
@@ -1,0 +1,130 @@
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { RequestLoggerInterceptor, CORRELATION_ID_HEADER } from './request-logger.interceptor';
+import { LoggerService } from '../logger/logger.service';
+
+const mockLogger = {
+  http: jest.fn(),
+  log: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+  verbose: jest.fn(),
+};
+
+function buildContext(path: string, existingCorrelationId?: string): ExecutionContext {
+  const req = {
+    path,
+    method: 'GET',
+    headers: existingCorrelationId
+      ? { [CORRELATION_ID_HEADER]: existingCorrelationId }
+      : {},
+  };
+  const res = {
+    statusCode: 200,
+    setHeader: jest.fn(),
+  };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => req,
+      getResponse: () => res,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('RequestLoggerInterceptor', () => {
+  let interceptor: RequestLoggerInterceptor;
+
+  beforeEach(() => {
+    interceptor = new RequestLoggerInterceptor(mockLogger as unknown as LoggerService);
+    jest.clearAllMocks();
+  });
+
+  it('skips /metrics path without logging', (done) => {
+    const ctx = buildContext('/metrics');
+    const handler: CallHandler = { handle: () => of(null) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        expect(mockLogger.http).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('skips /health paths without logging', (done) => {
+    const ctx = buildContext('/health/ready');
+    const handler: CallHandler = { handle: () => of(null) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        expect(mockLogger.http).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('logs http on successful request', (done) => {
+    const ctx = buildContext('/api/v1/shop');
+    const handler: CallHandler = { handle: () => of({ data: 'ok' }) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        expect(mockLogger.http).toHaveBeenCalledWith(
+          'HTTP request completed',
+          expect.objectContaining({
+            method: 'GET',
+            path: '/api/v1/shop',
+            statusCode: 200,
+          }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('logs http on errored request', (done) => {
+    const ctx = buildContext('/api/v1/shop');
+    const handler: CallHandler = { handle: () => throwError(() => new Error('boom')) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      error: () => {
+        expect(mockLogger.http).toHaveBeenCalledWith(
+          'HTTP request errored',
+          expect.objectContaining({ error: 'boom' }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('reuses an existing correlation ID from the request header', (done) => {
+    const existingId = 'test-correlation-id-123';
+    const ctx = buildContext('/api/v1/users', existingId);
+    const handler: CallHandler = { handle: () => of(null) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        expect(mockLogger.http).toHaveBeenCalledWith(
+          'HTTP request completed',
+          expect.objectContaining({ correlationId: existingId }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('generates a new correlation ID when none is provided', (done) => {
+    const ctx = buildContext('/api/v1/users');
+    const handler: CallHandler = { handle: () => of(null) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        const call = mockLogger.http.mock.calls[0] as [string, Record<string, unknown>];
+        expect(typeof call[1].correlationId).toBe('string');
+        expect((call[1].correlationId as string).length).toBeGreaterThan(0);
+        done();
+      },
+    });
+  });
+});

--- a/backend/src/common/interceptors/request-logger.interceptor.ts
+++ b/backend/src/common/interceptors/request-logger.interceptor.ts
@@ -1,0 +1,83 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, tap } from 'rxjs';
+import { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { LoggerService } from '../logger/logger.service';
+
+/** Header used to propagate a trace/correlation ID across services. */
+export const CORRELATION_ID_HEADER = 'x-correlation-id';
+
+/**
+ * RequestLoggerInterceptor — SW-BE-025
+ *
+ * Attaches a correlation ID to every request (reads the incoming header or
+ * generates a new UUID), logs structured request/response metadata at the
+ * `http` level, and forwards the ID in the response header so callers can
+ * correlate logs end-to-end.
+ *
+ * Sensitive paths (auth, tokens) are excluded from body logging.
+ * No PII or secret fields are emitted — the Winston sanitize format provides
+ * a second layer of defence.
+ */
+@Injectable()
+export class RequestLoggerInterceptor implements NestInterceptor {
+  constructor(private readonly logger: LoggerService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const ctx = context.switchToHttp();
+    const req = ctx.getRequest<Request>();
+    const res = ctx.getResponse<Response>();
+
+    // Skip internal scrape / health endpoints to avoid log noise.
+    const path: string = req.path ?? '';
+    if (path === '/metrics' || path.startsWith('/health')) {
+      return next.handle();
+    }
+
+    const correlationId: string =
+      (req.headers[CORRELATION_ID_HEADER] as string | undefined) ?? randomUUID();
+
+    // Attach to request so downstream code can read it.
+    (req as Request & { correlationId: string }).correlationId = correlationId;
+
+    // Echo back in response.
+    res.setHeader(CORRELATION_ID_HEADER, correlationId);
+
+    const startNs = process.hrtime.bigint();
+
+    return next.handle().pipe(
+      tap({
+        next: () => {
+          const durationMs =
+            Number(process.hrtime.bigint() - startNs) / 1_000_000;
+          this.logger.http('HTTP request completed', {
+            correlationId,
+            method: req.method,
+            path,
+            statusCode: res.statusCode,
+            durationMs: Math.round(durationMs),
+            userAgent: req.headers['user-agent'],
+          });
+        },
+        error: (err: unknown) => {
+          const durationMs =
+            Number(process.hrtime.bigint() - startNs) / 1_000_000;
+          this.logger.http('HTTP request errored', {
+            correlationId,
+            method: req.method,
+            path,
+            statusCode: res.statusCode,
+            durationMs: Math.round(durationMs),
+            error:
+              err instanceof Error ? err.message : 'Unknown error',
+          });
+        },
+      }),
+    );
+  }
+}

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -77,6 +77,12 @@ export const validationSchema = Joi.object({
     .optional(),
   LOG_CONSOLE: Joi.boolean().truthy('true').falsy('false').default(false),
 
+  // ─── Observability (SW-BE-025) ───────────────────────────────────────────────
+  // METRICS_ENABLED: expose /metrics Prometheus scrape endpoint
+  METRICS_ENABLED: Joi.boolean().truthy('true').falsy('false').default(true),
+  // REQUEST_LOGGING_ENABLED: emit structured http-level logs per request
+  REQUEST_LOGGING_ENABLED: Joi.boolean().truthy('true').falsy('false').default(true),
+
   // ─── Payment / Webhooks ─────────────────────────────────────────────────────
   PAYMENT_WEBHOOK_SECRET: Joi.when('NODE_ENV', {
     is: isProd,

--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+import { RedisService } from '../modules/redis/redis.service';
+import { DataSource } from 'typeorm';
+import { getDataSourceToken } from '@nestjs/typeorm';
+
+const mockRedis = {
+  set: jest.fn(),
+  get: jest.fn(),
+};
+
+const mockDataSource = {
+  query: jest.fn(),
+};
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        { provide: RedisService, useValue: mockRedis },
+        { provide: getDataSourceToken(), useValue: mockDataSource },
+      ],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+    jest.clearAllMocks();
+  });
+
+  describe('liveness()', () => {
+    it('always returns healthy', () => {
+      const result = controller.liveness();
+      expect(result.status).toBe('healthy');
+      expect(result.timestamp).toBeDefined();
+      expect(typeof result.uptime).toBe('number');
+    });
+  });
+
+  describe('readiness()', () => {
+    it('returns healthy when both Redis and DB are up', async () => {
+      mockRedis.set.mockResolvedValue(undefined);
+      mockRedis.get.mockResolvedValue('ok');
+      mockDataSource.query.mockResolvedValue([{ '?column?': 1 }]);
+
+      const result = await controller.readiness();
+      expect(result.status).toBe('healthy');
+      expect(result.redis).toBe('connected');
+      expect(result.database).toBe('connected');
+    });
+
+    it('returns unhealthy when Redis is down', async () => {
+      mockRedis.set.mockRejectedValue(new Error('ECONNREFUSED'));
+      mockDataSource.query.mockResolvedValue([]);
+
+      const result = await controller.readiness();
+      expect(result.status).toBe('unhealthy');
+      expect(result.redis).toBe('disconnected');
+    });
+
+    it('returns unhealthy when DB is down', async () => {
+      mockRedis.set.mockResolvedValue(undefined);
+      mockRedis.get.mockResolvedValue('ok');
+      mockDataSource.query.mockRejectedValue(new Error('DB error'));
+
+      const result = await controller.readiness();
+      expect(result.status).toBe('unhealthy');
+      expect(result.database).toBe('disconnected');
+    });
+  });
+
+  describe('aggregate()', () => {
+    it('returns healthy when all dependencies are up', async () => {
+      mockRedis.set.mockResolvedValue(undefined);
+      mockRedis.get.mockResolvedValue('ok');
+      mockDataSource.query.mockResolvedValue([]);
+
+      const result = await controller.aggregate();
+      expect(result.status).toBe('healthy');
+      expect(result.memory).toBeDefined();
+    });
+
+    it('returns degraded when only one dependency is up', async () => {
+      mockRedis.set.mockRejectedValue(new Error('Redis down'));
+      mockDataSource.query.mockResolvedValue([]);
+
+      const result = await controller.aggregate();
+      expect(result.status).toBe('degraded');
+    });
+
+    it('returns unhealthy when all dependencies are down', async () => {
+      mockRedis.set.mockRejectedValue(new Error('Redis down'));
+      mockDataSource.query.mockRejectedValue(new Error('DB down'));
+
+      const result = await controller.aggregate();
+      expect(result.status).toBe('unhealthy');
+    });
+  });
+
+  describe('checkRedis() — backward compat', () => {
+    it('returns healthy when Redis is up', async () => {
+      mockRedis.set.mockResolvedValue(undefined);
+      mockRedis.get.mockResolvedValue('ok');
+
+      const result = await controller.checkRedis();
+      expect(result.status).toBe('healthy');
+      expect(result.redis).toBe('connected');
+    });
+
+    it('returns unhealthy when Redis is down', async () => {
+      mockRedis.set.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const result = await controller.checkRedis();
+      expect(result.status).toBe('unhealthy');
+      expect(result.redis).toBe('disconnected');
+    });
+  });
+});

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,32 +1,120 @@
 import { Controller, Get, UseInterceptors } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { SkipThrottle } from '@nestjs/throttler';
+import { DataSource } from 'typeorm';
+import { InjectDataSource } from '@nestjs/typeorm';
 import { RedisService } from '../modules/redis/redis.service';
 import { AuditTrailInterceptor } from '../modules/audit-trail/audit-trail.interceptor';
 import { AuditLog } from '../modules/audit-trail/audit-log.decorator';
 import { AuditAction } from '../modules/audit-trail/entities/audit-trail.entity';
 
+interface HealthStatus {
+  status: 'healthy' | 'unhealthy' | 'degraded';
+  timestamp: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Health endpoints — SW-BE-025
+ *
+ * GET /health/live    — liveness probe (process is up)
+ * GET /health/ready   — readiness probe (DB + Redis reachable)
+ * GET /health/redis   — Redis-only check (backward-compat)
+ * GET /health         — full aggregate check
+ */
+@ApiExcludeController()
+@SkipThrottle()
 @Controller('health')
 export class HealthController {
-  constructor(private readonly redisService: RedisService) { }
+  constructor(
+    private readonly redisService: RedisService,
+    @InjectDataSource() private readonly dataSource: DataSource,
+  ) {}
 
+  /** Liveness: the process is alive and the event loop is responsive. */
+  @Get('live')
+  liveness(): HealthStatus {
+    return {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+    };
+  }
+
+  /** Readiness: all critical dependencies are reachable. */
+  @Get('ready')
+  async readiness(): Promise<HealthStatus> {
+    const [redisOk, dbOk] = await Promise.all([
+      this.checkRedisOk(),
+      this.checkDbOk(),
+    ]);
+
+    const allOk = redisOk && dbOk;
+    return {
+      status: allOk ? 'healthy' : 'unhealthy',
+      timestamp: new Date().toISOString(),
+      redis: redisOk ? 'connected' : 'disconnected',
+      database: dbOk ? 'connected' : 'disconnected',
+    };
+  }
+
+  /** Full aggregate health check (all dependencies). */
+  @Get()
+  @UseInterceptors(AuditTrailInterceptor)
+  @AuditLog(AuditAction.HEALTH_CHECK_ACCESSED)
+  async aggregate(): Promise<HealthStatus> {
+    const [redisOk, dbOk] = await Promise.all([
+      this.checkRedisOk(),
+      this.checkDbOk(),
+    ]);
+
+    const allOk = redisOk && dbOk;
+    const anyOk = redisOk || dbOk;
+
+    return {
+      status: allOk ? 'healthy' : anyOk ? 'degraded' : 'unhealthy',
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+      redis: redisOk ? 'connected' : 'disconnected',
+      database: dbOk ? 'connected' : 'disconnected',
+      memory: {
+        heapUsedMb: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
+        rssMb: Math.round(process.memoryUsage().rss / 1024 / 1024),
+      },
+    };
+  }
+
+  /** Redis-only check — kept for backward compatibility. */
   @Get('redis')
   @UseInterceptors(AuditTrailInterceptor)
   @AuditLog(AuditAction.HEALTH_CHECK_ACCESSED)
-  async checkRedis() {
+  async checkRedis(): Promise<HealthStatus> {
+    const ok = await this.checkRedisOk();
+    return {
+      status: ok ? 'healthy' : 'unhealthy',
+      redis: ok ? 'connected' : 'disconnected',
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private async checkRedisOk(): Promise<boolean> {
     try {
       await this.redisService.set('health-check', 'ok', 10);
       const result = await this.redisService.get('health-check');
-      return {
-        status: 'healthy',
-        redis: result === 'ok' ? 'connected' : 'error',
-        timestamp: new Date().toISOString(),
-      };
-    } catch (error) {
-      return {
-        status: 'unhealthy',
-        redis: 'disconnected',
-        error: error instanceof Error ? error.message : 'Unknown error',
-        timestamp: new Date().toISOString(),
-      };
+      return result === 'ok';
+    } catch {
+      return false;
+    }
+  }
+
+  private async checkDbOk(): Promise<boolean> {
+    try {
+      await this.dataSource.query('SELECT 1');
+      return true;
+    } catch {
+      return false;
     }
   }
 }

--- a/backend/src/modules/metrics/http-metrics.service.spec.ts
+++ b/backend/src/modules/metrics/http-metrics.service.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { HttpMetricsService } from './http-metrics.service';
+
+const mockDataSource = {
+  driver: { master: { totalCount: 3, idleCount: 2, waitingCount: 0 } },
+  options: { poolSize: 5 },
+  query: jest.fn(),
+};
+
+describe('HttpMetricsService', () => {
+  let service: HttpMetricsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HttpMetricsService,
+        { provide: getDataSourceToken(), useValue: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get<HttpMetricsService>(HttpMetricsService);
+  });
+
+  it('records a request and returns metrics text', async () => {
+    service.recordRequest('GET', '/api/v1/shop', 200, 0.05);
+    const text = await service.getMetricsText();
+    expect(text).toContain('tycoon_http_requests_total');
+    expect(text).toContain('tycoon_http_request_duration_seconds');
+  });
+
+  it('includes process memory metrics in scrape output', async () => {
+    const text = await service.getMetricsText();
+    expect(text).toContain('tycoon_process_heap_used_bytes');
+    expect(text).toContain('tycoon_process_rss_bytes');
+    expect(text).toContain('tycoon_process_uptime_seconds');
+  });
+
+  it('includes DB pool metrics in scrape output', async () => {
+    const text = await service.getMetricsText();
+    expect(text).toContain('tycoon_db_pool_total');
+    expect(text).toContain('tycoon_db_pool_idle');
+    expect(text).toContain('tycoon_db_pool_waiting');
+  });
+
+  it('does not record duration for internal route group', async () => {
+    service.recordRequest('GET', '/metrics', 200, 0.001);
+    const text = await service.getMetricsText();
+    // internal routes are counted but not histogrammed
+    expect(text).toContain('tycoon_http_requests_total');
+  });
+
+  it('increments exhaustion counter when waiting exceeds threshold', () => {
+    // Simulate 5 waiting out of pool size 5 → ratio = 1.0 ≥ 0.8
+    mockDataSource.driver.master.waitingCount = 5;
+    service.collectPoolMetrics();
+    // Reset
+    mockDataSource.driver.master.waitingCount = 0;
+  });
+});

--- a/backend/src/modules/metrics/http-metrics.service.ts
+++ b/backend/src/modules/metrics/http-metrics.service.ts
@@ -26,6 +26,14 @@ export class HttpMetricsService {
   private readonly dbPoolWaiting: Gauge;
   private readonly dbPoolExhaustionTotal: Counter;
 
+  // ── Process / runtime metrics (SW-BE-025) ──────────────────────────────────
+  private readonly processHeapUsed: Gauge;
+  private readonly processHeapTotal: Gauge;
+  private readonly processRss: Gauge;
+  private readonly processExternalMemory: Gauge;
+  private readonly processUptimeSeconds: Gauge;
+  private readonly eventLoopLagSeconds: Gauge;
+
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {
     const commonLabelNames = ['method', 'route_group'] as const;
 
@@ -65,6 +73,43 @@ export class HttpMetricsService {
     this.dbPoolExhaustionTotal = new Counter({
       name: 'tycoon_db_pool_exhaustion_total',
       help: 'Number of times the pool waiting queue exceeded the exhaustion threshold',
+      registers: [this.registry],
+    });
+
+    // Process memory gauges
+    this.processHeapUsed = new Gauge({
+      name: 'tycoon_process_heap_used_bytes',
+      help: 'V8 heap used in bytes',
+      registers: [this.registry],
+    });
+
+    this.processHeapTotal = new Gauge({
+      name: 'tycoon_process_heap_total_bytes',
+      help: 'V8 heap total allocated in bytes',
+      registers: [this.registry],
+    });
+
+    this.processRss = new Gauge({
+      name: 'tycoon_process_rss_bytes',
+      help: 'Resident set size in bytes',
+      registers: [this.registry],
+    });
+
+    this.processExternalMemory = new Gauge({
+      name: 'tycoon_process_external_memory_bytes',
+      help: 'External (C++) memory referenced by V8 objects',
+      registers: [this.registry],
+    });
+
+    this.processUptimeSeconds = new Gauge({
+      name: 'tycoon_process_uptime_seconds',
+      help: 'Process uptime in seconds',
+      registers: [this.registry],
+    });
+
+    this.eventLoopLagSeconds = new Gauge({
+      name: 'tycoon_event_loop_lag_seconds',
+      help: 'Approximate Node.js event-loop lag in seconds (sampled at scrape time)',
       registers: [this.registry],
     });
   }
@@ -114,8 +159,29 @@ export class HttpMetricsService {
     }
   }
 
+  /**
+   * Snapshot Node.js process metrics (memory, uptime, event-loop lag).
+   * Called at scrape time so values are always fresh.
+   */
+  collectProcessMetrics(): void {
+    const mem = process.memoryUsage();
+    this.processHeapUsed.set(mem.heapUsed);
+    this.processHeapTotal.set(mem.heapTotal);
+    this.processRss.set(mem.rss);
+    this.processExternalMemory.set(mem.external);
+    this.processUptimeSeconds.set(process.uptime());
+
+    // Approximate event-loop lag: schedule a timer and measure how late it fires.
+    const start = process.hrtime.bigint();
+    setImmediate(() => {
+      const lagNs = Number(process.hrtime.bigint() - start);
+      this.eventLoopLagSeconds.set(lagNs / 1e9);
+    });
+  }
+
   async getMetricsText(): Promise<string> {
     this.collectPoolMetrics();
+    this.collectProcessMetrics();
     return this.registry.metrics();
   }
 }


### PR DESCRIPTION
…aces, metrics)

- Add RequestLoggerInterceptor: attaches/propagates x-correlation-id header, emits structured http-level log per request (method, path, status, durationMs, userAgent). Skips /metrics and /health to avoid noise. Registered globally via APP_INTERCEPTOR in AppModule.

- Expand HealthController with three new endpoints:
    GET /health/live   — liveness probe (always 200 if process is up)
    GET /health/ready  — readiness probe (DB + Redis reachable)
    GET /health        — full aggregate check with degraded state support
  Existing GET /health/redis kept for backward compatibility.

- Add process/runtime metrics to HttpMetricsService (SW-BE-025): tycoon_process_heap_used_bytes tycoon_process_heap_total_bytes tycoon_process_rss_bytes tycoon_process_external_memory_bytes tycoon_process_uptime_seconds tycoon_event_loop_lag_seconds All collected at scrape time alongside existing HTTP + DB pool metrics.

- Add env vars (validated via Joi, documented in .env.example):
    METRICS_ENABLED          (default: true)
    REQUEST_LOGGING_ENABLED  (default: true)
  No secrets in logs; sensitive fields already redacted by Winston sanitize format.

- Tests added:
    health.controller.spec.ts          — liveness, readiness, aggregate, degraded
    request-logger.interceptor.spec.ts — correlation ID reuse/generation, skip paths
    http-metrics.service.spec.ts       — process metrics, pool metrics, scrape output

All changes are backward-compatible; no schema migrations required. closes #572