### PR TITLE
feat(backend): pagination sortBy allowlist + admin auth audit [SW-BE-…

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -21,9 +21,13 @@ const config: Config = {
     '^src/(.*)$': '<rootDir>/$1',
     '^@nestjs/config$': '<rootDir>/../test/mocks/nestjs-config.mock.ts',
     '^@nestjs/cache-manager$': '<rootDir>/../test/mocks/nestjs-cache-manager.mock.ts',
+    '^@nestjs/swagger$': '<rootDir>/../test/mocks/nestjs-swagger.mock.ts',
+    '^@nestjs/throttler$': '<rootDir>/../test/mocks/nestjs-throttler.mock.ts',
+    '^fast-csv$': '<rootDir>/../test/mocks/fast-csv.mock.ts',
     '^prom-client$': '<rootDir>/../test/mocks/prom-client.mock.ts',
     '^ioredis$': '<rootDir>/../test/mocks/ioredis.mock.ts',
     '^nest-winston$': '<rootDir>/../test/mocks/nest-winston.mock.ts',
+    '^winston-daily-rotate-file$': '<rootDir>/../test/mocks/winston-daily-rotate-file.mock.ts',
   },
   coverageThreshold: {
     global: {

--- a/backend/src/common/services/pagination.service.spec.ts
+++ b/backend/src/common/services/pagination.service.spec.ts
@@ -1,6 +1,7 @@
 import { PaginationService } from './pagination.service';
 import { SortOrder, PAGINATION_MAX_LIMIT } from '../dto/pagination.dto';
 import { SelectQueryBuilder } from 'typeorm';
+import { BadRequestException } from '@nestjs/common';
 
 /** Minimal stub that records the calls made by PaginationService. */
 function buildQb(rows: object[] = [], total = 0) {
@@ -117,5 +118,49 @@ describe('PaginationService', () => {
 
     expect(stub._skip).toBe(20);
     expect(stub._take).toBe(10);
+  });
+
+  describe('sortBy allowlist', () => {
+    it('allows a sortBy field that is in the allowlist', async () => {
+      const qb = buildQb([], 0);
+      await expect(
+        service.paginate(qb, { page: 1, sortBy: 'email' }, [], ['id', 'email', 'created_at']),
+      ).resolves.toBeDefined();
+    });
+
+    it('throws BadRequestException for a sortBy field not in the allowlist', async () => {
+      const qb = buildQb([], 0);
+      await expect(
+        service.paginate(qb, { page: 1, sortBy: 'password' }, [], ['id', 'email']),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for SQL-injection-style sortBy', async () => {
+      const qb = buildQb([], 0);
+      await expect(
+        service.paginate(
+          qb,
+          { page: 1, sortBy: '1; DROP TABLE users; --' },
+          [],
+          ['id', 'email'],
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('falls back to id sort when sortBy is absent even with an allowlist', async () => {
+      const qb = buildQb([], 0);
+      const stub = qb as unknown as { _orderBy: { expr: string }[] };
+      await service.paginate(qb, { page: 1 }, [], ['id', 'email']);
+
+      expect(stub._orderBy[0].expr).toBe('entity.id');
+    });
+
+    it('skips allowlist check when allowedSortFields is undefined', async () => {
+      const qb = buildQb([], 0);
+      // No allowedSortFields — any sortBy should be accepted (caller's responsibility)
+      await expect(
+        service.paginate(qb, { page: 1, sortBy: 'arbitrary_field' }),
+      ).resolves.toBeDefined();
+    });
   });
 });

--- a/backend/src/common/services/pagination.service.ts
+++ b/backend/src/common/services/pagination.service.ts
@@ -1,14 +1,27 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { SelectQueryBuilder, ObjectLiteral } from 'typeorm';
 import { PaginationDto, SortOrder, PAGINATION_MAX_LIMIT } from '../dto/pagination.dto';
 import { PaginatedResponse } from '../interfaces/paginated-response.interface';
 
 @Injectable()
 export class PaginationService {
+  /**
+   * @param queryBuilder  TypeORM query builder to paginate.
+   * @param paginationDto Validated pagination/sort/search parameters.
+   * @param searchableFields  Column names that may be searched via ILIKE.
+   * @param allowedSortFields Explicit allowlist of column names that may be
+   *   used as the primary sort key.  When provided and `sortBy` is not in the
+   *   list the method throws a 400 rather than forwarding an arbitrary column
+   *   name into the SQL ORDER BY clause (SQL-injection guard).
+   *   Pass an empty array to disable sorting entirely.
+   *   Omit (undefined) to skip the check — only do this when the caller has
+   *   already validated the field itself.
+   */
   async paginate<T extends ObjectLiteral>(
     queryBuilder: SelectQueryBuilder<T>,
     paginationDto: PaginationDto,
     searchableFields?: string[],
+    allowedSortFields?: string[],
   ): Promise<PaginatedResponse<T>> {
     const {
       page = 1,
@@ -31,9 +44,18 @@ export class PaginationService {
       queryBuilder.andWhere(`(${searchConditions})`, { search: `%${search}%` });
     }
 
+    // Validate sortBy against the allowlist when one is provided.
+    if (sortBy && allowedSortFields !== undefined) {
+      if (!allowedSortFields.includes(sortBy)) {
+        throw new BadRequestException(
+          `Invalid sortBy field "${sortBy}". Allowed: ${allowedSortFields.join(', ')}`,
+        );
+      }
+    }
+
     // Apply primary sort + stable secondary sort on `id` to guarantee
     // deterministic page boundaries when rows share the same primary sort value.
-    if (sortBy) {
+    if (sortBy && (allowedSortFields === undefined || allowedSortFields.includes(sortBy))) {
       queryBuilder
         .orderBy(`${queryBuilder.alias}.${sortBy}`, sortOrder)
         .addOrderBy(`${queryBuilder.alias}.id`, sortOrder);

--- a/backend/src/modules/auth/admin-auth.controller.spec.ts
+++ b/backend/src/modules/auth/admin-auth.controller.spec.ts
@@ -4,6 +4,7 @@ import { AdminAuthController } from './admin-auth.controller';
 import { AuthService } from './auth.service';
 import { Role } from './enums/role.enum';
 import { AdminLogsService } from '../admin-logs/admin-logs.service';
+import { AuthAuditService } from './audit/auth-audit.service';
 import { Request } from 'express';
 
 describe('AdminAuthController', () => {
@@ -43,6 +44,11 @@ describe('AdminAuthController', () => {
   });
 
   describe('login', () => {
+    const mockRequest = {
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'jest-agent' },
+    } as unknown as Request;
+
     it('should login admin successfully', async () => {
       const adminLoginDto = {
         email: 'admin@example.com',
@@ -62,27 +68,80 @@ describe('AdminAuthController', () => {
         refreshToken: 'mock-refresh-token',
       });
 
-      const mockRequest = {
-        ip: '127.0.0.1',
-        headers: { 'user-agent': 'jest' },
-      } as unknown as Request;
-
       const result = await controller.login(adminLoginDto, mockRequest);
 
       expect(result).toEqual({
         accessToken: 'mock-access-token',
         refreshToken: 'mock-refresh-token',
       });
+    });
+
+    it('passes ip and userAgent to validateAdmin', async () => {
+      const adminLoginDto = { email: 'admin@example.com', password: 'pw' };
+      const mockUser = { id: 1, email: 'admin@example.com', role: Role.ADMIN, is_admin: true };
+      (authService.validateAdmin as jest.Mock).mockResolvedValue(mockUser);
+      (authService.login as jest.Mock).mockResolvedValue({});
+
+      await controller.login(adminLoginDto, mockRequest);
+
       expect(authService.validateAdmin).toHaveBeenCalledWith(
         adminLoginDto.email,
         adminLoginDto.password,
+        '127.0.0.1',
+        'jest-agent',
       );
-      expect(authService.login).toHaveBeenCalledWith({
-        id: mockUser.id,
-        email: mockUser.email,
-        role: mockUser.role,
-        is_admin: mockUser.is_admin,
-      });
+    });
+
+    it('passes ip and userAgent to login', async () => {
+      const adminLoginDto = { email: 'admin@example.com', password: 'pw' };
+      const mockUser = { id: 1, email: 'admin@example.com', role: Role.ADMIN, is_admin: true };
+      (authService.validateAdmin as jest.Mock).mockResolvedValue(mockUser);
+      (authService.login as jest.Mock).mockResolvedValue({});
+
+      await controller.login(adminLoginDto, mockRequest);
+
+      expect(authService.login).toHaveBeenCalledWith(
+        { id: mockUser.id, email: mockUser.email, role: mockUser.role, is_admin: mockUser.is_admin },
+        '127.0.0.1',
+        'jest-agent',
+      );
+    });
+
+    it('logs a redacted email, not the raw email', async () => {
+      const adminLoginDto = { email: 'admin@example.com', password: 'pw' };
+      const mockUser = { id: 1, email: 'admin@example.com', role: Role.ADMIN, is_admin: true };
+      (authService.validateAdmin as jest.Mock).mockResolvedValue(mockUser);
+      (authService.login as jest.Mock).mockResolvedValue({});
+
+      await controller.login(adminLoginDto, mockRequest);
+
+      // The admin log should contain the redacted form, not the raw email
+      const redacted = AuthAuditService.redactEmail('admin@example.com');
+      expect(adminLogsService.createLog).toHaveBeenCalledWith(
+        mockUser.id,
+        'ADMIN_LOGIN_SUCCESS',
+        mockUser.id,
+        { email: redacted },
+        mockRequest,
+      );
+    });
+
+    it('logs redacted email on failed login', async () => {
+      const adminLoginDto = { email: 'admin@example.com', password: 'wrong' };
+      (authService.validateAdmin as jest.Mock).mockResolvedValue(null);
+
+      await expect(controller.login(adminLoginDto, mockRequest)).rejects.toThrow(
+        UnauthorizedException,
+      );
+
+      const redacted = AuthAuditService.redactEmail('admin@example.com');
+      expect(adminLogsService.createLog).toHaveBeenCalledWith(
+        undefined,
+        'ADMIN_LOGIN_FAILED',
+        undefined,
+        { email: redacted },
+        mockRequest,
+      );
     });
 
     it('should throw UnauthorizedException for invalid credentials', async () => {
@@ -92,11 +151,6 @@ describe('AdminAuthController', () => {
       };
 
       (authService.validateAdmin as jest.Mock).mockResolvedValue(null);
-
-      const mockRequest = {
-        ip: '127.0.0.1',
-        headers: { 'user-agent': 'jest' },
-      } as unknown as Request;
 
       await expect(
         controller.login(adminLoginDto, mockRequest),

--- a/backend/src/modules/auth/admin-auth.controller.ts
+++ b/backend/src/modules/auth/admin-auth.controller.ts
@@ -12,6 +12,7 @@ import { AdminLoginDto } from './dto/admin-login.dto';
 import { Throttle } from '@nestjs/throttler';
 
 import { AdminLogsService } from '../admin-logs/admin-logs.service';
+import { AuthAuditService } from './audit/auth-audit.service';
 import * as express from 'express';
 import { Req } from '@nestjs/common';
 
@@ -31,44 +32,54 @@ export class AdminAuthController {
     @Body() adminLoginDto: AdminLoginDto,
     @Req() req: express.Request,
   ) {
-    this.logger.log(`Admin login attempt for email: ${adminLoginDto.email}`);
+    const redactedEmail = AuthAuditService.redactEmail(adminLoginDto.email);
+    this.logger.log(`Admin login attempt for email: ${redactedEmail}`);
+
+    const ipAddress = req.ip;
+    const userAgent = req.headers?.['user-agent'];
 
     const user = await this.authService.validateAdmin(
       adminLoginDto.email,
       adminLoginDto.password,
+      ipAddress,
+      userAgent,
     );
 
     if (!user) {
       this.logger.warn(
-        `Failed admin login attempt for email: ${adminLoginDto.email}`,
+        `Failed admin login attempt for email: ${redactedEmail}`,
       );
 
       await this.adminLogsService.createLog(
         undefined,
         'ADMIN_LOGIN_FAILED',
         undefined,
-        { email: adminLoginDto.email },
+        { email: redactedEmail },
         req,
       );
 
       throw new UnauthorizedException('Invalid admin credentials');
     }
 
-    this.logger.log(`Successful admin login for email: ${adminLoginDto.email}`);
+    this.logger.log(`Successful admin login for email: ${redactedEmail}`);
 
     await this.adminLogsService.createLog(
       user.id,
       'ADMIN_LOGIN_SUCCESS',
       user.id,
-      { email: user.email },
+      { email: redactedEmail },
       req,
     );
 
-    return this.authService.login({
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      is_admin: user.is_admin,
-    });
+    return this.authService.login(
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        is_admin: user.is_admin,
+      },
+      ipAddress,
+      userAgent,
+    );
   }
 }

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -103,6 +103,18 @@ describe('UsersService', () => {
       expect(result).toEqual(paginatedResponse);
       expect(mockPaginationService.paginate).toHaveBeenCalled();
     });
+
+    it('passes an allowedSortFields array to PaginationService', async () => {
+      mockPaginationService.paginate.mockResolvedValue({ data: [], meta: {} });
+      repositoryMock.createQueryBuilder = jest.fn().mockReturnValue({});
+
+      await service.findAll({ page: 1, sortBy: 'email' });
+
+      const [, , , allowedSortFields] = mockPaginationService.paginate.mock.calls[0];
+      expect(Array.isArray(allowedSortFields)).toBe(true);
+      expect(allowedSortFields).toContain('email');
+      expect(allowedSortFields).toContain('id');
+    });
   });
 
   describe('findOne', () => {

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -61,10 +61,12 @@ export class UsersService {
   ): Promise<PaginatedResponse<User>> {
     const queryBuilder = this.userRepository.createQueryBuilder('user');
     const searchableFields = ['email', 'firstName', 'lastName'];
+    const allowedSortFields = ['id', 'email', 'firstName', 'lastName', 'created_at', 'updated_at'];
     return await this.paginationService.paginate(
       queryBuilder,
       paginationDto,
       searchableFields,
+      allowedSortFields,
     );
   }
 
@@ -337,8 +339,9 @@ export class UsersService {
       .orderBy('user.game_won', 'DESC')
       .addOrderBy('user.total_earned', 'DESC');
 
+    const allowedSortFields = ['id', 'username', 'game_won', 'games_played', 'total_earned'];
     return await this.paginationService.paginate(queryBuilder, paginationDto, [
       'username',
-    ]);
+    ], allowedSortFields);
   }
 }

--- a/backend/test/mocks/fast-csv.mock.ts
+++ b/backend/test/mocks/fast-csv.mock.ts
@@ -1,0 +1,5 @@
+/** Minimal fast-csv stub for unit tests. */
+export const write = jest.fn();
+export const format = jest.fn(() => ({ pipe: jest.fn(), write: jest.fn(), end: jest.fn() }));
+export const parseString = jest.fn();
+export const parseFile = jest.fn();

--- a/backend/test/mocks/nestjs-swagger.mock.ts
+++ b/backend/test/mocks/nestjs-swagger.mock.ts
@@ -1,0 +1,29 @@
+/** Minimal @nestjs/swagger stub for unit tests. */
+const noop = () => () => {};
+const noopClass = () => class {};
+
+export const ApiPropertyOptional = noop;
+export const ApiProperty = noop;
+export const ApiTags = noop;
+export const ApiOperation = noop;
+export const ApiResponse = noop;
+export const ApiOkResponse = noop;
+export const ApiCreatedResponse = noop;
+export const ApiNotFoundResponse = noop;
+export const ApiUnauthorizedResponse = noop;
+export const ApiBearerAuth = noop;
+export const ApiQuery = noop;
+export const ApiParam = noop;
+export const ApiBody = noop;
+export const ApiHeader = noop;
+export const ApiConsumes = noop;
+export const ApiExcludeController = noop;
+
+// Mapped types — return the input class unchanged
+export const PartialType = (cls: unknown) => cls;
+export const OmitType = (cls: unknown, _keys: unknown) => cls;
+export const PickType = (cls: unknown, _keys: unknown) => cls;
+export const IntersectionType = (...classes: unknown[]) => classes[0];
+
+export const DocumentBuilder = noopClass;
+export const SwaggerModule = { createDocument: () => ({}), setup: () => {} };

--- a/backend/test/mocks/nestjs-throttler.mock.ts
+++ b/backend/test/mocks/nestjs-throttler.mock.ts
@@ -1,0 +1,7 @@
+/** Minimal @nestjs/throttler stub for unit tests. */
+export const ThrottlerGuard = class {
+  canActivate() { return true; }
+};
+export const ThrottlerException = class extends Error {};
+export const Throttle = () => () => {};
+export const SkipThrottle = () => () => {};

--- a/backend/test/mocks/winston-daily-rotate-file.mock.ts
+++ b/backend/test/mocks/winston-daily-rotate-file.mock.ts
@@ -1,0 +1,8 @@
+/** Minimal winston-daily-rotate-file stub for unit tests. */
+const DailyRotateFile = jest.fn().mockImplementation(() => ({
+  on: jest.fn(),
+  write: jest.fn(),
+  end: jest.fn(),
+}));
+export default DailyRotateFile;
+module.exports = DailyRotateFile;


### PR DESCRIPTION
pr close #549 

- PaginationService.paginate() accepts allowedSortFields to enforce an explicit allowlist; throws 400 for disallowed or injection-style values
- UsersService.findAll() and getLeaderboard() pass per-endpoint allowlists
- AdminAuthController: redact email in all log/audit entries; forward ip + userAgent to both validateAdmin() and login() for full audit trail
- 10 new Jest specs covering allowlist enforcement and admin-auth fixes
- Add missing Jest mocks (@nestjs/swagger, @nestjs/throttler, fast-csv, winston-daily-rotate-file) that were blocking test suites

Closes SW-BE-002