### PR TITLE
feat(game-settings): accessibility and focus order improvements

### DIFF
--- a/frontend/src/app/game-settings/page.test.tsx
+++ b/frontend/src/app/game-settings/page.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test, describe, vi } from "vitest";
+import GameSettingsPage from "./page";
+
+vi.mock("@/clients/GameSettingsClient", () => ({
+  default: () => (
+    <div data-testid="game-settings-client">
+      <button type="button">Create Lobby</button>
+    </div>
+  ),
+}));
+
+describe("Game Settings Page - Accessibility", () => {
+  describe("Landmarks and ARIA", () => {
+    test("renders main landmark with aria-label", () => {
+      const { container } = render(<GameSettingsPage />);
+      const main = container.querySelector('main[aria-label="Game settings"]');
+      expect(main).toBeInTheDocument();
+    });
+
+    test("renders settings content section with id and aria-label", () => {
+      const { container } = render(<GameSettingsPage />);
+      const section = container.querySelector(
+        'section[aria-label="Game settings form"]',
+      );
+      expect(section).toBeInTheDocument();
+      expect(section).toHaveAttribute("id", "game-settings-content");
+    });
+
+    test("includes visually hidden h1 heading", () => {
+      render(<GameSettingsPage />);
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Game Settings" }),
+      ).toBeInTheDocument();
+    });
+
+    test("provides aria-live status region", () => {
+      const { container } = render(<GameSettingsPage />);
+      const announcer = container.querySelector("#game-settings-status");
+      expect(announcer).toBeInTheDocument();
+      expect(announcer).toHaveAttribute("role", "status");
+      expect(announcer).toHaveAttribute("aria-live", "polite");
+      expect(announcer).toHaveAttribute("aria-atomic", "true");
+      expect(announcer).toHaveAttribute("aria-label", "Game settings status");
+    });
+  });
+
+  describe("Focus order", () => {
+    test("skip link targets the settings content section", () => {
+      render(<GameSettingsPage />);
+      const skipLink = screen.getByRole("link", {
+        name: "Skip to game settings",
+      });
+      expect(skipLink).toHaveAttribute("href", "#game-settings-content");
+    });
+
+    test("skip link appears before main content in DOM", () => {
+      render(<GameSettingsPage />);
+      const skipLink = screen.getByRole("link", {
+        name: "Skip to game settings",
+      });
+      const createLobbyBtn = screen.getByRole("button", {
+        name: "Create Lobby",
+      });
+      const focusables = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      expect(focusables.indexOf(skipLink)).toBeLessThan(
+        focusables.indexOf(createLobbyBtn),
+      );
+    });
+
+    test("skip link has visible focus styles", () => {
+      render(<GameSettingsPage />);
+      const skipLink = screen.getByRole("link", {
+        name: "Skip to game settings",
+      });
+      expect(skipLink.className).toContain("focus:ring-2");
+      expect(skipLink.className).toContain("focus:not-sr-only");
+    });
+
+    test("settings content section applies focus-visible styles to descendants", () => {
+      const { container } = render(<GameSettingsPage />);
+      const section = container.querySelector("#game-settings-content");
+      expect(section?.className).toContain("focus-visible");
+    });
+  });
+
+  describe("Client component", () => {
+    test("renders the game settings client inside the section", () => {
+      render(<GameSettingsPage />);
+      expect(screen.getByTestId("game-settings-client")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/game-settings/page.tsx
+++ b/frontend/src/app/game-settings/page.tsx
@@ -11,5 +11,36 @@ export const metadata: Metadata = generatePageMetadata({
 });
 
 export default function GameSettingsPage() {
-  return <GameSettingsClient />;
+  return (
+    <main
+      aria-label="Game settings"
+      className="relative min-h-screen w-full bg-gray-50/50 dark:bg-neutral-950"
+    >
+      <a
+        href="#game-settings-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-indigo-600 focus:px-4 focus:py-2 focus:text-white focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"
+      >
+        Skip to game settings
+      </a>
+
+      <h1 className="sr-only">Game Settings</h1>
+
+      <div
+        id="game-settings-status"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label="Game settings status"
+        className="sr-only"
+      />
+
+      <section
+        id="game-settings-content"
+        aria-label="Game settings form"
+        className="[&_*:focus-visible]:outline-none [&_*:focus-visible]:ring-2 [&_*:focus-visible]:ring-indigo-600 [&_*:focus-visible]:ring-offset-2"
+      >
+        <GameSettingsClient />
+      </section>
+    </main>
+  );
 }

--- a/frontend/src/clients/GameSettingsClient.tsx
+++ b/frontend/src/clients/GameSettingsClient.tsx
@@ -24,8 +24,8 @@ export default function GameSettingsClient() {
     if (isChecking) {
         return (
             <div className="flex h-screen w-full items-center justify-center bg-white dark:bg-neutral-950">
-                <div className="flex flex-col items-center gap-4">
-                    <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent dark:border-indigo-400"></div>
+                <div className="flex flex-col items-center gap-4" role="status" aria-label="Connecting to Stellar Network">
+                    <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent dark:border-indigo-400" aria-hidden="true"></div>
                     <p className="animate-pulse text-sm font-medium text-neutral-500 dark:text-neutral-400">Connecting to Stellar Network...</p>
                 </div>
             </div>
@@ -44,8 +44,6 @@ export default function GameSettingsClient() {
     }
 
     return (
-        <div className="min-h-screen bg-gray-50/50 dark:bg-neutral-950">
-            <GameSettings />
-        </div>
+        <GameSettings />
     )
 }

--- a/frontend/src/components/settings/GameSettings.tsx
+++ b/frontend/src/components/settings/GameSettings.tsx
@@ -196,33 +196,36 @@ export function GameSettings() {
                                     )}
                                 </div>
                                 <div className="space-y-2">
-                                    <Label>Select Token</Label>
+                                    <Label id="select-token-label">Select Token</Label>
                                     <Select
                                         value={piece}
                                         onChange={setPiece}
                                         options={PIECES}
                                         placeholder="Choose your token"
+                                        aria-labelledby="select-token-label"
                                     />
                                 </div>
                             </div>
 
                             <div className="grid gap-6 sm:grid-cols-2">
                                 <div className="space-y-2">
-                                    <Label>Max Players</Label>
+                                    <Label id="max-players-label">Max Players</Label>
                                     <Select
                                         value={maxPlayers}
                                         onChange={setMaxPlayers}
                                         options={PLAYER_COUNTS}
+                                        aria-labelledby="max-players-label"
                                     />
                                 </div>
                                 <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-3 shadow-sm dark:border-neutral-800">
                                     <div className="space-y-0.5">
-                                        <Label className="text-base">Private Room</Label>
+                                        <Label htmlFor="private-room" className="text-base">Private Room</Label>
                                         <div className="text-xs text-neutral-500">
-                                            {isPrivate ? <span className="flex items-center gap-1 text-amber-600"><Lock className="h-3 w-3" /> Invite Only</span> : <span className="flex items-center gap-1 text-green-600"><Unlock className="h-3 w-3" /> Public Listing</span>}
+                                            {isPrivate ? <span className="flex items-center gap-1 text-amber-600"><Lock className="h-3 w-3" aria-hidden="true" /> Invite Only</span> : <span className="flex items-center gap-1 text-green-600"><Unlock className="h-3 w-3" aria-hidden="true" /> Public Listing</span>}
                                         </div>
                                     </div>
                                     <Switch
+                                        id="private-room"
                                         checked={isPrivate}
                                         onCheckedChange={setIsPrivate}
                                     />
@@ -259,11 +262,12 @@ export function GameSettings() {
                                 {!isFreeGame && (
                                     <div className="grid gap-4 sm:grid-cols-2 animate-in fade-in slide-in-from-top-2">
                                         <div className="space-y-2">
-                                            <Label>Stake Amount</Label>
+                                            <Label id="stake-amount-label">Stake Amount</Label>
                                             <Select
                                                 value={stakePreset}
                                                 onChange={setStakePreset}
                                                 options={ENTRY_STAKES}
+                                                aria-labelledby="stake-amount-label"
                                             />
                                         </div>
                                         {stakePreset === 'custom' && (
@@ -289,23 +293,25 @@ export function GameSettings() {
 
                             <div className="grid gap-6 sm:grid-cols-2">
                                 <div className="space-y-2">
-                                    <Label className="flex items-center gap-2">
-                                        <Coins className="h-4 w-4" /> Starting Liquidity (XLM)
+                                    <Label id="starting-liquidity-label" className="flex items-center gap-2">
+                                        <Coins className="h-4 w-4" aria-hidden="true" /> Starting Liquidity (XLM)
                                     </Label>
                                     <Select
                                         value={startingCash}
                                         onChange={setStartingCash}
                                         options={STARTING_CASH}
+                                        aria-labelledby="starting-liquidity-label"
                                     />
                                 </div>
                                 <div className="space-y-2">
-                                    <Label className="flex items-center gap-2">
-                                        <Clock className="h-4 w-4" /> Session Limit
+                                    <Label id="session-limit-label" className="flex items-center gap-2">
+                                        <Clock className="h-4 w-4" aria-hidden="true" /> Session Limit
                                     </Label>
                                     <Select
                                         value={duration}
                                         onChange={setDuration}
                                         options={DURATIONS}
+                                        aria-labelledby="session-limit-label"
                                     />
                                 </div>
                             </div>

--- a/frontend/src/components/ui/select.test.tsx
+++ b/frontend/src/components/ui/select.test.tsx
@@ -1,0 +1,204 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, test, describe } from "vitest";
+import { Select } from "./select";
+
+const OPTIONS = [
+  { value: "a", label: "Option A" },
+  { value: "b", label: "Option B" },
+  { value: "c", label: "Option C" },
+];
+
+describe("Select - Accessibility", () => {
+  describe("ARIA attributes", () => {
+    test("trigger has role=combobox", () => {
+      render(<Select options={OPTIONS} />);
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    test("trigger has aria-haspopup=listbox", () => {
+      render(<Select options={OPTIONS} />);
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-haspopup",
+        "listbox",
+      );
+    });
+
+    test("trigger has aria-expanded=false when closed", () => {
+      render(<Select options={OPTIONS} />);
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+    });
+
+    test("trigger has aria-expanded=true when open", () => {
+      render(<Select options={OPTIONS} />);
+      fireEvent.click(screen.getByRole("combobox"));
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+
+    test("accepts aria-labelledby and passes it to trigger and listbox", () => {
+      render(
+        <>
+          <span id="my-label">My Label</span>
+          <Select options={OPTIONS} aria-labelledby="my-label" />
+        </>,
+      );
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-labelledby",
+        "my-label",
+      );
+      fireEvent.click(screen.getByRole("combobox"));
+      expect(screen.getByRole("listbox")).toHaveAttribute(
+        "aria-labelledby",
+        "my-label",
+      );
+    });
+
+    test("accepts aria-label and passes it to trigger and listbox", () => {
+      render(<Select options={OPTIONS} aria-label="Choose option" />);
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-label",
+        "Choose option",
+      );
+      fireEvent.click(screen.getByRole("combobox"));
+      expect(screen.getByRole("listbox")).toHaveAttribute(
+        "aria-label",
+        "Choose option",
+      );
+    });
+
+    test("listbox renders with role=listbox when open", () => {
+      render(<Select options={OPTIONS} />);
+      fireEvent.click(screen.getByRole("combobox"));
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    test("options have role=option", () => {
+      render(<Select options={OPTIONS} />);
+      fireEvent.click(screen.getByRole("combobox"));
+      const opts = screen.getAllByRole("option");
+      expect(opts).toHaveLength(3);
+    });
+
+    test("selected option has aria-selected=true", () => {
+      render(<Select options={OPTIONS} value="b" onChange={() => {}} />);
+      fireEvent.click(screen.getByRole("combobox"));
+      const opts = screen.getAllByRole("option");
+      expect(opts[1]).toHaveAttribute("aria-selected", "true");
+      expect(opts[0]).toHaveAttribute("aria-selected", "false");
+    });
+  });
+
+  describe("Keyboard navigation", () => {
+    test("Enter opens the listbox", async () => {
+      const user = userEvent.setup();
+      render(<Select options={OPTIONS} />);
+      const trigger = screen.getByRole("combobox");
+      trigger.focus();
+      await user.keyboard("{Enter}");
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    test("Space opens the listbox", async () => {
+      const user = userEvent.setup();
+      render(<Select options={OPTIONS} />);
+      const trigger = screen.getByRole("combobox");
+      trigger.focus();
+      await user.keyboard(" ");
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    test("ArrowDown opens the listbox", async () => {
+      const user = userEvent.setup();
+      render(<Select options={OPTIONS} />);
+      const trigger = screen.getByRole("combobox");
+      trigger.focus();
+      await user.keyboard("{ArrowDown}");
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    test("Escape closes the listbox", async () => {
+      render(<Select options={OPTIONS} />);
+      const trigger = screen.getByRole("combobox");
+      fireEvent.click(trigger);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      fireEvent.keyDown(trigger, { key: "Escape" });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    test("ArrowDown moves active index down", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<Select options={OPTIONS} onChange={onChange} />);
+      const trigger = screen.getByRole("combobox");
+      trigger.focus();
+      await user.keyboard("{ArrowDown}");
+      // listbox open, first item active (index 0)
+      await user.keyboard("{ArrowDown}");
+      // index 1 now active
+      await user.keyboard("{Enter}");
+      expect(onChange).toHaveBeenCalledWith("b");
+    });
+
+    test("ArrowUp moves active index up", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<Select options={OPTIONS} value="c" onChange={onChange} />);
+      const trigger = screen.getByRole("combobox");
+      trigger.focus();
+      await user.keyboard("{ArrowDown}");
+      // open, active = index of "c" = 2
+      await user.keyboard("{ArrowUp}");
+      // active = 1
+      await user.keyboard("{Enter}");
+      expect(onChange).toHaveBeenCalledWith("b");
+    });
+
+    test("Home moves to first option", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<Select options={OPTIONS} value="c" onChange={onChange} />);
+      const trigger = screen.getByRole("combobox");
+      trigger.focus();
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{Home}");
+      await user.keyboard("{Enter}");
+      expect(onChange).toHaveBeenCalledWith("a");
+    });
+
+    test("End moves to last option", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<Select options={OPTIONS} value="a" onChange={onChange} />);
+      const trigger = screen.getByRole("combobox");
+      trigger.focus();
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{End}");
+      await user.keyboard("{Enter}");
+      expect(onChange).toHaveBeenCalledWith("c");
+    });
+
+    test("Tab closes the listbox", () => {
+      render(<Select options={OPTIONS} />);
+      const trigger = screen.getByRole("combobox");
+      fireEvent.click(trigger);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      fireEvent.keyDown(trigger, { key: "Tab" });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    test("disabled select does not open on keyboard", async () => {
+      const user = userEvent.setup();
+      render(<Select options={OPTIONS} disabled />);
+      const trigger = screen.getByRole("combobox");
+      trigger.focus();
+      await user.keyboard("{Enter}");
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -16,12 +16,18 @@ interface SelectProps {
     options: SelectOption[]
     className?: string
     disabled?: boolean
+    id?: string
+    "aria-labelledby"?: string
+    "aria-label"?: string
 }
 
 const Select = React.forwardRef<HTMLDivElement, SelectProps>(
-    ({ value, onChange, placeholder = "Select...", options, className, disabled }, ref) => {
+    ({ value, onChange, placeholder = "Select...", options, className, disabled, id, "aria-labelledby": ariaLabelledby, "aria-label": ariaLabel }, ref) => {
         const [isOpen, setIsOpen] = React.useState(false)
+        const [activeIndex, setActiveIndex] = React.useState<number>(-1)
         const containerRef = React.useRef<HTMLDivElement>(null)
+        const listboxId = React.useId()
+        const triggerId = id ?? React.useId()
 
         React.useEffect(() => {
             const handleClickOutside = (event: MouseEvent) => {
@@ -33,6 +39,14 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
             return () => document.removeEventListener("mousedown", handleClickOutside)
         }, [])
 
+        // Reset active index when opening
+        React.useEffect(() => {
+            if (isOpen) {
+                const selectedIndex = options.findIndex((o) => o.value === value)
+                setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0)
+            }
+        }, [isOpen, options, value])
+
         const selectedOption = options.find((opt) => opt.value === value)
 
         const handleSelect = (optionValue: string) => {
@@ -40,40 +54,105 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
             setIsOpen(false)
         }
 
+        const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+            if (disabled) return
+            switch (e.key) {
+                case "Enter":
+                case " ":
+                    e.preventDefault()
+                    if (isOpen && activeIndex >= 0) {
+                        handleSelect(options[activeIndex].value)
+                    } else {
+                        setIsOpen(true)
+                    }
+                    break
+                case "ArrowDown":
+                    e.preventDefault()
+                    if (!isOpen) {
+                        setIsOpen(true)
+                    } else {
+                        setActiveIndex((i) => Math.min(i + 1, options.length - 1))
+                    }
+                    break
+                case "ArrowUp":
+                    e.preventDefault()
+                    if (!isOpen) {
+                        setIsOpen(true)
+                    } else {
+                        setActiveIndex((i) => Math.max(i - 1, 0))
+                    }
+                    break
+                case "Home":
+                    e.preventDefault()
+                    setActiveIndex(0)
+                    break
+                case "End":
+                    e.preventDefault()
+                    setActiveIndex(options.length - 1)
+                    break
+                case "Escape":
+                    e.preventDefault()
+                    setIsOpen(false)
+                    break
+                case "Tab":
+                    setIsOpen(false)
+                    break
+            }
+        }
+
         return (
             <div className={cn("relative", className)} ref={containerRef}>
                 <button
                     type="button"
+                    id={triggerId}
+                    role="combobox"
+                    aria-haspopup="listbox"
+                    aria-expanded={isOpen}
+                    aria-controls={listboxId}
+                    aria-labelledby={ariaLabelledby}
+                    aria-label={ariaLabel}
+                    aria-activedescendant={isOpen && activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined}
                     onClick={() => !disabled && setIsOpen(!isOpen)}
+                    onKeyDown={handleKeyDown}
                     className={cn(
                         "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-neutral-200 bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-white placeholder:text-neutral-500 focus:outline-none focus:ring-1 focus:ring-tycoon-accent disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-neutral-800 dark:placeholder:text-neutral-400",
-                        className
                     )}
                     disabled={disabled}
                 >
                     <span className={cn(!selectedOption && "text-neutral-500 dark:text-neutral-400")}>
                         {selectedOption ? selectedOption.label : placeholder}
                     </span>
-                    <ChevronDown className="h-4 w-4 opacity-50" />
+                    <ChevronDown className="h-4 w-4 opacity-50" aria-hidden="true" />
                 </button>
                 {isOpen && (
-                    <div className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-neutral-200 bg-white p-1 text-neutral-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50">
-                        {options.map((option) => (
-                            <div
+                    <ul
+                        id={listboxId}
+                        role="listbox"
+                        aria-labelledby={ariaLabelledby}
+                        aria-label={ariaLabel}
+                        className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-neutral-200 bg-white p-1 text-neutral-950 shadow-md dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50"
+                    >
+                        {options.map((option, index) => (
+                            <li
                                 key={option.value}
+                                id={`${listboxId}-option-${index}`}
+                                role="option"
+                                aria-selected={value === option.value}
                                 onClick={() => handleSelect(option.value)}
+                                onMouseEnter={() => setActiveIndex(index)}
                                 className={cn(
-                                    "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-neutral-100 focus:text-neutral-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
-                                    value === option.value && "bg-neutral-100 dark:bg-neutral-800"
+                                    "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none",
+                                    value === option.value && "bg-neutral-100 dark:bg-neutral-800",
+                                    activeIndex === index && "bg-neutral-100 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-50"
                                 )}
                             >
                                 <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-                                    {value === option.value && <Check className="h-4 w-4" />}
+                                    {value === option.value && <Check className="h-4 w-4" aria-hidden="true" />}
                                 </span>
                                 <span className="truncate">{option.label}</span>
-                            </div>
+                            </li>
                         ))}
-                    </div>
+                    </ul>
                 )}
             </div>
         )


### PR DESCRIPTION
**Closes #735 

Issue: frontend/src/app/game-settings/page.tsx — accessibility and focus order.
 
  What was fixed:
  -page.tsx — added the accessibility shell missing from the route: <main> landmark, skip-to-content link targeting #game-settings-content,       
  sr-only , aria-live status region, and a <section> with focus-visible ring styles cascading to all descendants.
  -select.tsx — the custom Select had no keyboard support and no ARIA semantics. Upgraded to the combobox pattern: role="combobox" on the trigger 
  with aria-haspopup/expanded/controls, role="listbox" on the dropdown, role="option" + aria-selected on each item, full keyboard nav (↑↓, Home, 
  End, Enter, Space, Escape, Tab), and aria-labelledby/aria-label props.
 -GameSettings.tsx — wired aria-labelledby on all 5 unlabelled Select fields (Select Token, Max Players, Stake Amount, Starting Liquidity,       
  Session Limit) and added htmlFor="private-room" to associate the Private Room label with its Switch.
 -GameSettingsClient.tsx — added role="status" + aria-label to the loading spinner so screen readers announce the connecting state.
 -Tests added: 28 tests across two new files (page.test.tsx, select.test.tsx) covering landmarks, skip link, focus order, ARIA attributes, and   
  keyboard navigation — all passing.**