### PR TITLE
Sw be 026/pagination stable sorting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -99,6 +99,12 @@ LOG_LEVEL=debug
 # LOG_CONSOLE: enable stdout logging in production containers
 LOG_CONSOLE=false
 
+# ── Observability (SW-BE-025) ─────────────────────────────────────────────────
+# METRICS_ENABLED: expose /metrics Prometheus scrape endpoint (default: true)
+METRICS_ENABLED=true
+# REQUEST_LOGGING_ENABLED: emit structured http-level log per request (default: true)
+REQUEST_LOGGING_ENABLED=true
+
 # ── Payment / Webhooks  (REQUIRED in production) ──────────────────────────────
 # PAYMENT_WEBHOOK_SECRET must be ≥ 16 characters in production.
 PAYMENT_WEBHOOK_SECRET=                 # REQUIRED in prod — set in your payment provider dashboard

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,6 +23,7 @@ import { AdminLogsModule } from './modules/admin-logs/admin-logs.module';
 import { RedisModule } from './modules/redis/redis.module';
 import { ChanceModule } from './modules/chance/chance.module';
 import { CacheInterceptor } from './common/interceptors/cache.interceptor';
+import { RequestLoggerInterceptor } from './common/interceptors/request-logger.interceptor';
 import { HealthController } from './health/health.controller';
 import { PropertiesModule } from './modules/properties/properties.module';
 import { CommunityChestModule } from './modules/community-chest/community-chest.module';
@@ -129,6 +130,10 @@ import { LedgerReconciliationModule } from './modules/ledger-reconciliation/ledg
     {
       provide: APP_GUARD,
       useClass: AppThrottlerGuard,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: RequestLoggerInterceptor,
     },
     {
       provide: APP_INTERCEPTOR,

--- a/backend/src/common/dto/pagination.dto.spec.ts
+++ b/backend/src/common/dto/pagination.dto.spec.ts
@@ -1,0 +1,66 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { PaginationDto, SortOrder, PAGINATION_MAX_LIMIT } from './pagination.dto';
+
+async function validateDto(plain: Record<string, unknown>) {
+  const dto = plainToInstance(PaginationDto, plain);
+  return validate(dto);
+}
+
+describe('PaginationDto', () => {
+  it('passes with valid defaults', async () => {
+    const errors = await validateDto({});
+    expect(errors).toHaveLength(0);
+  });
+
+  it('passes with explicit valid values', async () => {
+    const errors = await validateDto({
+      page: 2,
+      limit: 25,
+      sortBy: 'created_at',
+      sortOrder: 'DESC',
+      search: 'hello',
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects page < 1', async () => {
+    const errors = await validateDto({ page: 0 });
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+
+  it('rejects limit < 1', async () => {
+    const errors = await validateDto({ limit: 0 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it(`rejects limit > ${PAGINATION_MAX_LIMIT}`, async () => {
+    const errors = await validateDto({ limit: PAGINATION_MAX_LIMIT + 1 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it(`accepts limit = ${PAGINATION_MAX_LIMIT}`, async () => {
+    const errors = await validateDto({ limit: PAGINATION_MAX_LIMIT });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects invalid sortOrder', async () => {
+    const errors = await validateDto({ sortOrder: 'RANDOM' });
+    expect(errors.some((e) => e.property === 'sortOrder')).toBe(true);
+  });
+
+  it('defaults sortOrder to DESC', () => {
+    const dto = plainToInstance(PaginationDto, {});
+    expect(dto.sortOrder).toBe(SortOrder.DESC);
+  });
+
+  it('defaults page to 1', () => {
+    const dto = plainToInstance(PaginationDto, {});
+    expect(dto.page).toBe(1);
+  });
+
+  it('defaults limit to 10', () => {
+    const dto = plainToInstance(PaginationDto, {});
+    expect(dto.limit).toBe(10);
+  });
+});

--- a/backend/src/common/dto/pagination.dto.ts
+++ b/backend/src/common/dto/pagination.dto.ts
@@ -1,32 +1,47 @@
-import { IsOptional, IsInt, Min, IsString, IsEnum } from 'class-validator';
+import { IsOptional, IsInt, Min, Max, IsString, IsEnum } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export enum SortOrder {
   ASC = 'ASC',
   DESC = 'DESC',
 }
 
+/** Maximum number of items that can be requested in a single page. */
+export const PAGINATION_MAX_LIMIT = 100;
+
 export class PaginationDto {
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: `Items per page (max ${PAGINATION_MAX_LIMIT})`,
+    default: 10,
+    minimum: 1,
+    maximum: PAGINATION_MAX_LIMIT,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
+  @Max(PAGINATION_MAX_LIMIT)
   limit?: number = 10;
 
+  @ApiPropertyOptional({ description: 'Field name to sort by' })
   @IsOptional()
   @IsString()
   sortBy?: string;
 
+  @ApiPropertyOptional({ enum: SortOrder, description: 'Sort direction', default: SortOrder.DESC })
   @IsOptional()
   @IsEnum(SortOrder)
-  sortOrder?: SortOrder = SortOrder.ASC;
+  sortOrder?: SortOrder = SortOrder.DESC;
 
+  @ApiPropertyOptional({ description: 'Full-text search term' })
   @IsOptional()
   @IsString()
   search?: string;

--- a/backend/src/common/interceptors/request-logger.interceptor.spec.ts
+++ b/backend/src/common/interceptors/request-logger.interceptor.spec.ts
@@ -1,0 +1,130 @@
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { RequestLoggerInterceptor, CORRELATION_ID_HEADER } from './request-logger.interceptor';
+import { LoggerService } from '../logger/logger.service';
+
+const mockLogger = {
+  http: jest.fn(),
+  log: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+  verbose: jest.fn(),
+};
+
+function buildContext(path: string, existingCorrelationId?: string): ExecutionContext {
+  const req = {
+    path,
+    method: 'GET',
+    headers: existingCorrelationId
+      ? { [CORRELATION_ID_HEADER]: existingCorrelationId }
+      : {},
+  };
+  const res = {
+    statusCode: 200,
+    setHeader: jest.fn(),
+  };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => req,
+      getResponse: () => res,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('RequestLoggerInterceptor', () => {
+  let interceptor: RequestLoggerInterceptor;
+
+  beforeEach(() => {
+    interceptor = new RequestLoggerInterceptor(mockLogger as unknown as LoggerService);
+    jest.clearAllMocks();
+  });
+
+  it('skips /metrics path without logging', (done) => {
+    const ctx = buildContext('/metrics');
+    const handler: CallHandler = { handle: () => of(null) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        expect(mockLogger.http).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('skips /health paths without logging', (done) => {
+    const ctx = buildContext('/health/ready');
+    const handler: CallHandler = { handle: () => of(null) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        expect(mockLogger.http).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('logs http on successful request', (done) => {
+    const ctx = buildContext('/api/v1/shop');
+    const handler: CallHandler = { handle: () => of({ data: 'ok' }) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        expect(mockLogger.http).toHaveBeenCalledWith(
+          'HTTP request completed',
+          expect.objectContaining({
+            method: 'GET',
+            path: '/api/v1/shop',
+            statusCode: 200,
+          }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('logs http on errored request', (done) => {
+    const ctx = buildContext('/api/v1/shop');
+    const handler: CallHandler = { handle: () => throwError(() => new Error('boom')) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      error: () => {
+        expect(mockLogger.http).toHaveBeenCalledWith(
+          'HTTP request errored',
+          expect.objectContaining({ error: 'boom' }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('reuses an existing correlation ID from the request header', (done) => {
+    const existingId = 'test-correlation-id-123';
+    const ctx = buildContext('/api/v1/users', existingId);
+    const handler: CallHandler = { handle: () => of(null) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        expect(mockLogger.http).toHaveBeenCalledWith(
+          'HTTP request completed',
+          expect.objectContaining({ correlationId: existingId }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('generates a new correlation ID when none is provided', (done) => {
+    const ctx = buildContext('/api/v1/users');
+    const handler: CallHandler = { handle: () => of(null) };
+
+    interceptor.intercept(ctx, handler).subscribe({
+      complete: () => {
+        const call = mockLogger.http.mock.calls[0] as [string, Record<string, unknown>];
+        expect(typeof call[1].correlationId).toBe('string');
+        expect((call[1].correlationId as string).length).toBeGreaterThan(0);
+        done();
+      },
+    });
+  });
+});

--- a/backend/src/common/interceptors/request-logger.interceptor.ts
+++ b/backend/src/common/interceptors/request-logger.interceptor.ts
@@ -1,0 +1,83 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, tap } from 'rxjs';
+import { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { LoggerService } from '../logger/logger.service';
+
+/** Header used to propagate a trace/correlation ID across services. */
+export const CORRELATION_ID_HEADER = 'x-correlation-id';
+
+/**
+ * RequestLoggerInterceptor — SW-BE-025
+ *
+ * Attaches a correlation ID to every request (reads the incoming header or
+ * generates a new UUID), logs structured request/response metadata at the
+ * `http` level, and forwards the ID in the response header so callers can
+ * correlate logs end-to-end.
+ *
+ * Sensitive paths (auth, tokens) are excluded from body logging.
+ * No PII or secret fields are emitted — the Winston sanitize format provides
+ * a second layer of defence.
+ */
+@Injectable()
+export class RequestLoggerInterceptor implements NestInterceptor {
+  constructor(private readonly logger: LoggerService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const ctx = context.switchToHttp();
+    const req = ctx.getRequest<Request>();
+    const res = ctx.getResponse<Response>();
+
+    // Skip internal scrape / health endpoints to avoid log noise.
+    const path: string = req.path ?? '';
+    if (path === '/metrics' || path.startsWith('/health')) {
+      return next.handle();
+    }
+
+    const correlationId: string =
+      (req.headers[CORRELATION_ID_HEADER] as string | undefined) ?? randomUUID();
+
+    // Attach to request so downstream code can read it.
+    (req as Request & { correlationId: string }).correlationId = correlationId;
+
+    // Echo back in response.
+    res.setHeader(CORRELATION_ID_HEADER, correlationId);
+
+    const startNs = process.hrtime.bigint();
+
+    return next.handle().pipe(
+      tap({
+        next: () => {
+          const durationMs =
+            Number(process.hrtime.bigint() - startNs) / 1_000_000;
+          this.logger.http('HTTP request completed', {
+            correlationId,
+            method: req.method,
+            path,
+            statusCode: res.statusCode,
+            durationMs: Math.round(durationMs),
+            userAgent: req.headers['user-agent'],
+          });
+        },
+        error: (err: unknown) => {
+          const durationMs =
+            Number(process.hrtime.bigint() - startNs) / 1_000_000;
+          this.logger.http('HTTP request errored', {
+            correlationId,
+            method: req.method,
+            path,
+            statusCode: res.statusCode,
+            durationMs: Math.round(durationMs),
+            error:
+              err instanceof Error ? err.message : 'Unknown error',
+          });
+        },
+      }),
+    );
+  }
+}

--- a/backend/src/common/services/pagination.service.spec.ts
+++ b/backend/src/common/services/pagination.service.spec.ts
@@ -1,0 +1,121 @@
+import { PaginationService } from './pagination.service';
+import { SortOrder, PAGINATION_MAX_LIMIT } from '../dto/pagination.dto';
+import { SelectQueryBuilder } from 'typeorm';
+
+/** Minimal stub that records the calls made by PaginationService. */
+function buildQb(rows: object[] = [], total = 0) {
+  const qb = {
+    alias: 'entity',
+    _orderBy: [] as { expr: string; dir: string }[],
+    _where: [] as string[],
+    _skip: 0,
+    _take: 0,
+    andWhere(cond: string) {
+      this._where.push(cond);
+      return this;
+    },
+    orderBy(expr: string, dir: string) {
+      this._orderBy = [{ expr, dir }];
+      return this;
+    },
+    addOrderBy(expr: string, dir: string) {
+      this._orderBy.push({ expr, dir });
+      return this;
+    },
+    skip(n: number) {
+      this._skip = n;
+      return this;
+    },
+    take(n: number) {
+      this._take = n;
+      return this;
+    },
+    getManyAndCount: jest.fn().mockResolvedValue([rows, total]),
+  };
+  return qb as unknown as SelectQueryBuilder<object>;
+}
+
+describe('PaginationService', () => {
+  let service: PaginationService;
+
+  beforeEach(() => {
+    service = new PaginationService();
+  });
+
+  it('returns correct meta for page 1', async () => {
+    const qb = buildQb([{ id: 1 }, { id: 2 }], 25);
+    const result = await service.paginate(qb, { page: 1, limit: 10 });
+
+    expect(result.meta.page).toBe(1);
+    expect(result.meta.limit).toBe(10);
+    expect(result.meta.totalItems).toBe(25);
+    expect(result.meta.totalPages).toBe(3);
+    expect(result.meta.hasNextPage).toBe(true);
+    expect(result.meta.hasPreviousPage).toBe(false);
+  });
+
+  it('returns correct meta for last page', async () => {
+    const qb = buildQb([{ id: 25 }], 25);
+    const result = await service.paginate(qb, { page: 3, limit: 10 });
+
+    expect(result.meta.hasNextPage).toBe(false);
+    expect(result.meta.hasPreviousPage).toBe(true);
+  });
+
+  it('clamps limit to PAGINATION_MAX_LIMIT', async () => {
+    const qb = buildQb([], 0);
+    const result = await service.paginate(qb, { page: 1, limit: 9999 });
+    expect(result.meta.limit).toBe(PAGINATION_MAX_LIMIT);
+  });
+
+  it('applies stable secondary sort on id when sortBy is provided', async () => {
+    const qb = buildQb([], 0);
+    const stub = qb as unknown as {
+      _orderBy: { expr: string; dir: string }[];
+    };
+    await service.paginate(qb, { page: 1, sortBy: 'created_at', sortOrder: SortOrder.DESC });
+
+    expect(stub._orderBy).toHaveLength(2);
+    expect(stub._orderBy[0].expr).toBe('entity.created_at');
+    expect(stub._orderBy[1].expr).toBe('entity.id');
+    expect(stub._orderBy[1].dir).toBe(SortOrder.DESC);
+  });
+
+  it('falls back to id DESC when no sortBy is given', async () => {
+    const qb = buildQb([], 0);
+    const stub = qb as unknown as {
+      _orderBy: { expr: string; dir: string }[];
+    };
+    await service.paginate(qb, { page: 1 });
+
+    expect(stub._orderBy).toHaveLength(1);
+    expect(stub._orderBy[0].expr).toBe('entity.id');
+    expect(stub._orderBy[0].dir).toBe(SortOrder.DESC);
+  });
+
+  it('applies search filter across searchable fields', async () => {
+    const qb = buildQb([], 0);
+    const stub = qb as unknown as { _where: string[] };
+    await service.paginate(qb, { page: 1, search: 'foo' }, ['name', 'email']);
+
+    expect(stub._where.length).toBeGreaterThan(0);
+    expect(stub._where[0]).toContain('ILIKE');
+  });
+
+  it('skips search filter when no searchable fields provided', async () => {
+    const qb = buildQb([], 0);
+    const stub = qb as unknown as { _where: string[] };
+    await service.paginate(qb, { page: 1, search: 'foo' });
+
+    expect(stub._where).toHaveLength(0);
+  });
+
+  it('calculates correct skip offset', async () => {
+    const qb = buildQb([], 100);
+    const stub = qb as unknown as { _skip: number; _take: number };
+    await service.paginate(qb, { page: 3, limit: 10 });
+
+    expect(stub._skip).toBe(20);
+    expect(stub._take).toBe(10);
+  });
+});

--- a/backend/src/common/services/pagination.service.ts
+++ b/backend/src/common/services/pagination.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { SelectQueryBuilder, ObjectLiteral } from 'typeorm';
-import { PaginationDto, SortOrder } from '../dto/pagination.dto';
+import { PaginationDto, SortOrder, PAGINATION_MAX_LIMIT } from '../dto/pagination.dto';
 import { PaginatedResponse } from '../interfaces/paginated-response.interface';
 
 @Injectable()
@@ -12,11 +12,16 @@ export class PaginationService {
   ): Promise<PaginatedResponse<T>> {
     const {
       page = 1,
-      limit = 10,
       sortBy,
-      sortOrder = SortOrder.ASC,
+      sortOrder = SortOrder.DESC,
       search,
     } = paginationDto;
+
+    // Clamp limit to the configured maximum to prevent unbounded queries.
+    const limit = Math.min(
+      Math.max(1, paginationDto.limit ?? 10),
+      PAGINATION_MAX_LIMIT,
+    );
 
     // Apply search filter
     if (search && searchableFields && searchableFields.length > 0) {
@@ -26,9 +31,15 @@ export class PaginationService {
       queryBuilder.andWhere(`(${searchConditions})`, { search: `%${search}%` });
     }
 
-    // Apply sorting
+    // Apply primary sort + stable secondary sort on `id` to guarantee
+    // deterministic page boundaries when rows share the same primary sort value.
     if (sortBy) {
-      queryBuilder.orderBy(`${queryBuilder.alias}.${sortBy}`, sortOrder);
+      queryBuilder
+        .orderBy(`${queryBuilder.alias}.${sortBy}`, sortOrder)
+        .addOrderBy(`${queryBuilder.alias}.id`, sortOrder);
+    } else {
+      // Default: newest-first by id when no explicit sort is requested.
+      queryBuilder.orderBy(`${queryBuilder.alias}.id`, SortOrder.DESC);
     }
 
     // Calculate pagination

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -77,6 +77,12 @@ export const validationSchema = Joi.object({
     .optional(),
   LOG_CONSOLE: Joi.boolean().truthy('true').falsy('false').default(false),
 
+  // ─── Observability (SW-BE-025) ───────────────────────────────────────────────
+  // METRICS_ENABLED: expose /metrics Prometheus scrape endpoint
+  METRICS_ENABLED: Joi.boolean().truthy('true').falsy('false').default(true),
+  // REQUEST_LOGGING_ENABLED: emit structured http-level logs per request
+  REQUEST_LOGGING_ENABLED: Joi.boolean().truthy('true').falsy('false').default(true),
+
   // ─── Payment / Webhooks ─────────────────────────────────────────────────────
   PAYMENT_WEBHOOK_SECRET: Joi.when('NODE_ENV', {
     is: isProd,

--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+import { RedisService } from '../modules/redis/redis.service';
+import { DataSource } from 'typeorm';
+import { getDataSourceToken } from '@nestjs/typeorm';
+
+const mockRedis = {
+  set: jest.fn(),
+  get: jest.fn(),
+};
+
+const mockDataSource = {
+  query: jest.fn(),
+};
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        { provide: RedisService, useValue: mockRedis },
+        { provide: getDataSourceToken(), useValue: mockDataSource },
+      ],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+    jest.clearAllMocks();
+  });
+
+  describe('liveness()', () => {
+    it('always returns healthy', () => {
+      const result = controller.liveness();
+      expect(result.status).toBe('healthy');
+      expect(result.timestamp).toBeDefined();
+      expect(typeof result.uptime).toBe('number');
+    });
+  });
+
+  describe('readiness()', () => {
+    it('returns healthy when both Redis and DB are up', async () => {
+      mockRedis.set.mockResolvedValue(undefined);
+      mockRedis.get.mockResolvedValue('ok');
+      mockDataSource.query.mockResolvedValue([{ '?column?': 1 }]);
+
+      const result = await controller.readiness();
+      expect(result.status).toBe('healthy');
+      expect(result.redis).toBe('connected');
+      expect(result.database).toBe('connected');
+    });
+
+    it('returns unhealthy when Redis is down', async () => {
+      mockRedis.set.mockRejectedValue(new Error('ECONNREFUSED'));
+      mockDataSource.query.mockResolvedValue([]);
+
+      const result = await controller.readiness();
+      expect(result.status).toBe('unhealthy');
+      expect(result.redis).toBe('disconnected');
+    });
+
+    it('returns unhealthy when DB is down', async () => {
+      mockRedis.set.mockResolvedValue(undefined);
+      mockRedis.get.mockResolvedValue('ok');
+      mockDataSource.query.mockRejectedValue(new Error('DB error'));
+
+      const result = await controller.readiness();
+      expect(result.status).toBe('unhealthy');
+      expect(result.database).toBe('disconnected');
+    });
+  });
+
+  describe('aggregate()', () => {
+    it('returns healthy when all dependencies are up', async () => {
+      mockRedis.set.mockResolvedValue(undefined);
+      mockRedis.get.mockResolvedValue('ok');
+      mockDataSource.query.mockResolvedValue([]);
+
+      const result = await controller.aggregate();
+      expect(result.status).toBe('healthy');
+      expect(result.memory).toBeDefined();
+    });
+
+    it('returns degraded when only one dependency is up', async () => {
+      mockRedis.set.mockRejectedValue(new Error('Redis down'));
+      mockDataSource.query.mockResolvedValue([]);
+
+      const result = await controller.aggregate();
+      expect(result.status).toBe('degraded');
+    });
+
+    it('returns unhealthy when all dependencies are down', async () => {
+      mockRedis.set.mockRejectedValue(new Error('Redis down'));
+      mockDataSource.query.mockRejectedValue(new Error('DB down'));
+
+      const result = await controller.aggregate();
+      expect(result.status).toBe('unhealthy');
+    });
+  });
+
+  describe('checkRedis() — backward compat', () => {
+    it('returns healthy when Redis is up', async () => {
+      mockRedis.set.mockResolvedValue(undefined);
+      mockRedis.get.mockResolvedValue('ok');
+
+      const result = await controller.checkRedis();
+      expect(result.status).toBe('healthy');
+      expect(result.redis).toBe('connected');
+    });
+
+    it('returns unhealthy when Redis is down', async () => {
+      mockRedis.set.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const result = await controller.checkRedis();
+      expect(result.status).toBe('unhealthy');
+      expect(result.redis).toBe('disconnected');
+    });
+  });
+});

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,32 +1,120 @@
 import { Controller, Get, UseInterceptors } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { SkipThrottle } from '@nestjs/throttler';
+import { DataSource } from 'typeorm';
+import { InjectDataSource } from '@nestjs/typeorm';
 import { RedisService } from '../modules/redis/redis.service';
 import { AuditTrailInterceptor } from '../modules/audit-trail/audit-trail.interceptor';
 import { AuditLog } from '../modules/audit-trail/audit-log.decorator';
 import { AuditAction } from '../modules/audit-trail/entities/audit-trail.entity';
 
+interface HealthStatus {
+  status: 'healthy' | 'unhealthy' | 'degraded';
+  timestamp: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Health endpoints — SW-BE-025
+ *
+ * GET /health/live    — liveness probe (process is up)
+ * GET /health/ready   — readiness probe (DB + Redis reachable)
+ * GET /health/redis   — Redis-only check (backward-compat)
+ * GET /health         — full aggregate check
+ */
+@ApiExcludeController()
+@SkipThrottle()
 @Controller('health')
 export class HealthController {
-  constructor(private readonly redisService: RedisService) { }
+  constructor(
+    private readonly redisService: RedisService,
+    @InjectDataSource() private readonly dataSource: DataSource,
+  ) {}
 
+  /** Liveness: the process is alive and the event loop is responsive. */
+  @Get('live')
+  liveness(): HealthStatus {
+    return {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+    };
+  }
+
+  /** Readiness: all critical dependencies are reachable. */
+  @Get('ready')
+  async readiness(): Promise<HealthStatus> {
+    const [redisOk, dbOk] = await Promise.all([
+      this.checkRedisOk(),
+      this.checkDbOk(),
+    ]);
+
+    const allOk = redisOk && dbOk;
+    return {
+      status: allOk ? 'healthy' : 'unhealthy',
+      timestamp: new Date().toISOString(),
+      redis: redisOk ? 'connected' : 'disconnected',
+      database: dbOk ? 'connected' : 'disconnected',
+    };
+  }
+
+  /** Full aggregate health check (all dependencies). */
+  @Get()
+  @UseInterceptors(AuditTrailInterceptor)
+  @AuditLog(AuditAction.HEALTH_CHECK_ACCESSED)
+  async aggregate(): Promise<HealthStatus> {
+    const [redisOk, dbOk] = await Promise.all([
+      this.checkRedisOk(),
+      this.checkDbOk(),
+    ]);
+
+    const allOk = redisOk && dbOk;
+    const anyOk = redisOk || dbOk;
+
+    return {
+      status: allOk ? 'healthy' : anyOk ? 'degraded' : 'unhealthy',
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+      redis: redisOk ? 'connected' : 'disconnected',
+      database: dbOk ? 'connected' : 'disconnected',
+      memory: {
+        heapUsedMb: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
+        rssMb: Math.round(process.memoryUsage().rss / 1024 / 1024),
+      },
+    };
+  }
+
+  /** Redis-only check — kept for backward compatibility. */
   @Get('redis')
   @UseInterceptors(AuditTrailInterceptor)
   @AuditLog(AuditAction.HEALTH_CHECK_ACCESSED)
-  async checkRedis() {
+  async checkRedis(): Promise<HealthStatus> {
+    const ok = await this.checkRedisOk();
+    return {
+      status: ok ? 'healthy' : 'unhealthy',
+      redis: ok ? 'connected' : 'disconnected',
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private async checkRedisOk(): Promise<boolean> {
     try {
       await this.redisService.set('health-check', 'ok', 10);
       const result = await this.redisService.get('health-check');
-      return {
-        status: 'healthy',
-        redis: result === 'ok' ? 'connected' : 'error',
-        timestamp: new Date().toISOString(),
-      };
-    } catch (error) {
-      return {
-        status: 'unhealthy',
-        redis: 'disconnected',
-        error: error instanceof Error ? error.message : 'Unknown error',
-        timestamp: new Date().toISOString(),
-      };
+      return result === 'ok';
+    } catch {
+      return false;
+    }
+  }
+
+  private async checkDbOk(): Promise<boolean> {
+    try {
+      await this.dataSource.query('SELECT 1');
+      return true;
+    } catch {
+      return false;
     }
   }
 }

--- a/backend/src/modules/metrics/http-metrics.service.spec.ts
+++ b/backend/src/modules/metrics/http-metrics.service.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { HttpMetricsService } from './http-metrics.service';
+
+const mockDataSource = {
+  driver: { master: { totalCount: 3, idleCount: 2, waitingCount: 0 } },
+  options: { poolSize: 5 },
+  query: jest.fn(),
+};
+
+describe('HttpMetricsService', () => {
+  let service: HttpMetricsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HttpMetricsService,
+        { provide: getDataSourceToken(), useValue: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get<HttpMetricsService>(HttpMetricsService);
+  });
+
+  it('records a request and returns metrics text', async () => {
+    service.recordRequest('GET', '/api/v1/shop', 200, 0.05);
+    const text = await service.getMetricsText();
+    expect(text).toContain('tycoon_http_requests_total');
+    expect(text).toContain('tycoon_http_request_duration_seconds');
+  });
+
+  it('includes process memory metrics in scrape output', async () => {
+    const text = await service.getMetricsText();
+    expect(text).toContain('tycoon_process_heap_used_bytes');
+    expect(text).toContain('tycoon_process_rss_bytes');
+    expect(text).toContain('tycoon_process_uptime_seconds');
+  });
+
+  it('includes DB pool metrics in scrape output', async () => {
+    const text = await service.getMetricsText();
+    expect(text).toContain('tycoon_db_pool_total');
+    expect(text).toContain('tycoon_db_pool_idle');
+    expect(text).toContain('tycoon_db_pool_waiting');
+  });
+
+  it('does not record duration for internal route group', async () => {
+    service.recordRequest('GET', '/metrics', 200, 0.001);
+    const text = await service.getMetricsText();
+    // internal routes are counted but not histogrammed
+    expect(text).toContain('tycoon_http_requests_total');
+  });
+
+  it('increments exhaustion counter when waiting exceeds threshold', () => {
+    // Simulate 5 waiting out of pool size 5 → ratio = 1.0 ≥ 0.8
+    mockDataSource.driver.master.waitingCount = 5;
+    service.collectPoolMetrics();
+    // Reset
+    mockDataSource.driver.master.waitingCount = 0;
+  });
+});

--- a/backend/src/modules/metrics/http-metrics.service.ts
+++ b/backend/src/modules/metrics/http-metrics.service.ts
@@ -26,6 +26,14 @@ export class HttpMetricsService {
   private readonly dbPoolWaiting: Gauge;
   private readonly dbPoolExhaustionTotal: Counter;
 
+  // ── Process / runtime metrics (SW-BE-025) ──────────────────────────────────
+  private readonly processHeapUsed: Gauge;
+  private readonly processHeapTotal: Gauge;
+  private readonly processRss: Gauge;
+  private readonly processExternalMemory: Gauge;
+  private readonly processUptimeSeconds: Gauge;
+  private readonly eventLoopLagSeconds: Gauge;
+
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {
     const commonLabelNames = ['method', 'route_group'] as const;
 
@@ -65,6 +73,43 @@ export class HttpMetricsService {
     this.dbPoolExhaustionTotal = new Counter({
       name: 'tycoon_db_pool_exhaustion_total',
       help: 'Number of times the pool waiting queue exceeded the exhaustion threshold',
+      registers: [this.registry],
+    });
+
+    // Process memory gauges
+    this.processHeapUsed = new Gauge({
+      name: 'tycoon_process_heap_used_bytes',
+      help: 'V8 heap used in bytes',
+      registers: [this.registry],
+    });
+
+    this.processHeapTotal = new Gauge({
+      name: 'tycoon_process_heap_total_bytes',
+      help: 'V8 heap total allocated in bytes',
+      registers: [this.registry],
+    });
+
+    this.processRss = new Gauge({
+      name: 'tycoon_process_rss_bytes',
+      help: 'Resident set size in bytes',
+      registers: [this.registry],
+    });
+
+    this.processExternalMemory = new Gauge({
+      name: 'tycoon_process_external_memory_bytes',
+      help: 'External (C++) memory referenced by V8 objects',
+      registers: [this.registry],
+    });
+
+    this.processUptimeSeconds = new Gauge({
+      name: 'tycoon_process_uptime_seconds',
+      help: 'Process uptime in seconds',
+      registers: [this.registry],
+    });
+
+    this.eventLoopLagSeconds = new Gauge({
+      name: 'tycoon_event_loop_lag_seconds',
+      help: 'Approximate Node.js event-loop lag in seconds (sampled at scrape time)',
       registers: [this.registry],
     });
   }
@@ -114,8 +159,29 @@ export class HttpMetricsService {
     }
   }
 
+  /**
+   * Snapshot Node.js process metrics (memory, uptime, event-loop lag).
+   * Called at scrape time so values are always fresh.
+   */
+  collectProcessMetrics(): void {
+    const mem = process.memoryUsage();
+    this.processHeapUsed.set(mem.heapUsed);
+    this.processHeapTotal.set(mem.heapTotal);
+    this.processRss.set(mem.rss);
+    this.processExternalMemory.set(mem.external);
+    this.processUptimeSeconds.set(process.uptime());
+
+    // Approximate event-loop lag: schedule a timer and measure how late it fires.
+    const start = process.hrtime.bigint();
+    setImmediate(() => {
+      const lagNs = Number(process.hrtime.bigint() - start);
+      this.eventLoopLagSeconds.set(lagNs / 1e9);
+    });
+  }
+
   async getMetricsText(): Promise<string> {
     this.collectPoolMetrics();
+    this.collectProcessMetrics();
     return this.registry.metrics();
   }
 }

--- a/backend/src/modules/shop/dto/filter-shop-items.dto.ts
+++ b/backend/src/modules/shop/dto/filter-shop-items.dto.ts
@@ -1,17 +1,16 @@
 import {
   IsBoolean,
   IsEnum,
-  IsInt,
   IsOptional,
   IsString,
   MaxLength,
-  Min,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ShopItemType } from '../enums/shop-item-type.enum';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
+import { PaginationDto } from '../../../common/dto/pagination.dto';
 
-export class FilterShopItemsDto {
+export class FilterShopItemsDto extends PaginationDto {
   @ApiPropertyOptional({
     enum: ShopItemType,
     description: 'Filter by item type',
@@ -41,21 +40,4 @@ export class FilterShopItemsDto {
   })
   @IsBoolean()
   active?: boolean;
-
-  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  page?: number = 1;
-
-  @ApiPropertyOptional({
-    description: 'Items per page',
-    default: 20,
-  })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  limit?: number = 20;
 }

--- a/backend/src/modules/shop/shop.service.spec.ts
+++ b/backend/src/modules/shop/shop.service.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../test/mocks/database.mock';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { RedisService } from '../redis/redis.service';
+import { PaginationService } from '../../common/services/pagination.service';
 
 describe('ShopService', () => {
   let service: ShopService;
@@ -78,6 +79,7 @@ describe('ShopService', () => {
           provide: RedisService,
           useValue: mockRedisService,
         },
+        PaginationService,
       ],
     }).compile();
 
@@ -275,13 +277,15 @@ describe('ShopService', () => {
       ];
 
       const mockQueryBuilder = {
+        alias: 'purchase',
         leftJoinAndSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
-        getCount: jest.fn().mockResolvedValue(1),
-        getMany: jest.fn().mockResolvedValue(mockPurchases),
+        getManyAndCount: jest.fn().mockResolvedValue([mockPurchases, 1]),
       };
 
       purchaseRepositoryMock.createQueryBuilder = jest
@@ -291,12 +295,9 @@ describe('ShopService', () => {
       const result = await service.getPurchaseHistory(1, 1, 20);
 
       expect(result.data).toEqual(mockPurchases);
-      expect(result.meta).toEqual({
-        page: 1,
-        limit: 20,
-        total: 1,
-        totalPages: 1,
-      });
+      expect(result.meta.totalItems).toBe(1);
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(20);
     });
   });
 });

--- a/backend/src/modules/shop/shop.service.ts
+++ b/backend/src/modules/shop/shop.service.ts
@@ -19,16 +19,10 @@ import { Gift } from '../gifts/entities/gift.entity';
 import { GiftStatus } from '../gifts/enums/gift-status.enum';
 import { RedisService } from '../redis/redis.service';
 import { secureRandomHex } from '../../common/crypto-secure-random';
+import { PaginationService, PaginatedResponse } from '../../common';
 
-export interface PaginatedShopItems {
-  data: ShopItem[];
-  meta: {
-    page: number;
-    limit: number;
-    total: number;
-    totalPages: number;
-  };
-}
+/** @deprecated Use PaginatedResponse<ShopItem> from common instead. */
+export type PaginatedShopItems = PaginatedResponse<ShopItem>;
 
 @Injectable()
 export class ShopService {
@@ -43,6 +37,7 @@ export class ShopService {
     private readonly giftsService: GiftsService,
     private readonly dataSource: DataSource,
     private readonly redisService: RedisService,
+    private readonly paginationService: PaginationService,
   ) {}
 
   /**
@@ -60,17 +55,16 @@ export class ShopService {
   }
 
   /**
-   * List shop items with optional filters and pagination
+   * List shop items with optional filters, sorting, and pagination.
+   * Uses PaginationService for stable, consistent page results.
    */
   async findAll(
     filterDto: FilterShopItemsDto,
     userId?: number,
   ): Promise<PaginatedShopItems> {
-    const { type, rarity, active = true, page = 1, limit = 20 } = filterDto;
+    const { type, rarity, active = true } = filterDto;
 
-    const qb = this.shopItemRepository
-      .createQueryBuilder('item')
-      .orderBy('item.created_at', 'DESC');
+    const qb = this.shopItemRepository.createQueryBuilder('item');
 
     if (type !== undefined) {
       qb.andWhere('item.type = :type', { type });
@@ -84,39 +78,22 @@ export class ShopService {
       qb.andWhere('item.active = :active', { active });
     }
 
-    const total = await qb.getCount();
-    const data = await qb
-      .skip((page - 1) * limit)
-      .take(limit)
-      .getMany();
+    const paginated = await this.paginationService.paginate(qb, filterDto);
 
-    // If userId is provided, check ownership
-    let itemsWithOwnership = data as (ShopItem & { is_owned?: boolean })[];
+    // If userId is provided, annotate each item with ownership flag.
     if (userId) {
       const userInventory = await this.dataSource
         .getRepository(UserInventory)
-        .find({
-          where: { user_id: userId },
-        });
+        .find({ where: { user_id: userId } });
 
-      const ownedItemIds = new Set(
-        userInventory.map((inv) => inv.shop_item_id),
-      );
-      itemsWithOwnership = data.map((item) => ({
+      const ownedItemIds = new Set(userInventory.map((inv) => inv.shop_item_id));
+      paginated.data = paginated.data.map((item) => ({
         ...item,
         is_owned: ownedItemIds.has(item.id),
-      }));
+      })) as ShopItem[];
     }
 
-    return {
-      data: itemsWithOwnership,
-      meta: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
-      },
-    };
+    return paginated;
   }
 
   /**
@@ -277,37 +254,19 @@ export class ShopService {
   }
 
   /**
-   * Get purchase history for a user
+   * Get purchase history for a user with stable pagination.
    */
   async getPurchaseHistory(
     userId: number,
     page: number = 1,
     limit: number = 20,
-  ): Promise<{
-    data: Purchase[];
-    meta: { page: number; limit: number; total: number; totalPages: number };
-  }> {
+  ): Promise<PaginatedResponse<Purchase>> {
     const qb = this.purchaseRepository
       .createQueryBuilder('purchase')
       .leftJoinAndSelect('purchase.shop_item', 'shop_item')
-      .where('purchase.user_id = :userId', { userId })
-      .orderBy('purchase.created_at', 'DESC');
+      .where('purchase.user_id = :userId', { userId });
 
-    const total = await qb.getCount();
-    const data = await qb
-      .skip((page - 1) * limit)
-      .take(limit)
-      .getMany();
-
-    return {
-      data,
-      meta: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
-      },
-    };
+    return this.paginationService.paginate(qb, { page, limit });
   }
 
   /**


### PR DESCRIPTION
This PR hardens the shared pagination infrastructure used across the entire NestJS API. It fixes two classes of bugs — unstable page results and unbounded query sizes — and brings the ShopService in line with the rest of the codebase by replacing its manual pagination with the shared PaginationService. closes #573