### PR TITLE
feat(game-waiting): accessibility and focus order improvements

### DIFF
--- a/frontend/src/app/game-waiting/page.test.tsx
+++ b/frontend/src/app/game-waiting/page.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test, describe, vi } from "vitest";
+import GameWaitingPage from "./page";
+
+vi.mock("@/clients/GameWaitingClient", () => ({
+  default: () => (
+    <div data-testid="game-waiting-client">
+      <button type="button" aria-label="Start game">Start</button>
+    </div>
+  ),
+}));
+
+async function renderPage(
+  searchParams?: Promise<Record<string, string | string[] | undefined>>,
+) {
+  return render(await GameWaitingPage({ searchParams }));
+}
+
+describe("Game Waiting Page - Accessibility", () => {
+  describe("Landmarks and ARIA", () => {
+    test("renders main landmark with aria-label", async () => {
+      const { container } = await renderPage(
+        Promise.resolve({ gameCode: "ABC123" }),
+      );
+      expect(
+        container.querySelector('main[aria-label="Game waiting lobby"]'),
+      ).toBeInTheDocument();
+    });
+
+    test("main landmark has aria-busy=true while waiting", async () => {
+      const { container } = await renderPage(
+        Promise.resolve({ gameCode: "ABC123" }),
+      );
+      expect(
+        container.querySelector('main[aria-busy="true"]'),
+      ).toBeInTheDocument();
+    });
+
+    test("renders waiting content section with id and aria-label", async () => {
+      const { container } = await renderPage(
+        Promise.resolve({ gameCode: "ABC123" }),
+      );
+      const section = container.querySelector(
+        'section[aria-label="Game waiting lobby content"]',
+      );
+      expect(section).toBeInTheDocument();
+      expect(section).toHaveAttribute("id", "game-waiting-content");
+    });
+
+    test("includes visually hidden h1 heading", async () => {
+      await renderPage(Promise.resolve({ gameCode: "ABC123" }));
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Waiting for Players" }),
+      ).toBeInTheDocument();
+    });
+
+    test("provides aria-live status region with lobby status text", async () => {
+      const { container } = await renderPage(
+        Promise.resolve({ gameCode: "ABC123" }),
+      );
+      const announcer = container.querySelector("#game-waiting-status");
+      expect(announcer).toBeInTheDocument();
+      expect(announcer).toHaveAttribute("role", "status");
+      expect(announcer).toHaveAttribute("aria-live", "polite");
+      expect(announcer).toHaveAttribute("aria-atomic", "true");
+      expect(announcer).toHaveAttribute("aria-label", "Lobby status updates");
+      expect(announcer?.textContent).toContain("ABC123");
+    });
+  });
+
+  describe("Focus order", () => {
+    test("skip link targets the waiting content section", async () => {
+      await renderPage(Promise.resolve({ gameCode: "ABC123" }));
+      const skipLink = screen.getByRole("link", { name: "Skip to waiting lobby" });
+      expect(skipLink).toHaveAttribute("href", "#game-waiting-content");
+    });
+
+    test("skip link appears before main content in DOM", async () => {
+      await renderPage(Promise.resolve({ gameCode: "ABC123" }));
+      const skipLink = screen.getByRole("link", { name: "Skip to waiting lobby" });
+      const startBtn = screen.getByRole("button", { name: "Start game" });
+      const focusables = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      expect(focusables.indexOf(skipLink)).toBeLessThan(
+        focusables.indexOf(startBtn),
+      );
+    });
+
+    test("skip link has visible focus styles", async () => {
+      await renderPage(Promise.resolve({ gameCode: "ABC123" }));
+      const skipLink = screen.getByRole("link", { name: "Skip to waiting lobby" });
+      expect(skipLink.className).toContain("focus:ring-2");
+      expect(skipLink.className).toContain("focus:not-sr-only");
+    });
+
+    test("waiting content section applies focus-visible styles to descendants", async () => {
+      const { container } = await renderPage(
+        Promise.resolve({ gameCode: "ABC123" }),
+      );
+      const section = container.querySelector("#game-waiting-content");
+      expect(section?.className).toContain("focus-visible");
+    });
+  });
+
+  describe("Invalid / stale state", () => {
+    test("renders alert landmark when gameCode is missing", async () => {
+      const { container } = await renderPage(Promise.resolve({}));
+      expect(container.querySelector('main[role="alert"]')).toBeInTheDocument();
+    });
+
+    test("renders Invalid Game Code heading when gameCode is absent", async () => {
+      await renderPage(Promise.resolve({}));
+      expect(
+        screen.getByRole("heading", { name: "Invalid Game Code" }),
+      ).toBeInTheDocument();
+    });
+
+    test("renders back link to game-settings in invalid state", async () => {
+      await renderPage(Promise.resolve({}));
+      expect(
+        screen.getByRole("link", { name: "Back to Game Settings" }),
+      ).toHaveAttribute("href", "/game-settings");
+    });
+
+    test("invalid state status text describes the problem", async () => {
+      const { container } = await renderPage(Promise.resolve({}));
+      const status = container.querySelector('[role="status"]');
+      expect(status?.textContent).toContain("Invalid or missing game code");
+    });
+
+    test("does not render waiting client in invalid state", async () => {
+      await renderPage(Promise.resolve({}));
+      expect(
+        screen.queryByTestId("game-waiting-client"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("renders invalid state for malformed gameCode", async () => {
+      await renderPage(Promise.resolve({ gameCode: "!@#$" }));
+      expect(
+        screen.getByRole("heading", { name: "Invalid Game Code" }),
+      ).toBeInTheDocument();
+    });
+
+    test("renders invalid state for empty gameCode", async () => {
+      await renderPage(Promise.resolve({ gameCode: "   " }));
+      expect(
+        screen.getByRole("heading", { name: "Invalid Game Code" }),
+      ).toBeInTheDocument();
+    });
+
+    test("normalizes gameCode to uppercase", async () => {
+      const { container } = await renderPage(
+        Promise.resolve({ gameCode: "abc123" }),
+      );
+      const announcer = container.querySelector("#game-waiting-status");
+      expect(announcer?.textContent).toContain("ABC123");
+    });
+
+    test("handles array gameCode param — uses first value", async () => {
+      const { container } = await renderPage(
+        Promise.resolve({ gameCode: ["XYZ789", "OTHER1"] }),
+      );
+      const announcer = container.querySelector("#game-waiting-status");
+      expect(announcer?.textContent).toContain("XYZ789");
+    });
+
+    test("handles empty array gameCode as invalid", async () => {
+      await renderPage(Promise.resolve({ gameCode: [] }));
+      expect(
+        screen.getByRole("heading", { name: "Invalid Game Code" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/game-waiting/page.tsx
+++ b/frontend/src/app/game-waiting/page.tsx
@@ -1,6 +1,7 @@
 import GameWaitingClient from "@/clients/GameWaitingClient";
 import { generatePageMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
+import * as React from "react";
 
 export const metadata: Metadata = generatePageMetadata({
   title: "Waiting for Players",
@@ -10,6 +11,127 @@ export const metadata: Metadata = generatePageMetadata({
   keywords: ["game lobby", "waiting room", "multiplayer", "game start"],
 });
 
-export default function GameWaitingPage() {
-  return <GameWaitingClient />;
+type WaitingState = "waiting" | "invalid";
+
+interface PageProps {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function normalizeSearchParam(
+  value: string | string[] | undefined,
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (Array.isArray(value)) {
+    const first: string | undefined = value[0];
+    return first !== undefined ? first : undefined;
+  }
+  return value;
+}
+
+function parseGameCode(raw: string | undefined): string | null {
+  const trimmed: string = raw?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed.toUpperCase() : null;
+}
+
+function resolveWaitingState(gameCode: string | null): WaitingState {
+  if (gameCode === null) return "invalid";
+  // Game codes are alphanumeric, 4–12 chars
+  if (!/^[A-Z0-9]{4,12}$/.test(gameCode)) return "invalid";
+  return "waiting";
+}
+
+function buildStatusText(
+  waitingState: WaitingState,
+  gameCode: string | null,
+): string {
+  if (waitingState === "invalid") {
+    return "Invalid or missing game code. Please return to game settings.";
+  }
+  return `Waiting for players to join lobby ${gameCode ?? ""}.`;
+}
+
+interface GameWaitingContentProps {
+  waitingState: WaitingState;
+  gameCode: string | null;
+}
+
+function GameWaitingContent({
+  waitingState,
+  gameCode,
+}: GameWaitingContentProps): React.JSX.Element {
+  const statusText: string = buildStatusText(waitingState, gameCode);
+
+  if (waitingState === "invalid") {
+    return (
+      <main
+        aria-label="Game waiting — invalid state"
+        role="alert"
+        className="relative flex min-h-screen w-full flex-col items-center justify-center overflow-x-hidden bg-[#010F10] px-4"
+      >
+        <h1 className="mb-4 text-center font-orbitron text-2xl font-bold text-[#00F0FF]">
+          Invalid Game Code
+        </h1>
+        <p className="mb-6 text-center text-[#869298]">
+          No valid game code was provided. Please go back and create a lobby.
+        </p>
+        <a
+          href="/game-settings"
+          className="rounded bg-[#00F0FF] px-6 py-3 font-orbitron font-bold text-[#010F10] focus:outline-none focus:ring-2 focus:ring-[#00F0FF] focus:ring-offset-2 focus:ring-offset-[#010F10]"
+        >
+          Back to Game Settings
+        </a>
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {statusText}
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      aria-label="Game waiting lobby"
+      aria-busy="true"
+      className="relative min-h-screen w-full overflow-x-hidden bg-[#010F10]"
+    >
+      <a
+        href="#game-waiting-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-[#00F0FF] focus:px-4 focus:py-2 focus:font-bold focus:text-[#010F10] focus:outline-none focus:ring-2 focus:ring-[#00F0FF] focus:ring-offset-2 focus:ring-offset-[#010F10]"
+      >
+        Skip to waiting lobby
+      </a>
+
+      <h1 className="sr-only">Waiting for Players</h1>
+
+      <div
+        id="game-waiting-status"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label="Lobby status updates"
+        className="sr-only"
+      >
+        {statusText}
+      </div>
+
+      <section
+        id="game-waiting-content"
+        aria-label="Game waiting lobby content"
+        className="h-full w-full [&_*:focus-visible]:outline-none [&_*:focus-visible]:ring-2 [&_*:focus-visible]:ring-[#00F0FF] [&_*:focus-visible]:ring-offset-2 [&_*:focus-visible]:ring-offset-[#010F10]"
+      >
+        <GameWaitingClient />
+      </section>
+    </main>
+  );
+}
+
+export default async function GameWaitingPage({
+  searchParams,
+}: PageProps): Promise<React.JSX.Element> {
+  const params: Record<string, string | string[] | undefined> =
+    searchParams !== undefined ? await searchParams : {};
+  const rawGameCode: string | undefined = normalizeSearchParam(params.gameCode);
+  const gameCode: string | null = parseGameCode(rawGameCode);
+  const waitingState: WaitingState = resolveWaitingState(gameCode);
+
+  return <GameWaitingContent waitingState={waitingState} gameCode={gameCode} />;
 }


### PR DESCRIPTION
Closes #737 

Summary of what was done:
 
  page.tsx — rewritten as an async server component following the game-room-loading pattern. Added searchParams prop to read the gameCode URL    
  param (passed from game-settings after lobby creation). Added parseGameCode (trims, uppercases, returns null if empty) and resolveWaitingState 
   (validates alphanumeric 4–12 chars, returns "waiting" | "invalid").
 
  Invalid state renders a role="alert" <main> with an "Invalid Game Code" heading, description, and a "Back to Game Settings" link — handles     
  missing, empty, malformed, and array param values gracefully.
 
  Valid state renders: <main> with aria-label + aria-busy="true", a skip link to #game-waiting-content, sr-only h1, an aria-live="polite"      
  status region announcing the lobby code, and a <section> with id and focus-visible ring styles cascading to all descendants.
 
  page.test.tsx (new, 19 tests) — covers all landmarks, ARIA attributes, skip link, focus order, and every invalid/stale/malformed/array/empty   
  gameCode edge case.