### PR TITLE
feat(frontend): tree-shake audit for lib/near — barrel index + unit t…

### DIFF
--- a/frontend/src/lib/near/__tests__/config.test.ts
+++ b/frontend/src/lib/near/__tests__/config.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getNearNetworkId,
+  isValidNearAccountId,
+  getNearContractId,
+  DEFAULT_FUNCTION_CALL_GAS,
+} from "../config";
+
+describe("getNearNetworkId", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns testnet by default when env is unset", () => {
+    delete process.env.NEXT_PUBLIC_NEAR_NETWORK;
+    expect(getNearNetworkId()).toBe("testnet");
+  });
+
+  it("returns mainnet when env is 'mainnet'", () => {
+    process.env.NEXT_PUBLIC_NEAR_NETWORK = "mainnet";
+    expect(getNearNetworkId()).toBe("mainnet");
+  });
+
+  it("returns mainnet when env is 'MAINNET' (case-insensitive)", () => {
+    process.env.NEXT_PUBLIC_NEAR_NETWORK = "MAINNET";
+    expect(getNearNetworkId()).toBe("mainnet");
+  });
+
+  it("returns testnet for any other value", () => {
+    process.env.NEXT_PUBLIC_NEAR_NETWORK = "staging";
+    expect(getNearNetworkId()).toBe("testnet");
+  });
+});
+
+describe("isValidNearAccountId", () => {
+  it("accepts a simple account id", () => {
+    expect(isValidNearAccountId("alice.near")).toBe(true);
+  });
+
+  it("accepts a testnet account id", () => {
+    expect(isValidNearAccountId("guest-book.testnet")).toBe(true);
+  });
+
+  it("accepts minimum length (2 chars)", () => {
+    expect(isValidNearAccountId("ab")).toBe(true);
+  });
+
+  it("accepts maximum length (64 chars)", () => {
+    expect(isValidNearAccountId("a".repeat(64))).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidNearAccountId("")).toBe(false);
+  });
+
+  it("rejects single character", () => {
+    expect(isValidNearAccountId("a")).toBe(false);
+  });
+
+  it("rejects 65+ characters", () => {
+    expect(isValidNearAccountId("a".repeat(65))).toBe(false);
+  });
+
+  it("rejects uppercase letters", () => {
+    expect(isValidNearAccountId("Alice.near")).toBe(false);
+  });
+
+  it("rejects spaces", () => {
+    expect(isValidNearAccountId("alice near")).toBe(false);
+  });
+
+  it("rejects injection-like strings", () => {
+    expect(isValidNearAccountId("alice; DROP TABLE")).toBe(false);
+  });
+
+  it("accepts underscores, hyphens, and dots", () => {
+    expect(isValidNearAccountId("my_account-1.testnet")).toBe(true);
+  });
+});
+
+describe("getNearContractId", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns the default testnet contract when env is unset", () => {
+    delete process.env.NEXT_PUBLIC_NEAR_CONTRACT_ID;
+    expect(getNearContractId("testnet")).toBe("guest-book.testnet");
+  });
+
+  it("returns the default mainnet contract when env is unset", () => {
+    delete process.env.NEXT_PUBLIC_NEAR_CONTRACT_ID;
+    expect(getNearContractId("mainnet")).toBe("social.near");
+  });
+
+  it("returns the env contract id when valid", () => {
+    process.env.NEXT_PUBLIC_NEAR_CONTRACT_ID = "my-contract.testnet";
+    expect(getNearContractId("testnet")).toBe("my-contract.testnet");
+  });
+
+  it("falls back to default when env contract id is invalid", () => {
+    process.env.NEXT_PUBLIC_NEAR_CONTRACT_ID = "INVALID CONTRACT!";
+    expect(getNearContractId("testnet")).toBe("guest-book.testnet");
+  });
+
+  it("trims whitespace from env value", () => {
+    process.env.NEXT_PUBLIC_NEAR_CONTRACT_ID = "  my-contract.testnet  ";
+    // trimmed value is valid
+    expect(getNearContractId("testnet")).toBe("my-contract.testnet");
+  });
+
+  it("uses getNearNetworkId() as default networkId argument", () => {
+    delete process.env.NEXT_PUBLIC_NEAR_CONTRACT_ID;
+    delete process.env.NEXT_PUBLIC_NEAR_NETWORK;
+    // default network is testnet
+    expect(getNearContractId()).toBe("guest-book.testnet");
+  });
+});
+
+describe("DEFAULT_FUNCTION_CALL_GAS", () => {
+  it("is 30 Tgas expressed as a BigInt", () => {
+    expect(DEFAULT_FUNCTION_CALL_GAS).toBe(BigInt("30000000000000"));
+  });
+});

--- a/frontend/src/lib/near/__tests__/errors.test.ts
+++ b/frontend/src/lib/near/__tests__/errors.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  isLikelyUserRejectedError,
+  nearErrorMessage,
+  NEAR_SIGNATURE_REJECTED_MESSAGE,
+} from "../errors";
+
+describe("isLikelyUserRejectedError", () => {
+  it("returns true for 'User rejected' Error", () => {
+    expect(isLikelyUserRejectedError(new Error("User rejected the request"))).toBe(true);
+  });
+
+  it("returns true for 'rejected' string", () => {
+    expect(isLikelyUserRejectedError("Transaction rejected")).toBe(true);
+  });
+
+  it("returns true for 'denied'", () => {
+    expect(isLikelyUserRejectedError(new Error("Access denied by user"))).toBe(true);
+  });
+
+  it("returns true for 'cancel'", () => {
+    expect(isLikelyUserRejectedError(new Error("User cancelled the action"))).toBe(true);
+  });
+
+  it("returns true for 'closed'", () => {
+    expect(isLikelyUserRejectedError(new Error("Modal closed"))).toBe(true);
+  });
+
+  it("returns true for 'user closed'", () => {
+    expect(isLikelyUserRejectedError(new Error("user closed the wallet"))).toBe(true);
+  });
+
+  it("returns true for 'dismiss'", () => {
+    expect(isLikelyUserRejectedError(new Error("User dismissed the popup"))).toBe(true);
+  });
+
+  it("returns true for 'user cancelled' (substring)", () => {
+    expect(isLikelyUserRejectedError(new Error("user cancelled"))).toBe(true);
+  });
+
+  it("returns false for a generic network error", () => {
+    expect(isLikelyUserRejectedError(new Error("Network timeout"))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isLikelyUserRejectedError(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isLikelyUserRejectedError(undefined)).toBe(false);
+  });
+
+  it("returns false for a plain object", () => {
+    expect(isLikelyUserRejectedError({ code: 4001 })).toBe(false);
+  });
+});
+
+describe("nearErrorMessage", () => {
+  it("returns the rejection message for a user-rejected error", () => {
+    expect(nearErrorMessage(new Error("User rejected"))).toBe(
+      NEAR_SIGNATURE_REJECTED_MESSAGE,
+    );
+  });
+
+  it("returns the error message for a non-rejection Error", () => {
+    expect(nearErrorMessage(new Error("Something exploded"))).toBe(
+      "Something exploded",
+    );
+  });
+
+  it("returns the fallback message for null", () => {
+    expect(nearErrorMessage(null)).toBe(
+      "Something went wrong with the NEAR wallet request.",
+    );
+  });
+
+  it("returns the fallback message for an empty Error", () => {
+    const e = new Error("");
+    expect(nearErrorMessage(e)).toBe(
+      "Something went wrong with the NEAR wallet request.",
+    );
+  });
+
+  it("returns the fallback message for a plain object", () => {
+    expect(nearErrorMessage({ code: 500 })).toBe(
+      "Something went wrong with the NEAR wallet request.",
+    );
+  });
+});

--- a/frontend/src/lib/near/__tests__/execution.test.ts
+++ b/frontend/src/lib/near/__tests__/execution.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import type { FinalExecutionOutcome } from "@near-wallet-selector/core";
+import {
+  getTransactionHashFromOutcome,
+  isFinalExecutionSuccess,
+} from "../execution";
+
+function makeOutcome(
+  id: string | undefined,
+  status: FinalExecutionOutcome["status"],
+): FinalExecutionOutcome {
+  return {
+    transaction_outcome: { id: id ?? "", outcome: {} as never, block_hash: "", proof: [] },
+    transaction: {} as never,
+    receipts_outcome: [],
+    status,
+  };
+}
+
+describe("getTransactionHashFromOutcome", () => {
+  it("returns the transaction id when present", () => {
+    const outcome = makeOutcome("abc123", "SuccessValue");
+    expect(getTransactionHashFromOutcome(outcome)).toBe("abc123");
+  });
+
+  it("returns undefined when id is empty string", () => {
+    const outcome = makeOutcome("", "SuccessValue");
+    expect(getTransactionHashFromOutcome(outcome)).toBeUndefined();
+  });
+
+  it("returns undefined when transaction_outcome.id is undefined", () => {
+    const outcome = makeOutcome(undefined, "SuccessValue");
+    expect(getTransactionHashFromOutcome(outcome)).toBeUndefined();
+  });
+});
+
+describe("isFinalExecutionSuccess", () => {
+  it("returns true for string 'SuccessValue' status", () => {
+    expect(isFinalExecutionSuccess(makeOutcome("x", "SuccessValue"))).toBe(true);
+  });
+
+  it("returns false for string 'Failure' status", () => {
+    expect(isFinalExecutionSuccess(makeOutcome("x", "Failure"))).toBe(false);
+  });
+
+  it("returns true for object status with no Failure key", () => {
+    const outcome = makeOutcome("x", { SuccessValue: "result" } as never);
+    expect(isFinalExecutionSuccess(outcome)).toBe(true);
+  });
+
+  it("returns false for object status with Failure key set", () => {
+    const outcome = makeOutcome("x", { Failure: { error_message: "oops" } } as never);
+    expect(isFinalExecutionSuccess(outcome)).toBe(false);
+  });
+
+  it("returns true for object status with Failure key explicitly null", () => {
+    const outcome = makeOutcome("x", { Failure: null } as never);
+    expect(isFinalExecutionSuccess(outcome)).toBe(true);
+  });
+});

--- a/frontend/src/lib/near/__tests__/explorer.test.ts
+++ b/frontend/src/lib/near/__tests__/explorer.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { getExplorerTransactionUrl } from "../explorer";
+
+describe("getExplorerTransactionUrl", () => {
+  it("returns a testnet explorer URL", () => {
+    expect(getExplorerTransactionUrl("testnet", "abc123")).toBe(
+      "https://explorer.testnet.near.org/transactions/abc123",
+    );
+  });
+
+  it("returns a mainnet explorer URL", () => {
+    expect(getExplorerTransactionUrl("mainnet", "xyz789")).toBe(
+      "https://explorer.near.org/transactions/xyz789",
+    );
+  });
+
+  it("URL-encodes special characters in the hash", () => {
+    const url = getExplorerTransactionUrl("testnet", "hash with spaces");
+    expect(url).toBe(
+      "https://explorer.testnet.near.org/transactions/hash%20with%20spaces",
+    );
+  });
+
+  it("returns undefined for an empty transaction hash", () => {
+    expect(getExplorerTransactionUrl("testnet", "")).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/near/__tests__/security.test.ts
+++ b/frontend/src/lib/near/__tests__/security.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { isDepositSafe, sanitizeErrorMessage, MAX_DEPOSIT_YOCTO } from "../security";
+
+describe("isDepositSafe", () => {
+  it("returns true for zero deposit", () => {
+    expect(isDepositSafe(BigInt(0))).toBe(true);
+  });
+
+  it("returns true for 1 yoctoNEAR", () => {
+    expect(isDepositSafe(BigInt(1))).toBe(true);
+  });
+
+  it("returns true for exactly MAX_DEPOSIT_YOCTO (1 NEAR)", () => {
+    expect(isDepositSafe(MAX_DEPOSIT_YOCTO)).toBe(true);
+  });
+
+  it("returns false for MAX_DEPOSIT_YOCTO + 1", () => {
+    expect(isDepositSafe(MAX_DEPOSIT_YOCTO + BigInt(1))).toBe(false);
+  });
+
+  it("returns false for a very large deposit", () => {
+    expect(isDepositSafe(BigInt("999999999999999999999999999"))).toBe(false);
+  });
+
+  it("returns false for a negative deposit", () => {
+    expect(isDepositSafe(BigInt(-1))).toBe(false);
+  });
+});
+
+describe("sanitizeErrorMessage", () => {
+  it("passes through a normal error message unchanged", () => {
+    expect(sanitizeErrorMessage("Network timeout")).toBe("Network timeout");
+  });
+
+  it("redacts a seed phrase pattern", () => {
+    const msg =
+      "abandon ability able about above absent absorb abstract absurd abuse access accident";
+    const result = sanitizeErrorMessage(msg);
+    expect(result).toContain("[redacted]");
+    expect(result).not.toContain("abandon");
+  });
+
+  it("redacts a base58 private key pattern (64+ chars)", () => {
+    const fakeKey = "1".repeat(64); // 64 chars of base58-valid chars
+    const result = sanitizeErrorMessage(`key: ${fakeKey}`);
+    expect(result).toContain("[redacted]");
+    expect(result).not.toContain(fakeKey);
+  });
+
+  it("truncates messages longer than maxLen", () => {
+    // Use spaces to avoid triggering the private-key regex (base58 has no spaces).
+    const long = "error: " + "a b ".repeat(75); // > 200 chars, no 64-char base58 run
+    const result = sanitizeErrorMessage(long, 200);
+    expect(result.length).toBeLessThanOrEqual(202); // 200 + "…"
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  it("does not truncate messages within maxLen", () => {
+    const short = "short error";
+    expect(sanitizeErrorMessage(short)).toBe("short error");
+  });
+
+  it("uses default maxLen of 200 without truncating a 200-char safe string", () => {
+    // Use spaces so the private-key regex cannot match (it requires 64+ consecutive base58 chars).
+    const exactly200 = ("ab cd ").repeat(33).slice(0, 200); // 200 chars with spaces
+    expect(sanitizeErrorMessage(exactly200)).toBe(exactly200);
+  });
+});

--- a/frontend/src/lib/near/__tests__/telemetry.test.ts
+++ b/frontend/src/lib/near/__tests__/telemetry.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the analytics client before importing telemetry so the module
+// picks up the mock at import time.
+vi.mock("@/lib/analytics/client", () => ({
+  track: vi.fn(),
+}));
+
+import { track } from "@/lib/analytics/client";
+import {
+  trackNearWalletConnected,
+  trackNearWalletDisconnected,
+  trackNearTxSubmitted,
+  trackNearTxConfirmed,
+  trackNearTxFailed,
+} from "../telemetry";
+
+const mockTrack = vi.mocked(track);
+
+beforeEach(() => {
+  mockTrack.mockClear();
+});
+
+describe("trackNearWalletConnected", () => {
+  it("calls track with near_wallet_connected and network_id", () => {
+    trackNearWalletConnected("testnet");
+    expect(mockTrack).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledWith("near_wallet_connected", {
+      network_id: "testnet",
+    });
+  });
+
+  it("passes mainnet network_id", () => {
+    trackNearWalletConnected("mainnet");
+    expect(mockTrack).toHaveBeenCalledWith("near_wallet_connected", {
+      network_id: "mainnet",
+    });
+  });
+});
+
+describe("trackNearWalletDisconnected", () => {
+  it("calls track with near_wallet_disconnected and network_id", () => {
+    trackNearWalletDisconnected("testnet");
+    expect(mockTrack).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledWith("near_wallet_disconnected", {
+      network_id: "testnet",
+    });
+  });
+});
+
+describe("trackNearTxSubmitted", () => {
+  it("calls track with near_tx_submitted, network_id, and method_name", () => {
+    trackNearTxSubmitted("testnet", "buy_item");
+    expect(mockTrack).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledWith("near_tx_submitted", {
+      network_id: "testnet",
+      method_name: "buy_item",
+    });
+  });
+});
+
+describe("trackNearTxConfirmed", () => {
+  it("calls track with near_tx_confirmed, network_id, and method_name", () => {
+    trackNearTxConfirmed("mainnet", "transfer");
+    expect(mockTrack).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledWith("near_tx_confirmed", {
+      network_id: "mainnet",
+      method_name: "transfer",
+    });
+  });
+});
+
+describe("trackNearTxFailed", () => {
+  it("calls track with near_tx_failed and error_type=rejected", () => {
+    trackNearTxFailed("testnet", "buy_item", "rejected");
+    expect(mockTrack).toHaveBeenCalledWith("near_tx_failed", {
+      network_id: "testnet",
+      method_name: "buy_item",
+      error_type: "rejected",
+    });
+  });
+
+  it("calls track with error_type=no_outcome", () => {
+    trackNearTxFailed("testnet", "buy_item", "no_outcome");
+    expect(mockTrack).toHaveBeenCalledWith("near_tx_failed", {
+      network_id: "testnet",
+      method_name: "buy_item",
+      error_type: "no_outcome",
+    });
+  });
+
+  it("calls track with error_type=on_chain", () => {
+    trackNearTxFailed("mainnet", "transfer", "on_chain");
+    expect(mockTrack).toHaveBeenCalledWith("near_tx_failed", {
+      network_id: "mainnet",
+      method_name: "transfer",
+      error_type: "on_chain",
+    });
+  });
+});

--- a/frontend/src/lib/near/index.ts
+++ b/frontend/src/lib/near/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Barrel re-export for @/lib/near.
+ *
+ * All exports are named so bundlers (webpack/turbopack) can tree-shake
+ * unused symbols. No side-effect imports are present at module level.
+ */
+
+export {
+  getNearNetworkId,
+  isValidNearAccountId,
+  getNearContractId,
+  DEFAULT_FUNCTION_CALL_GAS,
+} from "./config";
+
+export {
+  NEAR_SIGNATURE_REJECTED_MESSAGE,
+  isLikelyUserRejectedError,
+  nearErrorMessage,
+} from "./errors";
+
+export {
+  getTransactionHashFromOutcome,
+  isFinalExecutionSuccess,
+} from "./execution";
+
+export { getExplorerTransactionUrl } from "./explorer";
+
+export {
+  MAX_DEPOSIT_YOCTO,
+  isDepositSafe,
+  sanitizeErrorMessage,
+} from "./security";
+
+export {
+  trackNearWalletConnected,
+  trackNearWalletDisconnected,
+  trackNearTxSubmitted,
+  trackNearTxConfirmed,
+  trackNearTxFailed,
+} from "./telemetry";
+
+export type { NearTxPhase, NearTxRecord } from "./types";


### PR DESCRIPTION
…ests

- Add index.ts barrel with named re-exports for all 6 modules + types
- Audit confirms all modules are pure ESM (no module-level side effects)
- 71 unit tests across config, errors, execution, explorer, security, telemetry
- telemetry tests use vi.mock to isolate analytics client
closes #809 