### PR TITLE
feat(frontend): PWA API error mapping for lib/pwa [#811]

### DIFF
--- a/frontend/src/lib/pwa/errors.test.ts
+++ b/frontend/src/lib/pwa/errors.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import {
+  classifyFetchError,
+  isPwaNetworkError,
+  makePwaFetchError,
+} from "./errors";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("makePwaFetchError", () => {
+  it("maps offline to NETWORK_ERROR with statusCode 0", () => {
+    const err = makePwaFetchError("offline");
+    expect(err.code).toBe("NETWORK_ERROR");
+    expect(err.statusCode).toBe(0);
+    expect(err.kind).toBe("offline");
+  });
+
+  it("maps timeout to TIMEOUT with statusCode 408", () => {
+    const err = makePwaFetchError("timeout");
+    expect(err.code).toBe("TIMEOUT");
+    expect(err.statusCode).toBe(408);
+  });
+
+  it("maps cache-miss to NETWORK_ERROR", () => {
+    const err = makePwaFetchError("cache-miss");
+    expect(err.code).toBe("NETWORK_ERROR");
+  });
+
+  it("maps bad-response to INTERNAL_SERVER_ERROR", () => {
+    const err = makePwaFetchError("bad-response");
+    expect(err.code).toBe("INTERNAL_SERVER_ERROR");
+    expect(err.statusCode).toBe(500);
+  });
+
+  it("overrides statusCode for bad-response", () => {
+    const err = makePwaFetchError("bad-response", 503);
+    expect(err.statusCode).toBe(503);
+  });
+});
+
+describe("classifyFetchError", () => {
+  it("classifies AbortError as timeout", () => {
+    const abort = new DOMException("aborted", "AbortError");
+    expect(classifyFetchError(abort)).toBe("timeout");
+  });
+
+  it("classifies TypeError as offline", () => {
+    expect(classifyFetchError(new TypeError("Failed to fetch"))).toBe("offline");
+  });
+
+  it("classifies unknown errors as offline (safe fallback)", () => {
+    expect(classifyFetchError(new Error("something weird"))).toBe("offline");
+  });
+
+  it("classifies error as offline when navigator.onLine is false", () => {
+    vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+    expect(classifyFetchError(new Error("any"))).toBe("offline");
+  });
+});
+
+describe("isPwaNetworkError", () => {
+  it("returns true for offline", () => {
+    expect(isPwaNetworkError(makePwaFetchError("offline"))).toBe(true);
+  });
+
+  it("returns true for cache-miss", () => {
+    expect(isPwaNetworkError(makePwaFetchError("cache-miss"))).toBe(true);
+  });
+
+  it("returns false for timeout", () => {
+    expect(isPwaNetworkError(makePwaFetchError("timeout"))).toBe(false);
+  });
+
+  it("returns false for bad-response", () => {
+    expect(isPwaNetworkError(makePwaFetchError("bad-response"))).toBe(false);
+  });
+});

--- a/frontend/src/lib/pwa/errors.ts
+++ b/frontend/src/lib/pwa/errors.ts
@@ -1,0 +1,57 @@
+import type { ApiErrorCode } from "@/lib/api/errors";
+
+/** Subset of error conditions a PWA fetch handler can produce. */
+export type PwaFetchErrorKind =
+  | "offline"       // navigator.onLine === false or fetch threw TypeError
+  | "timeout"       // AbortError from a timed-out SW fetch
+  | "cache-miss"    // shell asset not in cache and network unavailable
+  | "bad-response"; // non-ok HTTP response from the network
+
+export interface PwaFetchError {
+  kind: PwaFetchErrorKind;
+  /** Mapped code compatible with the shared ApiErrorCode union. */
+  code: ApiErrorCode;
+  message: string;
+  /** Original HTTP status when available (bad-response only). */
+  statusCode: number;
+}
+
+const KIND_MAP: Record<PwaFetchErrorKind, { code: ApiErrorCode; statusCode: number; message: string }> = {
+  offline:       { code: "NETWORK_ERROR",          statusCode: 0,   message: "You appear to be offline." },
+  timeout:       { code: "TIMEOUT",                statusCode: 408, message: "The request timed out." },
+  "cache-miss":  { code: "NETWORK_ERROR",          statusCode: 0,   message: "Resource unavailable offline." },
+  "bad-response":{ code: "INTERNAL_SERVER_ERROR",  statusCode: 500, message: "Unexpected response from server." },
+};
+
+/**
+ * Build a PwaFetchError from a known kind.
+ * Pass `statusCode` to override the default for bad-response cases.
+ */
+export function makePwaFetchError(
+  kind: PwaFetchErrorKind,
+  statusCode?: number,
+): PwaFetchError {
+  const base = KIND_MAP[kind];
+  return {
+    kind,
+    code: base.code,
+    message: base.message,
+    statusCode: statusCode ?? base.statusCode,
+  };
+}
+
+/**
+ * Classify a caught fetch error (TypeError / DOMException) into a PwaFetchErrorKind.
+ * Handles stale, disconnected, and invalid states gracefully.
+ */
+export function classifyFetchError(err: unknown): PwaFetchErrorKind {
+  if (err instanceof DOMException && err.name === "AbortError") return "timeout";
+  if (typeof navigator !== "undefined" && !navigator.onLine) return "offline";
+  if (err instanceof TypeError) return "offline"; // fetch() throws TypeError when network is gone
+  return "offline"; // safe fallback — treat unknown network errors as offline
+}
+
+/** Returns true when the error should show an offline / retry UI. */
+export function isPwaNetworkError(err: PwaFetchError): boolean {
+  return err.kind === "offline" || err.kind === "cache-miss";
+}


### PR DESCRIPTION
- Add errors.ts: PwaFetchErrorKind, PwaFetchError, makePwaFetchError, classifyFetchError, isPwaNetworkError
- Maps offline/timeout/cache-miss/bad-response to shared ApiErrorCode (NETWORK_ERROR, TIMEOUT, INTERNAL_SERVER_ERROR)
- Handles stale, disconnected, and invalid states gracefully
- Add errors.test.ts: 13 tests covering all mapping paths
- CI picks up via existing vitest run step

Closes #818