### PR TITLE
SW-FE-830: Fix hero MSW content handlers and add empty/error fixture parity tests

### DIFF
--- a/frontend/src/mocks/handlers/hero.ts
+++ b/frontend/src/mocks/handlers/hero.ts
@@ -9,26 +9,17 @@ import { http, HttpResponse } from "msw";
 import { mockHeroContent, mockHeroContentEmpty, mockHeroApiError } from "../fixtures/hero";
 
 export const heroHandlers = [
-  // GET /api/hero/content — fetch hero content (announcements, features, welcome message)
-  http.get("*/api/hero/content", () => {
-    return HttpResponse.json(mockHeroContent, { status: 200 });
-  }),
-
-  // GET /api/hero/content?empty=true — simulate empty state
-  http.get("*/api/hero/content", ({ request }) => {
-    const url = new URL(request.url);
-    if (url.searchParams.get("empty") === "true") {
-      return HttpResponse.json(mockHeroContentEmpty, { status: 200 });
-    }
-    return HttpResponse.json(mockHeroContent, { status: 200 });
-  }),
-
-  // GET /api/hero/content?error=true — simulate server error
+  // GET /api/hero/content — fetch hero content and allow fixture overrides for empty/error states
   http.get("*/api/hero/content", ({ request }) => {
     const url = new URL(request.url);
     if (url.searchParams.get("error") === "true") {
       return HttpResponse.json(mockHeroApiError, { status: 500 });
     }
+
+    if (url.searchParams.get("empty") === "true") {
+      return HttpResponse.json(mockHeroContentEmpty, { status: 200 });
+    }
+
     return HttpResponse.json(mockHeroContent, { status: 200 });
   }),
 

--- a/frontend/test/hero-msw-handlers.test.ts
+++ b/frontend/test/hero-msw-handlers.test.ts
@@ -56,6 +56,24 @@ describe("SW-FE-008: Hero MSW handlers — parity with API", () => {
     expect(feature).toHaveProperty("order");
   });
 
+  it("GET /api/hero/content?empty=true returns empty hero content", async () => {
+    const res = await fetch("/api/hero/content?empty=true");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.announcements).toHaveLength(0);
+    expect(body.features).toHaveLength(0);
+    expect(body.welcomeMessage).toBe(mockHeroContentEmpty.welcomeMessage);
+  });
+
+  it("GET /api/hero/content?error=true returns 500 and hero error payload", async () => {
+    const res = await fetch("/api/hero/content?error=true");
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toHaveProperty("code", mockHeroApiError.code);
+    expect(body).toHaveProperty("message", mockHeroApiError.message);
+    expect(body).toHaveProperty("statusCode", mockHeroApiError.statusCode);
+  });
+
   it("GET /api/hero/announcements returns paginated announcements", async () => {
     const res = await fetch("/api/hero/announcements");
     expect(res.status).toBe(200);


### PR DESCRIPTION
closes #830 