### PR TITLE
feat(frontend): lib/theme strict barrel exports [#816]

### DIFF
--- a/frontend/src/lib/theme/constants.test.ts
+++ b/frontend/src/lib/theme/constants.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  THEME_ATTRIBUTE,
+  THEME_BOOTSTRAP_SCRIPT,
+  THEME_STORAGE_KEY,
+} from "./constants";
+import type { ResolvedTheme, ThemePreference } from "./constants";
+
+describe("theme constants", () => {
+  it("THEME_STORAGE_KEY is a non-empty string", () => {
+    expect(typeof THEME_STORAGE_KEY).toBe("string");
+    expect(THEME_STORAGE_KEY.length).toBeGreaterThan(0);
+  });
+
+  it("THEME_ATTRIBUTE is a non-empty string", () => {
+    expect(typeof THEME_ATTRIBUTE).toBe("string");
+    expect(THEME_ATTRIBUTE.length).toBeGreaterThan(0);
+  });
+
+  it("THEME_BOOTSTRAP_SCRIPT is a non-empty string", () => {
+    expect(typeof THEME_BOOTSTRAP_SCRIPT).toBe("string");
+    expect(THEME_BOOTSTRAP_SCRIPT.length).toBeGreaterThan(0);
+  });
+
+  it("THEME_BOOTSTRAP_SCRIPT references THEME_STORAGE_KEY", () => {
+    expect(THEME_BOOTSTRAP_SCRIPT).toContain(THEME_STORAGE_KEY);
+  });
+
+  it("THEME_BOOTSTRAP_SCRIPT references THEME_ATTRIBUTE", () => {
+    expect(THEME_BOOTSTRAP_SCRIPT).toContain(THEME_ATTRIBUTE);
+  });
+
+  it("THEME_BOOTSTRAP_SCRIPT falls back to light theme on error", () => {
+    expect(THEME_BOOTSTRAP_SCRIPT).toContain("light");
+  });
+});
+
+describe("ThemePreference type", () => {
+  it("accepts valid preference values", () => {
+    const values: ThemePreference[] = ["system", "light", "dark"];
+    expect(values).toHaveLength(3);
+  });
+});
+
+describe("ResolvedTheme type", () => {
+  it("accepts valid resolved theme values", () => {
+    const values: ResolvedTheme[] = ["light", "dark"];
+    expect(values).toHaveLength(2);
+  });
+});

--- a/frontend/src/lib/theme/index.ts
+++ b/frontend/src/lib/theme/index.ts
@@ -5,3 +5,4 @@ export {
 } from "./constants";
 export type { ResolvedTheme, ThemePreference } from "./constants";
 export { getChartPalette, getContrastRatio } from "./chart-palette";
+export type { ChartPalette } from "./chart-palette";


### PR DESCRIPTION
## Summary

Closes #816

Scope: `frontend/src/lib/theme/`

### Changes

**`index.ts`** — added missing `ChartPalette` type export. All public symbols are now explicitly named in the barrel:

| Symbol | Kind |
|---|---|
| `THEME_ATTRIBUTE` | const |
| `THEME_BOOTSTRAP_SCRIPT` | const |
| `THEME_STORAGE_KEY` | const |
| `ThemePreference` | type |
| `ResolvedTheme` | type |
| `getChartPalette` | function |
| `getContrastRatio` | function |
| `ChartPalette` | type (**new**) |

**`constants.test.ts`** — new test file (8 tests):
- `THEME_STORAGE_KEY`, `THEME_ATTRIBUTE`, `THEME_BOOTSTRAP_SCRIPT` are non-empty strings
- Bootstrap script embeds the storage key and attribute name
- Bootstrap script falls back to `light` on error
- `ThemePreference` and `ResolvedTheme` type-level coverage

### CI

The existing `frontend-ci.yml` runs `npm test -- --run` (vitest), which picks up the new test file automatically. All 11 tests pass (3 pre-existing + 8 new).

### No regressions

No consumer imports changed — `ChartPalette` was only missing from the barrel, not from the source file.