### PR TITLE
Feat/sw ct 009 tycoon game simulation scenarios

### DIFF
--- a/contract/contracts/tycoon-game/CHANGELOG.md
+++ b/contract/contracts/tycoon-game/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - SW-CT-007
+
+### Added
+- `SECURITY_REVIEW_CHECKLIST.md` — full security review covering access control,
+  CEI pattern, input validation, integer arithmetic, storage consistency, event
+  emission, privileged roles, DoS/gas, and Soroban best practices for the
+  tycoon-game contract. Includes six open items to resolve before mainnet.
+
 ## [0.2.0] - 2026-04-24 — SW-CT-012
 
 ### Added

--- a/contract/contracts/tycoon-game/CHANGELOG.md
+++ b/contract/contracts/tycoon-game/CHANGELOG.md
@@ -10,6 +10,21 @@ All notable changes to this project will be documented in this file.
   emission, privileged roles, DoS/gas, and Soroban best practices for the
   tycoon-game contract. Includes six open items to resolve before mainnet.
 
+## [Unreleased] - SW-CT-009
+
+### Added
+- `simulation_scenarios.rs` expanded with SIM-12 through SIM-20 (9 new scenarios):
+  - SIM-12: Full player lifecycle — register then owner removes from game
+  - SIM-13: Large collectible catalogue — 10 distinct token IDs stored and retrieved
+  - SIM-14: All cash tiers set in one pass; each value independently correct
+  - SIM-15: Partial USDC withdrawal leaves correct residual balance
+  - SIM-16: Owner removes multiple players from the same game in sequence
+  - SIM-17: Backend controller removes players across multiple concurrent games
+  - SIM-18: Treasury invariant holds across multiple escrow cycles with varying stakes
+  - SIM-19: Unregistered address returns `None` from `get_user`
+  - SIM-20: `export_state` reflects reward_system address set during initialize
+- Module doc-comment table updated to list all 20 scenarios.
+
 ## [0.2.0] - 2026-04-24 — SW-CT-012
 
 ### Added

--- a/contract/contracts/tycoon-game/SECURITY_REVIEW_CHECKLIST.md
+++ b/contract/contracts/tycoon-game/SECURITY_REVIEW_CHECKLIST.md
@@ -1,0 +1,157 @@
+# Security Review Checklist — tycoon-game (SW-CT-007)
+
+**Issue:** SW-CT-007
+**Reviewer:** (assign before merge)
+**Date:** 2026-04-26
+**Contract:** `contract/contracts/tycoon-game/src/lib.rs`
+**SDK:** soroban-sdk 23
+**Version:** 0.2.0
+
+---
+
+## 1. Access Control
+
+| # | Check | Status | Notes |
+|---|---|---|---|
+| AC-1 | `initialize` can only be called once | ✅ | Guards on `DataKey::IsInitialized`; panics with `"Contract already initialized"` |
+| AC-2 | `initialize` requires `initial_owner.require_auth()` | ✅ | Owner must sign the initialization transaction |
+| AC-3 | `admin_migrate` requires owner via `require_admin` | ✅ | |
+| AC-4 | `admin_withdraw_funds` requires owner via `require_admin` | ✅ | |
+| AC-5 | `admin_set_collectible_info` requires owner via `require_admin` | ✅ | |
+| AC-6 | `admin_set_cash_tier_value` requires owner via `require_admin` | ✅ | |
+| AC-7 | `admin_set_game_controller` requires owner via `require_admin` | ✅ | |
+| AC-8 | `admin_mint_registration_voucher` requires owner via `require_admin` | ✅ | |
+| AC-9 | `require_admin` panics with `"Contract not initialized"` if owner key absent | ✅ | Prevents calling admin functions before `initialize` |
+| AC-10 | `register_player` requires `caller.require_auth()` | ✅ | Player must sign their own registration |
+| AC-11 | `remove_player_from_game` requires `caller.require_auth()` | ✅ | Caller must sign; then checked against owner or backend controller |
+| AC-12 | `remove_player_from_game` rejects callers that are neither owner nor backend controller | ✅ | Panics with `"Unauthorized: caller must be owner or backend game controller"` |
+| AC-13 | `get_user`, `get_collectible_info`, `get_cash_tier_value`, `export_state` are read-only with no auth | ✅ | Public view functions; no state mutation |
+| AC-14 | No unaudited oracle or privileged pattern without review | ✅ | No oracle used; `backend_game_controller` is the only privileged off-chain role and is admin-controlled |
+
+---
+
+## 2. CEI (Checks-Effects-Interactions) Pattern
+
+| # | Function | Checks before effects? | Effects before interactions? | Status |
+|---|---|---|---|---|
+| CEI-1 | `admin_withdraw_funds` | ✅ validates token address and balance | ✅ no state mutation after `token.transfer` | ✅ |
+| CEI-2 | `admin_mint_registration_voucher` | ✅ admin auth check first | ✅ no local state written; cross-contract call is the only action | ⚠️ See note below |
+| CEI-3 | `initialize` | ✅ re-init guard first | ✅ all storage writes before any external interaction | ✅ |
+| CEI-4 | `register_player` | ✅ auth + duplicate + username length checks | ✅ storage writes only; no external calls | ✅ |
+| CEI-5 | `remove_player_from_game` | ✅ auth + role check | ✅ event emission only; no external calls | ✅ |
+
+> **CEI-2 note:** `admin_mint_registration_voucher` makes a cross-contract call to the reward system via `env.invoke_contract`. There is no local state to protect before the call, so CEI ordering is satisfied. However, the reward system address is stored at initialization and cannot be changed post-deploy, which limits the attack surface. Ensure the reward system contract is audited before mainnet.
+
+---
+
+## 3. Input Validation
+
+| # | Check | Status | Notes |
+|---|---|---|---|
+| IV-1 | `initialize` — rejects re-initialization | ✅ | `"Contract already initialized"` |
+| IV-2 | `admin_withdraw_funds` — rejects token addresses other than TYC or USDC | ✅ | `"Invalid token address"` |
+| IV-3 | `admin_withdraw_funds` — rejects withdrawal exceeding contract balance | ✅ | `"Insufficient contract balance"` |
+| IV-4 | `register_player` — rejects duplicate registration | ✅ | `"Address already registered"` |
+| IV-5 | `register_player` — rejects username shorter than 3 characters | ✅ | `"Username must be 3-20 characters"` |
+| IV-6 | `register_player` — rejects username longer than 20 characters | ✅ | `"Username must be 3-20 characters"` |
+| IV-7 | `get_collectible_info` — rejects unknown `token_id` | ✅ | `"Collectible does not exist"` |
+| IV-8 | `get_cash_tier_value` — rejects unknown `tier` | ✅ | `"Cash tier does not exist"` |
+| IV-9 | `admin_withdraw_funds` — `amount` is `u128`; no negative value possible | ✅ | Type-level guarantee |
+
+---
+
+## 4. Integer Arithmetic
+
+| # | Check | Status | Notes |
+|---|---|---|---|
+| INT-1 | `admin_withdraw_funds` — `amount as i128` cast | ⚠️ | If `amount > i128::MAX` the cast silently truncates. Add an explicit bounds check: `assert!(amount <= i128::MAX as u128, "amount exceeds i128::MAX")` before the cast |
+| INT-2 | `TreasurySnapshot::invariant_holds` — uses `checked_add` | ✅ | Returns `false` on overflow rather than panicking |
+| INT-3 | `TreasurySnapshot::assert_invariant` — panics with descriptive message | ✅ | |
+| INT-4 | No arithmetic on user-supplied values in storage reads/writes | ✅ | Collectible prices and stock are stored as-is; no on-chain arithmetic on them |
+
+---
+
+## 5. Storage & State Consistency
+
+| # | Check | Status | Notes |
+|---|---|---|---|
+| ST-1 | `DataKey` variants are distinct; no key collision possible | ✅ | Enum variants with typed payloads |
+| ST-2 | `IsInitialized` flag is set atomically with all other init state | ✅ | Set last in `initialize` after all other keys are written |
+| ST-3 | `BackendGameController` is `Option<Address>`; absence is handled correctly | ✅ | `get_backend_game_controller` returns `None`; `remove_player_from_game` handles `None` safely via `is_some_and` |
+| ST-4 | `User` struct stores `registered_at` from `env.ledger().timestamp()` | ✅ | Ledger timestamp is consensus-derived; not manipulable by a single validator |
+| ST-5 | `StateVersion` is set to `1` during `initialize`; `admin_migrate` advances it safely | ✅ | No version can be skipped or decremented |
+| ST-6 | `Collectible` and `CashTier` entries use `persistent` storage | ✅ | Appropriate for long-lived game data |
+| ST-7 | `Owner`, `TycToken`, `UsdcToken`, `RewardSystem`, `BackendGameController`, `StateVersion`, `IsInitialized` use `instance` storage | ✅ | Appropriate for contract-lifetime configuration |
+| ST-8 | `User` and `Registered` entries use `persistent` storage keyed by `Address` | ✅ | Per-player data correctly scoped |
+
+---
+
+## 6. Event Emission
+
+| # | Function | Event | Status |
+|---|---|---|---|
+| EV-1 | `admin_withdraw_funds` | `FundsWithdrawn` (topics: token, to; data: amount) | ✅ |
+| EV-2 | `remove_player_from_game` | `PlayerRemovedFromGame` (topics: game_id, player; data: turn_count) | ✅ |
+| EV-3 | `initialize` | No event emitted | ℹ️ Intentional — initialization is a one-time bootstrap; indexers can detect it from the transaction |
+| EV-4 | `register_player` | No event emitted | ℹ️ Consider adding a `PlayerRegistered` event for off-chain indexing |
+| EV-5 | `admin_set_game_controller` | No event emitted | ⚠️ Controller rotation is a privileged action; recommend adding a `ControllerUpdated` event for auditability |
+
+---
+
+## 7. Privileged Roles
+
+| Role | How granted | How rotated | Notes |
+|---|---|---|---|
+| `owner` | Set in `initialize` | No rotation mechanism | ⚠️ Owner key cannot be rotated post-deploy. If the owner key is compromised, the contract cannot be recovered. Consider adding an `admin_transfer_ownership` entrypoint. |
+| `backend_game_controller` | Set by owner via `admin_set_game_controller` | Owner calls `admin_set_game_controller` with new address | ✅ Rotation is supported |
+
+---
+
+## 8. Denial-of-Service / Gas
+
+| # | Check | Status | Notes |
+|---|---|---|---|
+| DOS-1 | No unbounded loops in any public function | ✅ | |
+| DOS-2 | No dynamic storage reads proportional to user count | ✅ | All reads are O(1) keyed lookups |
+| DOS-3 | `admin_withdraw_funds` makes a single external token transfer | ✅ | |
+| DOS-4 | `admin_mint_registration_voucher` makes a single cross-contract call | ✅ | |
+
+---
+
+## 9. Stellar / Soroban Best Practices
+
+| # | Check | Status | Notes |
+|---|---|---|---|
+| SBP-1 | Uses `soroban_sdk::token::Client` for token transfers | ✅ | |
+| SBP-2 | Uses `env.current_contract_address()` for self-reference | ✅ | |
+| SBP-3 | `#[contracttype]` on `DataKey`, `CollectibleInfo`, `User`, `ContractStateDump` | ✅ | |
+| SBP-4 | `overflow-checks = true` in release profile | ✅ | Workspace `Cargo.toml` |
+| SBP-5 | `panic = "abort"` in release profile | ✅ | |
+| SBP-6 | No `unsafe` blocks | ✅ | |
+| SBP-7 | `#[no_std]` | ✅ | |
+| SBP-8 | Deprecated shims carry `#[deprecated(since = "0.2.0")]` | ✅ | Clear migration signal for integrators |
+| SBP-9 | `require_admin` is a single internal helper — auth boundary is easy to audit | ✅ | |
+
+---
+
+## 10. Open Items (Must Resolve Before Mainnet)
+
+| ID | Severity | Description | Owner | Status |
+|---|---|---|---|---|
+| OI-1 | Medium | `amount as i128` cast in `admin_withdraw_funds` is unchecked — add `assert!(amount <= i128::MAX as u128)` | | 🔲 Open |
+| OI-2 | Medium | No owner rotation mechanism — add `admin_transfer_ownership` to allow key rotation | | 🔲 Open |
+| OI-3 | Low | `admin_set_game_controller` emits no event — add `ControllerUpdated` event for auditability | | 🔲 Open |
+| OI-4 | Low | `register_player` emits no event — add `PlayerRegistered` event for off-chain indexing | | 🔲 Open |
+| OI-5 | Info | Reward system address is immutable post-deploy — ensure it is audited before `initialize` is called on mainnet | | 🔲 Pending audit |
+| OI-6 | Info | External audit recommended before mainnet | | 🔲 Pending budget |
+
+---
+
+## 11. Sign-Off
+
+| Role | Name | Date | Signature |
+|---|---|---|---|
+| Smart Contract Dev | | | |
+| Tech Lead | | | |
+| Security Reviewer | | | |
+| External Auditor | | | (pending) |

--- a/contract/contracts/tycoon-game/src/simulation_scenarios.rs
+++ b/contract/contracts/tycoon-game/src/simulation_scenarios.rs
@@ -1,4 +1,4 @@
-/// # Simulation Scenarios — tycoon-game (SW-FE-001)
+/// # Simulation Scenarios — tycoon-game (SW-CT-009)
 ///
 /// These tests exercise the contract's on-chain behaviour under realistic
 /// game-session scenarios. Each scenario is self-contained: it creates its
@@ -19,12 +19,21 @@
 /// | SIM-09 | Withdraw-all empties contract balance to zero |
 /// | SIM-10 | Withdraw-zero is a no-op (balance unchanged) |
 /// | SIM-11 | `export_state` view returns correct initialized values |
+/// | SIM-12 | Full player lifecycle: register → play → remove from game |
+/// | SIM-13 | Large collectible catalogue: 10 distinct token IDs stored and retrieved |
+/// | SIM-14 | All cash tiers set in one pass; each value is independently correct |
+/// | SIM-15 | Partial USDC withdrawal leaves correct residual balance |
+/// | SIM-16 | Owner removes multiple players from the same game in sequence |
+/// | SIM-17 | Backend controller removes players across multiple concurrent games |
+/// | SIM-18 | Treasury invariant holds across multiple escrow lock/release cycles |
+/// | SIM-19 | Unregistered address returns `None` from `get_user` |
+/// | SIM-20 | `export_state` reflects reward_system address set during initialize |
 #[cfg(test)]
 mod tests {
     extern crate std;
     use crate::{TreasurySnapshot, TycoonContract, TycoonContractClient};
     use soroban_sdk::{
-        testutils::Address as _,
+        testutils::{Address as _, Events},
         token::{StellarAssetClient, TokenClient},
         Address, Env, String,
     };
@@ -306,6 +315,290 @@ mod tests {
         assert_ne!(
             dump.reward_system, contract_id,
             "SIM-11: reward_system should not equal the game contract address"
+        );
+    }
+
+    // ── SIM-12 ────────────────────────────────────────────────────────────────
+
+    /// SIM-12: Full player lifecycle — register, then owner removes them from a game.
+    ///
+    /// Verifies that registration and game removal are independent operations
+    /// that compose correctly: a registered player can be removed from a game
+    /// by the owner, and their profile is still readable afterwards.
+    #[test]
+    fn sim_12_full_player_lifecycle_register_then_remove() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, owner, _, _) = setup(&env);
+
+        let player = Address::generate(&env);
+        client.register_player(&String::from_str(&env, "tycoon_pro"), &player);
+
+        let user = client.get_user(&player).expect("SIM-12: user must exist after registration");
+        assert_eq!(user.username, String::from_str(&env, "tycoon_pro"));
+        assert_eq!(user.games_played, 0);
+
+        // Owner removes the player from game 1 at turn 7
+        client.remove_player_from_game(&owner, &1, &player, &7);
+
+        // Profile is still intact after removal
+        let user_after = client.get_user(&player).expect("SIM-12: user must still exist after removal");
+        assert_eq!(user_after.address, player, "SIM-12: address must be unchanged");
+    }
+
+    // ── SIM-13 ────────────────────────────────────────────────────────────────
+
+    /// SIM-13: Large collectible catalogue — 10 distinct token IDs stored and retrieved.
+    ///
+    /// Confirms that persistent storage correctly scopes each `Collectible(token_id)`
+    /// key independently and that no entry overwrites another.
+    #[test]
+    fn sim_13_large_collectible_catalogue_ten_entries() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, _, _) = setup(&env);
+
+        // Store 10 collectibles with distinct values
+        for i in 1_u128..=10 {
+            client.admin_set_collectible_info(
+                &i,
+                &(i as u32),       // perk
+                &(i as u32 * 10),  // strength
+                &(i * 1_000),      // tyc_price
+                &(i * 500),        // usdc_price
+                &(i as u64 * 5),   // shop_stock
+            );
+        }
+
+        // Verify each entry is independently correct
+        for i in 1_u128..=10 {
+            let info = client.get_collectible_info(&i);
+            assert_eq!(info.0, i as u32,           "SIM-13: perk mismatch for token {i}");
+            assert_eq!(info.1, i as u32 * 10,      "SIM-13: strength mismatch for token {i}");
+            assert_eq!(info.2, i * 1_000,          "SIM-13: tyc_price mismatch for token {i}");
+            assert_eq!(info.3, i * 500,            "SIM-13: usdc_price mismatch for token {i}");
+            assert_eq!(info.4, i as u64 * 5,       "SIM-13: shop_stock mismatch for token {i}");
+        }
+    }
+
+    // ── SIM-14 ────────────────────────────────────────────────────────────────
+
+    /// SIM-14: All cash tiers set in one pass; each value is independently correct.
+    ///
+    /// Simulates the admin bootstrapping the full cash-tier table at launch.
+    /// Verifies that tiers do not bleed into each other.
+    #[test]
+    fn sim_14_all_cash_tiers_set_and_retrieved_independently() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, _, _) = setup(&env);
+
+        let tiers: [(u32, u128); 5] = [
+            (1, 100),
+            (2, 500),
+            (3, 1_000),
+            (4, 5_000),
+            (5, 10_000),
+        ];
+
+        for (tier, value) in tiers {
+            client.admin_set_cash_tier_value(&tier, &value);
+        }
+
+        for (tier, expected) in tiers {
+            assert_eq!(
+                client.get_cash_tier_value(&tier),
+                expected,
+                "SIM-14: cash tier {tier} value mismatch"
+            );
+        }
+    }
+
+    // ── SIM-15 ────────────────────────────────────────────────────────────────
+
+    /// SIM-15: Partial USDC withdrawal leaves the correct residual balance.
+    ///
+    /// Mirrors SIM-09 but for USDC and with a partial (not full) withdrawal,
+    /// confirming the two token balances are tracked independently.
+    #[test]
+    fn sim_15_partial_usdc_withdrawal_leaves_correct_residual() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, _, _, usdc_id) = setup(&env);
+
+        let total: i128 = 10_000;
+        fund(&env, &usdc_id, &contract_id, total);
+
+        let recipient = Address::generate(&env);
+        client.admin_withdraw_funds(&usdc_id, &recipient, &3_000);
+
+        assert_eq!(
+            TokenClient::new(&env, &usdc_id).balance(&contract_id),
+            7_000,
+            "SIM-15: contract USDC residual must be 7_000"
+        );
+        assert_eq!(
+            TokenClient::new(&env, &usdc_id).balance(&recipient),
+            3_000,
+            "SIM-15: recipient must receive exactly 3_000 USDC"
+        );
+    }
+
+    // ── SIM-16 ────────────────────────────────────────────────────────────────
+
+    /// SIM-16: Owner removes multiple players from the same game in sequence.
+    ///
+    /// Simulates a game-end sweep where the owner evicts all remaining players.
+    /// Each removal must succeed independently and emit its own event.
+    #[test]
+    fn sim_16_owner_removes_multiple_players_same_game() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, owner, _, _) = setup(&env);
+
+        let game_id: u128 = 42;
+        let players = [
+            Address::generate(&env),
+            Address::generate(&env),
+            Address::generate(&env),
+        ];
+        let turn_counts = [3_u32, 7, 12];
+
+        for (player, turns) in players.iter().zip(turn_counts.iter()) {
+            client.register_player(&String::from_str(&env, "player"), player);
+            client.remove_player_from_game(&owner, &game_id, player, turns);
+        }
+
+        // All removals succeeded — verify via event count (3 remove events + 3 register no-ops)
+        let events = env.events().all();
+        assert!(
+            !events.is_empty(),
+            "SIM-16: PlayerRemovedFromGame events must be emitted"
+        );
+    }
+
+    // ── SIM-17 ────────────────────────────────────────────────────────────────
+
+    /// SIM-17: Backend controller removes players across multiple concurrent games.
+    ///
+    /// Verifies that the backend controller role works correctly when managing
+    /// several game sessions simultaneously — game IDs are independent.
+    #[test]
+    fn sim_17_backend_controller_removes_players_across_games() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, _, _) = setup(&env);
+
+        let controller = Address::generate(&env);
+        client.admin_set_game_controller(&controller);
+
+        let player_a = Address::generate(&env);
+        let player_b = Address::generate(&env);
+        let player_c = Address::generate(&env);
+
+        // Three different game IDs
+        client.remove_player_from_game(&controller, &101, &player_a, &5);
+        client.remove_player_from_game(&controller, &102, &player_b, &9);
+        client.remove_player_from_game(&controller, &103, &player_c, &2);
+
+        let events = env.events().all();
+        assert!(
+            !events.is_empty(),
+            "SIM-17: events must be emitted for each removal"
+        );
+    }
+
+    // ── SIM-18 ────────────────────────────────────────────────────────────────
+
+    /// SIM-18: Treasury invariant holds across multiple escrow lock/release cycles.
+    ///
+    /// Extends SIM-04 with a larger iteration count and varying stake sizes to
+    /// stress-test the invariant across realistic game-session patterns.
+    #[test]
+    fn sim_18_treasury_invariant_multiple_escrow_cycles_varying_stakes() {
+        let stakes = [100_u64, 250, 500, 1_000, 2_500];
+        let mut snap = TreasurySnapshot {
+            sum_of_balances: 20_000,
+            escrow: 0,
+            liabilities: 8_000,
+            treasury: 12_000,
+        };
+        snap.assert_invariant();
+
+        for stake in stakes {
+            // Lock into escrow
+            snap.sum_of_balances -= stake;
+            snap.escrow += stake;
+            snap.assert_invariant();
+
+            // Release back to balances (game resolved, no payout)
+            snap.escrow -= stake;
+            snap.sum_of_balances += stake;
+            snap.assert_invariant();
+        }
+    }
+
+    // ── SIM-19 ────────────────────────────────────────────────────────────────
+
+    /// SIM-19: Unregistered address returns `None` from `get_user`.
+    ///
+    /// Confirms the storage default for an unknown key is `None` and that
+    /// looking up a non-existent player does not panic.
+    #[test]
+    fn sim_19_unregistered_address_returns_none() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, _, _) = setup(&env);
+
+        let stranger = Address::generate(&env);
+        assert!(
+            client.get_user(&stranger).is_none(),
+            "SIM-19: get_user must return None for an unregistered address"
+        );
+    }
+
+    // ── SIM-20 ────────────────────────────────────────────────────────────────
+
+    /// SIM-20: `export_state` reflects the reward_system address set during initialize.
+    ///
+    /// Verifies that the reward system address stored at init time is faithfully
+    /// returned by the read-only `export_state` view and is distinct from both
+    /// the game contract address and the token addresses.
+    #[test]
+    fn sim_20_export_state_reflects_reward_system_address() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(TycoonContract, ());
+        let client = TycoonContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let tyc_id = env
+            .register_stellar_asset_contract_v2(Address::generate(&env))
+            .address();
+        let usdc_id = env
+            .register_stellar_asset_contract_v2(Address::generate(&env))
+            .address();
+        let reward_system = Address::generate(&env);
+
+        client.initialize(&tyc_id, &usdc_id, &owner, &reward_system);
+
+        let dump = client.export_state();
+
+        assert_eq!(
+            dump.reward_system, reward_system,
+            "SIM-20: reward_system must match the address passed to initialize"
+        );
+        assert_ne!(
+            dump.reward_system, contract_id,
+            "SIM-20: reward_system must not equal the game contract address"
+        );
+        assert_ne!(
+            dump.reward_system, tyc_id,
+            "SIM-20: reward_system must not equal the TYC token address"
+        );
+        assert_ne!(
+            dump.reward_system, usdc_id,
+            "SIM-20: reward_system must not equal the USDC token address"
         );
     }
 }

--- a/contract/contracts/tycoon-token/ACCEPTANCE_CRITERIA.md
+++ b/contract/contracts/tycoon-token/ACCEPTANCE_CRITERIA.md
@@ -1,0 +1,168 @@
+# Acceptance Criteria — tycoon-token (SW-CT-004)
+
+Stellar Wave · Contract (Soroban / Stellar)
+Issue: SW-CT-004
+
+---
+
+## Functional Acceptance Criteria
+
+### Initialization
+
+- [x] `initialize` sets the admin, mints `initial_supply` to admin, and stores `TotalSupply`.
+  - A second call panics with `"Already initialized"`.
+  - Rejects a negative `initial_supply` with `"Initial supply cannot be negative"`.
+  - Emits `MintEvent { to: admin, amount: initial_supply }`.
+
+### Admin Functions
+
+- [x] `mint` creates new tokens and credits them to `to`.
+  - Requires admin authorization (`require_auth()`); non-admin callers are rejected.
+  - Rejects `amount <= 0` with `"Amount must be positive"`.
+  - Increments `total_supply` by exactly `amount` (`checked_add`; panics on overflow).
+  - Emits `MintEvent { to, amount }`.
+- [x] `set_admin` transfers the admin role to `new_admin`.
+  - Requires current admin authorization.
+  - Emits `SetAdminEvent { old_admin, new_admin }`.
+- [x] `admin` returns the current admin address (read-only, no auth required).
+- [x] `total_supply` returns the current total supply (read-only, no auth required).
+
+### SEP-41 Token Operations
+
+- [x] `transfer` moves `amount` from `from` to `to`.
+  - Requires `from` authorization.
+  - Rejects negative `amount` with `"Amount cannot be negative"`.
+  - Zero-amount transfer is a documented no-op (returns without state change).
+  - Fails with `"Insufficient balance"` when `from` holds fewer tokens than `amount`.
+  - Recipient balance updated with `checked_add` (panics on overflow).
+  - Emits `TransferEvent { from, to, amount }`.
+- [x] `transfer_from` moves `amount` on behalf of `from` using spender's allowance.
+  - Requires `spender` authorization.
+  - Rejects negative `amount` with `"Amount cannot be negative"`.
+  - Zero-amount is a no-op.
+  - Fails with `"Allowance expired"` when `expiration_ledger > 0` and current ledger exceeds it.
+  - Fails with `"Insufficient allowance"` when allowance is less than `amount`.
+  - Fails with `"Insufficient balance"` when `from` balance is less than `amount`.
+  - Decrements allowance by exactly `amount` after a successful transfer.
+  - Emits `TransferEvent { from, to, amount }`.
+- [x] `approve` sets a spending allowance for `spender` on behalf of `from`.
+  - Requires `from` authorization.
+  - Rejects negative `amount` with `"Amount cannot be negative"`.
+  - `expiration_ledger = 0` is treated as a permanent (non-expiring) allowance.
+  - Emits `ApproveEvent { from, spender, amount, expiration_ledger }`.
+- [x] `allowance` returns the current allowance for `(from, spender)`.
+  - Returns `0` for expired entries (no stale reads).
+  - Returns `0` when no allowance has been set.
+- [x] `balance` returns the token balance for `id` (defaults to `0` if never set).
+- [x] `burn` destroys `amount` tokens held by `from`.
+  - Requires `from` authorization.
+  - Rejects `amount <= 0` with `"Amount must be positive"`.
+  - Fails with `"Insufficient balance"` when balance is less than `amount`.
+  - Decrements `total_supply` by exactly `amount` (`checked_sub`; panics on underflow).
+  - Emits `BurnEvent { from, amount }`.
+- [x] `burn_from` destroys `amount` tokens from `from` using spender's allowance.
+  - Requires `spender` authorization.
+  - Rejects `amount <= 0` with `"Amount must be positive"`.
+  - Fails with `"Allowance expired"` when allowance has expired.
+  - Fails with `"Insufficient allowance"` when allowance is less than `amount`.
+  - Fails with `"Insufficient balance"` when `from` balance is less than `amount`.
+  - Decrements both allowance and balance by exactly `amount`.
+  - Decrements `total_supply` by exactly `amount`.
+  - Emits `BurnEvent { from, amount }`.
+
+### Metadata
+
+- [x] `name` returns `"Tycoon"` (read-only).
+- [x] `symbol` returns `"TYC"` (read-only).
+- [x] `decimals` returns `18` (read-only).
+
+### Legacy / Deprecated Entrypoints
+
+- [x] `legacy_mint` panics with `"legacy_mint is deprecated; use mint instead"`.
+- [x] `legacy_burn` panics with `"legacy_burn is deprecated; use burn instead"`.
+- [x] `legacy_transfer` panics with `"legacy_transfer is deprecated; use transfer instead"`.
+
+---
+
+## Invariants
+
+| ID     | Invariant |
+|--------|-----------|
+| INV-01 | `total_supply` always equals the sum of all individual balances |
+| INV-02 | `total_supply` increases by exactly `amount` on every successful `mint` |
+| INV-03 | `total_supply` decreases by exactly `amount` on every successful `burn` / `burn_from` |
+| INV-04 | `total_supply` is never negative |
+| INV-05 | Minting zero or a negative amount is rejected (`"Amount must be positive"`) |
+| INV-06 | Burning zero or a negative amount is rejected (`"Amount must be positive"`) |
+| INV-07 | Burning more than a holder's balance is rejected (`"Insufficient balance"`) |
+| INV-08 | `burn_from` is rejected when allowance is insufficient (`"Insufficient allowance"`) |
+| INV-09 | Arithmetic overflow on `mint` is caught and panics — no silent wrap (`checked_add`) |
+| INV-10 | Sequential mint → burn round-trip restores the original `total_supply` |
+| INV-11 | Multiple independent mints accumulate correctly in `total_supply` |
+| INV-12 | Multiple independent burns reduce `total_supply` correctly |
+| INV-13 | Burning the entire supply of a holder reduces `total_supply` to zero |
+| INV-14 | `burn_from` reduces both the holder's balance and the spender's allowance |
+| INV-15 | Only the admin can mint; non-admin callers are rejected by `require_auth()` |
+| INV-16 | `MintEvent` is emitted with correct `to` and `amount` on every mint (including init) |
+| INV-17 | `BurnEvent` is emitted with correct `from` and `amount` on every burn / `burn_from` |
+
+---
+
+## Non-Functional Acceptance Criteria
+
+- [x] `cargo check --package tycoon-token` passes with no errors or warnings.
+- [x] `cargo test --package tycoon-token` passes (all tests green).
+- [x] No unaudited oracle or privileged off-chain price feed in production paths.
+- [x] CEI pattern is not applicable here — no cross-contract calls are made within this contract.
+- [x] All admin functions use `require_auth()`.
+- [x] All arithmetic uses `checked_add` / `checked_sub` — no silent integer overflow or underflow.
+- [x] `AllowanceValue` stores `amount` and `expiration_ledger` together — expiry cannot be stripped from the allowance record.
+
+---
+
+## Test Coverage Checklist
+
+| Area | Test(s) |
+|---|---|
+| Initialize / metadata | `test_initialization` |
+| Double-init guard | `test_cannot_reinitialize` |
+| Admin mint (positive) | `test_admin_can_mint` |
+| Admin mint (zero rejected) | `test_cannot_mint_zero` |
+| Transfer (success) | `test_transfer` |
+| Transfer (insufficient balance) | `test_transfer_insufficient_balance` |
+| Approve + transfer_from | `test_approve_and_transfer_from` |
+| transfer_from (insufficient allowance) | `test_transfer_from_insufficient_allowance` |
+| Burn (success) | `test_burn` |
+| Burn (insufficient balance) | `test_burn_insufficient_balance` |
+| burn_from (success) | `test_burn_from` |
+| burn_from (insufficient allowance) | `test_burn_from_insufficient_allowance` |
+| set_admin | `test_set_admin` |
+| New admin can mint | `test_new_admin_can_mint` |
+| Supply invariants | `invariant_tests` module |
+| Error branches | `error_branch_tests` module |
+| Access control | `access_control_tests` module |
+| Deprecation guards | `deprecation_tests` module |
+| Security review | `security_review_tests` module |
+
+---
+
+## Rollout / Migration Notes
+
+1. **No schema migration required** for this PR — only documentation and acceptance criteria are added; no on-chain state is modified.
+2. If deploying a fresh instance:
+   - Call `initialize(admin, initial_supply)` once.
+   - The admin address receives the full `initial_supply`.
+   - Admin key must be secured; it holds unlimited minting power.
+3. If upgrading an existing deployment:
+   - No `migrate` entrypoint is required for this change.
+   - Existing balances, allowances, and `total_supply` are unaffected.
+4. Legacy entrypoints (`legacy_mint`, `legacy_burn`, `legacy_transfer`) are retained in the ABI to surface a clear deprecation panic rather than a silent "function not found" error. Remove them only after all integrators have migrated.
+5. There is intentionally no hard supply cap. The practical ceiling is `i128::MAX` (~1.7 × 10³⁸), enforced by `checked_add` overflow guards.
+
+---
+
+## References
+
+- Stellar Wave batch issue: SW-CT-004
+- Related contracts: `tycoon-reward-system` (consumes `TycoonTokenClient::mint`), `tycoon-collectibles` (uses TYC as payment currency)
+- Related docs: `SECURITY_REVIEW_CHECKLIST.md`, `README.md`, `contract/docs/STORAGE_ECONOMICS.md`

--- a/contract/contracts/tycoon-token/CHANGELOG.md
+++ b/contract/contracts/tycoon-token/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - SW-CT-004
+
+### Added
+- `ACCEPTANCE_CRITERIA.md` — full functional and non-functional acceptance criteria for the tycoon-token contract, covering all entrypoints, invariants, test coverage checklist, and rollout/migration notes.
+
 ## [0.1.0] - 2026-03-27
 
 ### Added


### PR DESCRIPTION
Expands simulation_scenarios.rs with 9 new end-to-end simulation scenarios (SIM-12 through SIM-20) covering realistic game-session flows not exercised by the existing SIM-01–SIM-11 suite. No production code is modified. closes #598 