### PR TITLE
feat: landing hero telemetry hooks (privacy-safe)

### DIFF
--- a/frontend/src/components/guest/HeroSection.tsx
+++ b/frontend/src/components/guest/HeroSection.tsx
@@ -37,20 +37,20 @@ const subSpeed = 30;
 
 const HeroSection: React.FC<HeroSectionProps> = ({ className }) => {
   const router = useRouter();
-  const { fire } = useHeroTelemetry();
+  const { trackHeroViewed, trackCtaClicked } = useHeroTelemetry();
   const prefersReducedMotion = usePrefersReducedMotion();
   const [error, setError] = useState<HeroErrorState>({ hasError: false, message: "" });
 
-  // SW-3: fire hero_view once on mount
+  // #828: track hero section view once on mount
   useEffect(() => {
-    fire("hero_view");
-  }, [fire]);
+    trackHeroViewed();
+  }, [trackHeroViewed]);
 
   // SW-FE-005: Error boundary for navigation failures
   const handleTrackedNavigation = useCallback(
-    (event: "continue_game_click" | "multiplayer_click" | "join_room_click" | "challenge_ai_click", destination: string) => {
+    (cta: "continue_game" | "multiplayer" | "join_room" | "challenge_ai", destination: string) => {
       try {
-        fire(event);
+        trackCtaClicked(cta, destination);
         router.push(destination);
       } catch (err) {
         const sanitized = sanitizeError(err);
@@ -59,7 +59,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ className }) => {
         }
       }
     },
-    [fire, router],
+    [trackCtaClicked, router],
   );
 
   // SW-FE-005: Empty state — show a friendly message when there's no content to display
@@ -80,7 +80,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ className }) => {
           <button
             onClick={() => {
               setError({ hasError: false, message: "" });
-              fire("hero_view");
+              trackHeroViewed();
             }}
             className="font-orbitron text-[#010F10] bg-[#00F0FF] px-6 py-3 rounded-lg font-[700] text-[14px] hover:opacity-90 transition-opacity"
             aria-label="Try again"
@@ -205,7 +205,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ className }) => {
           <button
             data-testid="hero-primary-cta"
             aria-label="Continue game"
-            onClick={() => handleTrackedNavigation("continue_game_click", "/game-settings")}
+            onClick={() => handleTrackedNavigation("continue_game", "/game-settings")}
             className="relative group w-[300px] h-[56px] bg-transparent border-none p-0 overflow-hidden cursor-pointer transition-transform group-hover:scale-105"
           >
             <svg
@@ -233,7 +233,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ className }) => {
           {/* Multiplayer */}
           <button
             aria-label="Multiplayer"
-            onClick={() => handleTrackedNavigation("multiplayer_click", "/game-settings")}
+            onClick={() => handleTrackedNavigation("multiplayer", "/game-settings")}
             className="relative group w-[227px] h-[40px] bg-transparent border-none p-0 overflow-hidden cursor-pointer"
           >
             <svg
@@ -262,7 +262,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ className }) => {
           {/* Join Room */}
           <button
             aria-label="Join room"
-            onClick={() => handleTrackedNavigation("join_room_click", "/join-room")}
+            onClick={() => handleTrackedNavigation("join_room", "/join-room")}
             className="relative group w-[140px] h-[40px] bg-transparent border-none p-0 overflow-hidden cursor-pointer"
           >
             <svg
@@ -291,7 +291,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ className }) => {
           {/* Challenge AI */}
           <button
             aria-label="Challenge AI"
-            onClick={() => handleTrackedNavigation("challenge_ai_click", "/play-ai")}
+            onClick={() => handleTrackedNavigation("challenge_ai", "/play-ai")}
             className="relative group w-[260px] h-[52px] bg-transparent border-none p-0 overflow-hidden cursor-pointer transition-transform duration-300 group-hover:scale-105"
           >
             <svg

--- a/frontend/src/components/guest/HeroSectionMobile.tsx
+++ b/frontend/src/components/guest/HeroSectionMobile.tsx
@@ -3,7 +3,7 @@
 import { Dices, Gamepad2, Bot } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { track } from "@/lib/analytics";
+import { useHeroTelemetry } from "@/hooks/useHeroTelemetry";
 
 interface HeroSectionMobileProps {
   className?: string | undefined;
@@ -48,20 +48,22 @@ function usePrefersReducedMotion(): boolean {
  */
 export default function HeroSectionMobile({ className }: HeroSectionMobileProps): React.ReactElement {
   const router = useRouter();
+  const { trackHeroViewed, trackCtaClicked } = useHeroTelemetry();
   const prefersReducedMotion = usePrefersReducedMotion();
+
+  // #828: track hero section view once on mount
+  useEffect(() => {
+    trackHeroViewed();
+  }, [trackHeroViewed]);
 
   const ctaBase =
     "min-h-[48px] min-w-[48px] flex items-center justify-center gap-2 font-orbitron font-[700] rounded-xl transition-transform active:scale-95 touch-manipulation";
 
   const handleTrackedNavigation = (
-    event: "continue_game_click" | "multiplayer_click" | "join_room_click" | "play_ai_click",
+    cta: "continue_game" | "multiplayer" | "join_room" | "challenge_ai",
     destination: string,
   ): void => {
-    track(event, {
-      route: "/",
-      destination,
-    });
-
+    trackCtaClicked(cta, destination);
     router.push(destination);
   }
 
@@ -108,7 +110,7 @@ export default function HeroSectionMobile({ className }: HeroSectionMobileProps)
         {/* Stacked CTAs - touch-friendly (min 48px) */}
         <div className="w-full flex flex-col gap-3 mt-2">
           <button
-            onClick={() => handleTrackedNavigation("continue_game_click", "/game-settings")}
+            onClick={() => handleTrackedNavigation("continue_game", "/game-settings")}
             className={`w-full ${ctaBase} bg-[#00F0FF] text-[#010F10] text-[16px] py-4`}
             aria-label="Continue game"
           >
@@ -117,7 +119,7 @@ export default function HeroSectionMobile({ className }: HeroSectionMobileProps)
           </button>
 
           <button
-            onClick={() => handleTrackedNavigation("multiplayer_click", "/game-settings")}
+            onClick={() => handleTrackedNavigation("multiplayer", "/game-settings")}
             className={`w-full ${ctaBase} border-2 border-[#00F0FF] text-[#00F0FF] text-[14px] py-3`}
             aria-label="Multiplayer"
           >
@@ -126,7 +128,7 @@ export default function HeroSectionMobile({ className }: HeroSectionMobileProps)
           </button>
 
           <button
-            onClick={() => handleTrackedNavigation("join_room_click", "/join-room")}
+            onClick={() => handleTrackedNavigation("join_room", "/join-room")}
             className={`w-full ${ctaBase} border-2 border-[#003B3E] text-[#0FF0FC] text-[14px] py-3`}
             aria-label="Join room"
           >
@@ -135,7 +137,7 @@ export default function HeroSectionMobile({ className }: HeroSectionMobileProps)
           </button>
 
           <button
-            onClick={() => handleTrackedNavigation("play_ai_click", "/play-ai")}
+            onClick={() => handleTrackedNavigation("challenge_ai", "/play-ai")}
             className={`w-full ${ctaBase} bg-[#00F0FF] text-[#010F10] text-[14px] py-4 uppercase tracking-wide`}
             aria-label="Challenge AI"
           >

--- a/frontend/src/hooks/__tests__/useHeroTelemetry.test.tsx
+++ b/frontend/src/hooks/__tests__/useHeroTelemetry.test.tsx
@@ -1,0 +1,151 @@
+import { renderHook, act } from '@testing-library/react';
+import { useHeroTelemetry } from '../useHeroTelemetry';
+import { track } from '@/lib/analytics';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('@/lib/analytics', () => ({
+  track: vi.fn(),
+}));
+
+describe('useHeroTelemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('returns trackHeroViewed and trackCtaClicked', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      expect(result.current.trackHeroViewed).toBeDefined();
+      expect(result.current.trackCtaClicked).toBeDefined();
+    });
+
+    it('uses default route "/"', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => { result.current.trackHeroViewed(); });
+      expect(track).toHaveBeenCalledWith('hero_viewed', expect.objectContaining({ route: '/' }));
+    });
+
+    it('accepts a custom route', () => {
+      const { result } = renderHook(() => useHeroTelemetry('/landing'));
+      act(() => { result.current.trackHeroViewed(); });
+      expect(track).toHaveBeenCalledWith('hero_viewed', expect.objectContaining({ route: '/landing' }));
+    });
+  });
+
+  describe('trackHeroViewed', () => {
+    it('tracks hero_viewed with default source', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => { result.current.trackHeroViewed(); });
+      expect(track).toHaveBeenCalledWith('hero_viewed', { route: '/', source: 'page_load' });
+    });
+
+    it('tracks hero_viewed with custom source', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => { result.current.trackHeroViewed('scroll'); });
+      expect(track).toHaveBeenCalledWith('hero_viewed', { route: '/', source: 'scroll' });
+    });
+
+    it('does not include PII in payload', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => { result.current.trackHeroViewed(); });
+      const payload = (track as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(payload).not.toHaveProperty('user_id');
+      expect(payload).not.toHaveProperty('wallet_address');
+      expect(payload).not.toHaveProperty('session');
+    });
+  });
+
+  describe('trackCtaClicked', () => {
+    it('tracks hero_cta_clicked for continue_game', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => { result.current.trackCtaClicked('continue_game', '/game-settings'); });
+      expect(track).toHaveBeenCalledWith('hero_cta_clicked', {
+        route: '/',
+        cta: 'continue_game',
+        destination: '/game-settings',
+      });
+    });
+
+    it('tracks hero_cta_clicked for multiplayer', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => { result.current.trackCtaClicked('multiplayer', '/game-settings'); });
+      expect(track).toHaveBeenCalledWith('hero_cta_clicked', {
+        route: '/',
+        cta: 'multiplayer',
+        destination: '/game-settings',
+      });
+    });
+
+    it('tracks hero_cta_clicked for join_room', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => { result.current.trackCtaClicked('join_room', '/join-room'); });
+      expect(track).toHaveBeenCalledWith('hero_cta_clicked', {
+        route: '/',
+        cta: 'join_room',
+        destination: '/join-room',
+      });
+    });
+
+    it('tracks hero_cta_clicked for challenge_ai', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => { result.current.trackCtaClicked('challenge_ai', '/play-ai'); });
+      expect(track).toHaveBeenCalledWith('hero_cta_clicked', {
+        route: '/',
+        cta: 'challenge_ai',
+        destination: '/play-ai',
+      });
+    });
+
+    it('does not include PII in payload', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => { result.current.trackCtaClicked('continue_game', '/game-settings'); });
+      const payload = (track as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(payload).not.toHaveProperty('user_id');
+      expect(payload).not.toHaveProperty('wallet_address');
+      expect(payload).not.toHaveProperty('session');
+    });
+  });
+
+  describe('callback stability', () => {
+    it('returns stable references across re-renders with same route', () => {
+      const { result, rerender } = renderHook(
+        ({ route }: { route: string }) => useHeroTelemetry(route),
+        { initialProps: { route: '/' } },
+      );
+      const first = result.current.trackHeroViewed;
+      rerender({ route: '/' });
+      expect(result.current.trackHeroViewed).toBe(first);
+    });
+
+    it('updates callbacks when route changes', () => {
+      const { result, rerender } = renderHook(
+        ({ route }: { route: string }) => useHeroTelemetry(route),
+        { initialProps: { route: '/' } },
+      );
+      act(() => { result.current.trackHeroViewed(); });
+      expect(track).toHaveBeenCalledWith('hero_viewed', expect.objectContaining({ route: '/' }));
+
+      vi.clearAllMocks();
+      rerender({ route: '/promo' });
+      act(() => { result.current.trackHeroViewed(); });
+      expect(track).toHaveBeenCalledWith('hero_viewed', expect.objectContaining({ route: '/promo' }));
+    });
+  });
+
+  describe('privacy compliance', () => {
+    it('never sends user identifiers across all events', () => {
+      const { result } = renderHook(() => useHeroTelemetry());
+      act(() => {
+        result.current.trackHeroViewed();
+        result.current.trackCtaClicked('continue_game', '/game-settings');
+        result.current.trackCtaClicked('challenge_ai', '/play-ai');
+      });
+      (track as ReturnType<typeof vi.fn>).mock.calls.forEach(([, payload]: [string, Record<string, unknown>]) => {
+        expect(payload).not.toHaveProperty('user_id');
+        expect(payload).not.toHaveProperty('wallet_address');
+        expect(payload).not.toHaveProperty('session_id');
+        expect(payload).not.toHaveProperty('email');
+      });
+    });
+  });
+});

--- a/frontend/src/hooks/useHeroTelemetry.ts
+++ b/frontend/src/hooks/useHeroTelemetry.ts
@@ -1,50 +1,38 @@
+/**
+ * Privacy-safe telemetry hook for the landing hero (#828).
+ *
+ * Privacy guarantees:
+ *  - No user IDs, wallet addresses, or session tokens are ever sent.
+ *  - Only non-linkable fields: route, source, cta, destination.
+ *  - All payloads pass through sanitizeAnalyticsPayload automatically via track().
+ *  - Disabled server-side (track() is a no-op in SSR via analytics client guard).
+ */
+
 "use client";
 
-// SW-3: Privacy-safe telemetry hook for the landing hero.
-//
-// Design principles:
-//   - No PII collected (no IP, no user ID, no fingerprinting).
-//   - No external analytics SDK — events are dispatched on `window` so any
-//     first-party collector (e.g. a future /api/telemetry endpoint) can listen.
-//   - Disabled server-side (SSR-safe).
-//   - Feature-flagged via NEXT_PUBLIC_TELEMETRY_ENABLED env var.
-//   - All event names are string-literal typed to prevent typos.
+import { useCallback } from "react";
+import { track } from "@/lib/analytics";
 
-export type HeroEventName =
-  | "hero_view"
-  | "hero_cta_click"
-  | "hero_join_room_click"
-  | "hero_challenge_ai_click"
-  | "hero_multiplayer_click";
+export type HeroCta =
+  | "continue_game"
+  | "multiplayer"
+  | "join_room"
+  | "challenge_ai";
 
-export interface HeroTelemetryEvent {
-  name: HeroEventName;
-  /** Milliseconds since page load — no wall-clock timestamp to avoid PII */
-  elapsed: number;
-}
-
-function isTelemetryEnabled(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    process.env.NEXT_PUBLIC_TELEMETRY_ENABLED === "true"
+export function useHeroTelemetry(route = "/") {
+  const trackHeroViewed = useCallback(
+    (source = "page_load") => {
+      track("hero_viewed", { route, source });
+    },
+    [route],
   );
-}
 
-let pageLoadTime: number | null = null;
+  const trackCtaClicked = useCallback(
+    (cta: HeroCta, destination: string) => {
+      track("hero_cta_clicked", { route, cta, destination });
+    },
+    [route],
+  );
 
-function getElapsed(): number {
-  if (typeof window === "undefined") return 0;
-  if (pageLoadTime === null) pageLoadTime = performance.now();
-  return Math.round(performance.now() - pageLoadTime);
-}
-
-export function trackHeroEvent(name: HeroEventName): void {
-  if (!isTelemetryEnabled()) return;
-  const payload: HeroTelemetryEvent = { name, elapsed: getElapsed() };
-  window.dispatchEvent(new CustomEvent("tycoon:telemetry", { detail: payload }));
-}
-
-/** React hook — returns a stable fire() callback. */
-export function useHeroTelemetry() {
-  return { fire: trackHeroEvent };
+  return { trackHeroViewed, trackCtaClicked };
 }

--- a/frontend/src/lib/analytics/taxonomy.ts
+++ b/frontend/src/lib/analytics/taxonomy.ts
@@ -8,10 +8,10 @@ export const analyticsEventSchema = {
   shop_grid_viewed: ["route", "item_count", "source"],
   shop_item_impression: ["route", "item_id", "item_name", "item_category", "item_rarity"],
   shop_purchase_initiated: ["route", "item_id", "item_name", "item_category", "item_rarity", "currency", "value"],
-  continue_game_click: ["route", "destination"],
-  multiplayer_click: ["route", "destination"],
-  join_room_click: ["route", "destination"],
-  play_ai_click: ["route", "destination"],
+  // Landing hero telemetry — #828
+  // Intentionally omits user_id, wallet_address, and session tokens (PII / linkable).
+  hero_viewed: ["route", "source"],
+  hero_cta_clicked: ["route", "cta", "destination"],
   // Join room telemetry — SW-FE-039
   // Intentionally omits room_code, user_id, and session tokens (PII / linkable).
   join_room_form_viewed: ["route", "source"],


### PR DESCRIPTION
- Rewrite useHeroTelemetry to use shared track() client (aligns with useShopTelemetry, useJoinRoomTelemetry, usePurchaseModalTelemetry)
- Add hero_viewed and hero_cta_clicked events to analytics taxonomy
- Remove stale per-CTA event names (continue_game_click etc.) that are now superseded by the unified hero_cta_clicked event
- Wire trackHeroViewed (on mount) and trackCtaClicked (on button press) in both HeroSection and HeroSectionMobile
- Align HeroSectionMobile to use the hook instead of calling track() directly
- Add useHeroTelemetry.test.tsx covering: init, trackHeroViewed, trackCtaClicked (all 4 CTAs), callback stability, and privacy compliance

Privacy guarantees:
  - No user IDs, wallet addresses, or session tokens sent
  - Only non-linkable fields: route, source, cta, destination
  - All payloads sanitized via sanitizeAnalyticsPayload through track()

Closes #828 