### PR TITLE
fix: hero accessibility, focus management & mobile error states (#823, #827)

### DIFF
--- a/frontend/src/components/guest/HeroSection.tsx
+++ b/frontend/src/components/guest/HeroSection.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import { Dices, Gamepad2 } from "lucide-react";
 import { TypeAnimation } from "react-type-animation";
 import { useRouter } from "next/navigation";
@@ -40,11 +40,20 @@ const HeroSection: React.FC<HeroSectionProps> = ({ className }) => {
   const { fire } = useHeroTelemetry();
   const prefersReducedMotion = usePrefersReducedMotion();
   const [error, setError] = useState<HeroErrorState>({ hasError: false, message: "" });
+  const tryAgainRef = useRef<HTMLButtonElement>(null);
 
   // SW-3: fire hero_view once on mount
   useEffect(() => {
     fire("hero_view");
   }, [fire]);
+
+  // Move focus to Try Again when error state activates so keyboard/screen-reader
+  // users are immediately directed to the recovery action.
+  useEffect(() => {
+    if (error.hasError) {
+      tryAgainRef.current?.focus();
+    }
+  }, [error.hasError]);
 
   // SW-FE-005: Error boundary for navigation failures
   const handleTrackedNavigation = useCallback(
@@ -78,6 +87,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ className }) => {
             {error.message}
           </p>
           <button
+            ref={tryAgainRef}
             onClick={() => {
               setError({ hasError: false, message: "" });
               fire("hero_view");

--- a/frontend/src/components/guest/HeroSectionMobile.tsx
+++ b/frontend/src/components/guest/HeroSectionMobile.tsx
@@ -2,11 +2,17 @@
 
 import { Dices, Gamepad2, Bot } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { track } from "@/lib/analytics";
+import { sanitizeError } from "@/lib/errors";
 
 interface HeroSectionMobileProps {
   className?: string | undefined;
+}
+
+interface HeroErrorState {
+  hasError: boolean;
+  message: string;
 }
 
 function usePrefersReducedMotion(): boolean {
@@ -49,24 +55,69 @@ function usePrefersReducedMotion(): boolean {
 export default function HeroSectionMobile({ className }: HeroSectionMobileProps): React.ReactElement {
   const router = useRouter();
   const prefersReducedMotion = usePrefersReducedMotion();
+  const [error, setError] = useState<HeroErrorState>({ hasError: false, message: "" });
+  const tryAgainRef = useRef<HTMLButtonElement>(null);
+
+  // Move focus to Try Again when error state activates.
+  useEffect(() => {
+    if (error.hasError) {
+      tryAgainRef.current?.focus();
+    }
+  }, [error.hasError]);
 
   const ctaBase =
     "min-h-[48px] min-w-[48px] flex items-center justify-center gap-2 font-orbitron font-[700] rounded-xl transition-transform active:scale-95 touch-manipulation";
 
-  const handleTrackedNavigation = (
-    event: "continue_game_click" | "multiplayer_click" | "join_room_click" | "play_ai_click",
-    destination: string,
-  ): void => {
-    track(event, {
-      route: "/",
-      destination,
-    });
+  const handleTrackedNavigation = useCallback(
+    (
+      event: "continue_game_click" | "multiplayer_click" | "join_room_click" | "play_ai_click",
+      destination: string,
+    ): void => {
+      try {
+        track(event, { route: "/", destination });
+        router.push(destination);
+      } catch (err) {
+        const sanitized = sanitizeError(err);
+        if (sanitized) {
+          setError({ hasError: true, message: sanitized.userMessage || "An unexpected error occurred" });
+        }
+      }
+    },
+    [router],
+  );
 
-    router.push(destination);
+  if (error.hasError) {
+    return (
+      <section
+        aria-label="Landing hero"
+        role="alert"
+        className={`z-0 w-full min-h-[calc(100dvh-87px)] relative overflow-x-hidden py-8 px-4 bg-[#010F10] flex items-center justify-center ${className || ""}`}
+      >
+        <div className="text-center px-4">
+          <p className="font-orbitron text-[#00F0FF] text-[20px] font-[700] mb-4">
+            Something went wrong
+          </p>
+          <p className="font-dmSans text-[#F0F7F7] text-[14px] mb-6">
+            {error.message}
+          </p>
+          <button
+            ref={tryAgainRef}
+            onClick={() => setError({ hasError: false, message: "" })}
+            className="font-orbitron text-[#010F10] bg-[#00F0FF] px-6 py-3 rounded-lg font-[700] text-[14px] hover:opacity-90 transition-opacity"
+            aria-label="Try again"
+          >
+            Try Again
+          </button>
+        </div>
+      </section>
+    );
   }
 
   return (
-    <section className={`z-0 w-full min-h-[calc(100dvh-87px)] relative overflow-x-hidden py-8 px-4 bg-[#010F10] ${className || ""}`}>
+    <section
+      aria-label="Landing hero"
+      className={`z-0 w-full min-h-[calc(100dvh-87px)] relative overflow-x-hidden py-8 px-4 bg-[#010F10] ${className || ""}`}
+    >
       {/* Simplified background: flat gradient */}
       <div
         className="absolute inset-0 opacity-60"
@@ -74,7 +125,7 @@ export default function HeroSectionMobile({ className }: HeroSectionMobileProps)
           background:
             "linear-gradient(180deg, #010F10 0%, #0a1f21 40%, #010F10 100%)",
         }}
-        aria-hidden
+        aria-hidden="true"
       />
 
       <div className="relative z-10 mx-auto flex max-w-md flex-col items-center gap-6 text-center">
@@ -112,7 +163,7 @@ export default function HeroSectionMobile({ className }: HeroSectionMobileProps)
             className={`w-full ${ctaBase} bg-[#00F0FF] text-[#010F10] text-[16px] py-4`}
             aria-label="Continue game"
           >
-            <Gamepad2 className="w-6 h-6 shrink-0" />
+            <Gamepad2 aria-hidden="true" className="w-6 h-6 shrink-0" />
             Continue Game
           </button>
 
@@ -121,7 +172,7 @@ export default function HeroSectionMobile({ className }: HeroSectionMobileProps)
             className={`w-full ${ctaBase} border-2 border-[#00F0FF] text-[#00F0FF] text-[14px] py-3`}
             aria-label="Multiplayer"
           >
-            <Gamepad2 className="w-5 h-5 shrink-0" />
+            <Gamepad2 aria-hidden="true" className="w-5 h-5 shrink-0" />
             Multiplayer
           </button>
 
@@ -130,7 +181,7 @@ export default function HeroSectionMobile({ className }: HeroSectionMobileProps)
             className={`w-full ${ctaBase} border-2 border-[#003B3E] text-[#0FF0FC] text-[14px] py-3`}
             aria-label="Join room"
           >
-            <Dices className="w-5 h-5 shrink-0" />
+            <Dices aria-hidden="true" className="w-5 h-5 shrink-0" />
             Join Room
           </button>
 
@@ -139,7 +190,7 @@ export default function HeroSectionMobile({ className }: HeroSectionMobileProps)
             className={`w-full ${ctaBase} bg-[#00F0FF] text-[#010F10] text-[14px] py-4 uppercase tracking-wide`}
             aria-label="Challenge AI"
           >
-            <Bot className="w-5 h-5 shrink-0" />
+            <Bot aria-hidden="true" className="w-5 h-5 shrink-0" />
             Challenge AI!
           </button>
         </div>

--- a/frontend/test/HeroSectionMobile.test.tsx
+++ b/frontend/test/HeroSectionMobile.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * SW-FE-023/SW-FE-027: HeroSectionMobile — accessibility, error, and empty states.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockPush = vi.fn();
+const mockTrack = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+vi.mock("@/lib/errors", () => ({
+  sanitizeError: (err: unknown) => ({
+    userMessage: err instanceof Error ? err.message : "An unexpected error occurred",
+    category: "unknown",
+    recoverable: true,
+  }),
+}));
+
+import HeroSectionMobile from "@/components/guest/HeroSectionMobile";
+
+// ─── Tests ───────────────────────────────────────────────────────────────────────
+
+describe("HeroSectionMobile — accessibility", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockTrack.mockClear();
+  });
+
+  it("renders the section with an aria-label", () => {
+    render(<HeroSectionMobile />);
+    expect(screen.getByRole("region", { name: "Landing hero" })).toBeInTheDocument();
+  });
+
+  it("renders a single h1 element", () => {
+    render(<HeroSectionMobile />);
+    expect(document.querySelectorAll("h1")).toHaveLength(1);
+  });
+
+  it("renders all four CTA buttons", () => {
+    render(<HeroSectionMobile />);
+    expect(screen.getAllByRole("button")).toHaveLength(4);
+  });
+
+  it("all CTA buttons have accessible names", () => {
+    render(<HeroSectionMobile />);
+    for (const btn of screen.getAllByRole("button")) {
+      expect(btn).toHaveAttribute("aria-label");
+    }
+  });
+
+  it("decorative background element is hidden from assistive technology", () => {
+    const { container } = render(<HeroSectionMobile />);
+    const bg = container.querySelector<HTMLElement>("section > div[aria-hidden='true']");
+    expect(bg).not.toBeNull();
+  });
+
+  it("navigates correctly when Continue Game is clicked", () => {
+    render(<HeroSectionMobile />);
+    fireEvent.click(screen.getByRole("button", { name: /continue game/i }));
+    expect(mockPush).toHaveBeenCalledWith("/game-settings");
+  });
+
+  it("navigates correctly when Multiplayer is clicked", () => {
+    render(<HeroSectionMobile />);
+    fireEvent.click(screen.getByRole("button", { name: /multiplayer/i }));
+    expect(mockPush).toHaveBeenCalledWith("/game-settings");
+  });
+
+  it("navigates correctly when Join Room is clicked", () => {
+    render(<HeroSectionMobile />);
+    fireEvent.click(screen.getByRole("button", { name: /join room/i }));
+    expect(mockPush).toHaveBeenCalledWith("/join-room");
+  });
+
+  it("navigates correctly when Challenge AI is clicked", () => {
+    render(<HeroSectionMobile />);
+    fireEvent.click(screen.getByRole("button", { name: /challenge ai/i }));
+    expect(mockPush).toHaveBeenCalledWith("/play-ai");
+  });
+});
+
+describe("HeroSectionMobile — error state", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockTrack.mockClear();
+  });
+
+  it("renders error UI when navigation throws", () => {
+    mockPush.mockImplementationOnce(() => { throw new Error("Navigation failed"); });
+
+    render(<HeroSectionMobile />);
+    fireEvent.click(screen.getByRole("button", { name: /continue game/i }));
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("Navigation failed")).toBeInTheDocument();
+  });
+
+  it("renders generic message for non-Error throws", () => {
+    mockPush.mockImplementationOnce(() => { throw "string error"; });
+
+    render(<HeroSectionMobile />);
+    fireEvent.click(screen.getByRole("button", { name: /continue game/i }));
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("An unexpected error occurred")).toBeInTheDocument();
+  });
+
+  it("error state has role='alert' for screen readers", () => {
+    mockPush.mockImplementationOnce(() => { throw new Error("fail"); });
+
+    render(<HeroSectionMobile />);
+    fireEvent.click(screen.getByRole("button", { name: /continue game/i }));
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("Try Again button resets the error and restores normal state", () => {
+    mockPush.mockImplementationOnce(() => { throw new Error("fail"); });
+
+    render(<HeroSectionMobile />);
+    fireEvent.click(screen.getByRole("button", { name: /continue game/i }));
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Landing hero" })).toBeInTheDocument();
+  });
+
+  it("does not expose stack traces in error messages", () => {
+    const err = new Error("fail");
+    err.stack = "Error: fail\n    at Object.<anonymous> (test.ts:1:1)";
+    mockPush.mockImplementationOnce(() => { throw err; });
+
+    render(<HeroSectionMobile />);
+    fireEvent.click(screen.getByRole("button", { name: /continue game/i }));
+
+    expect(screen.queryByText(/at Object/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/test\.ts/)).not.toBeInTheDocument();
+  });
+});
+
+describe("HeroSectionMobile — empty state (happy path)", () => {
+  it("renders all content in normal state", () => {
+    render(<HeroSectionMobile />);
+    expect(screen.getByText("Welcome back, Player!")).toBeInTheDocument();
+    expect(screen.getByText("TYCOON")).toBeInTheDocument();
+  });
+
+  it("all buttons are enabled in normal state", () => {
+    render(<HeroSectionMobile />);
+    for (const btn of screen.getAllByRole("button")) {
+      expect(btn).not.toBeDisabled();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #823 — Landing hero: accessibility and focus order
Closes #827 — Landing hero: error and empty states

### Changes

**`HeroSection.tsx` (desktop) — issue #823**
- When the error state activates, `useRef` + `useEffect` move keyboard focus directly to the "Try Again" button so screen-reader and keyboard users are immediately directed to the recovery action — no manual navigation required.

**`HeroSectionMobile.tsx` — issues #823 & #827**
- Ported the full error-state pattern from the desktop component: catches navigation errors with `sanitizeError`, renders a `role="alert"` fallback with the sanitised message, and shows "Try Again" which auto-receives focus on mount and resets to the normal view on click.
- Added `aria-label="Landing hero"` to the `<section>` element (was missing entirely on mobile).
- Added `aria-hidden="true"` to all decorative Lucide icons inside CTA buttons, matching the desktop component's treatment.
- Converted `handleTrackedNavigation` to `useCallback` for consistency with the desktop component.

**`test/HeroSectionMobile.test.tsx`** (new, 16 cases)
- Accessibility: landmark role, single `<h1>`, all CTAs have accessible names, decorative background is `aria-hidden`.
- Navigation: all four buttons route to the correct destination.
- Error state: `Error` throws, string throws, `role="alert"` presence, Try-Again reset, no stack-trace leakage.
- Empty/happy path: content renders, all buttons enabled.

### Test results

```
Test Files  4 passed (4)
     Tests  47 passed (47)   ← 16 new + 31 existing hero/focus-trap tests
```

Pre-existing `JoinRoomForm` failures are unrelated to this PR (confirmed by running the suite on `main` before any changes).

## Test plan

- [ ] Run `npm test` in `frontend/` — all hero and focus-trap tests green.
- [ ] Manually tab through the landing hero on desktop; verify focus lands on "Try Again" after triggering an error.
- [ ] Verify mobile layout renders the error fallback (`role="alert"`) and that "Try Again" restores the normal view.
- [ ] Run axe / browser accessibility audit on the landing page — no new violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)