### PR TITLE
feat(frontend): tree-shake audit for lib/theme [#815]

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "sideEffects": false,
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/lib/theme/chart-palette.test.ts
+++ b/frontend/src/lib/theme/chart-palette.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getChartPalette, getContrastRatio } from "./chart-palette";
+import {
+  DARK_CHART_PALETTE,
+  LIGHT_CHART_PALETTE,
+  getChartPalette,
+  getContrastRatio,
+} from "./chart-palette";
 
 describe("getChartPalette", () => {
   it("keeps dark chart text highly legible against the dark chart background", () => {
@@ -20,5 +25,39 @@ describe("getChartPalette", () => {
     const palette = getChartPalette("light");
 
     expect(getContrastRatio(palette.foreground, palette.background)).toBeGreaterThanOrEqual(7);
+  });
+});
+
+// Tree-shake audit: named palette constants must be independently importable
+// so bundlers can eliminate the unused theme at build time.
+describe("tree-shake audit — named palette exports", () => {
+  it("LIGHT_CHART_PALETTE is a standalone export with the expected shape", () => {
+    expect(LIGHT_CHART_PALETTE).toMatchObject({
+      background: expect.any(String),
+      foreground: expect.any(String),
+      grid: expect.any(String),
+      series: expect.arrayContaining([expect.any(String)]),
+    });
+  });
+
+  it("DARK_CHART_PALETTE is a standalone export with the expected shape", () => {
+    expect(DARK_CHART_PALETTE).toMatchObject({
+      background: expect.any(String),
+      foreground: expect.any(String),
+      grid: expect.any(String),
+      series: expect.arrayContaining([expect.any(String)]),
+    });
+  });
+
+  it("getChartPalette('light') returns the same reference as LIGHT_CHART_PALETTE", () => {
+    expect(getChartPalette("light")).toBe(LIGHT_CHART_PALETTE);
+  });
+
+  it("getChartPalette('dark') returns the same reference as DARK_CHART_PALETTE", () => {
+    expect(getChartPalette("dark")).toBe(DARK_CHART_PALETTE);
+  });
+
+  it("LIGHT_CHART_PALETTE and DARK_CHART_PALETTE are distinct objects", () => {
+    expect(LIGHT_CHART_PALETTE).not.toBe(DARK_CHART_PALETTE);
   });
 });

--- a/frontend/src/lib/theme/chart-palette.ts
+++ b/frontend/src/lib/theme/chart-palette.ts
@@ -7,23 +7,22 @@ export type ChartPalette = {
   series: string[];
 };
 
-const chartPalettes: Record<ResolvedTheme, ChartPalette> = {
-  light: {
-    background: "#F7FAFB",
-    foreground: "#12262A",
-    grid: "#BBD4D6",
-    series: ["#006D77", "#00A7B5", "#1D4ED8", "#EA580C"],
-  },
-  dark: {
-    background: "#07181B",
-    foreground: "#E6FEFF",
-    grid: "#2B5C60",
-    series: ["#00F0FF", "#00FFA8", "#8AB4FF", "#FFB86C"],
-  },
+export const LIGHT_CHART_PALETTE: ChartPalette = {
+  background: "#F7FAFB",
+  foreground: "#12262A",
+  grid: "#BBD4D6",
+  series: ["#006D77", "#00A7B5", "#1D4ED8", "#EA580C"],
+};
+
+export const DARK_CHART_PALETTE: ChartPalette = {
+  background: "#07181B",
+  foreground: "#E6FEFF",
+  grid: "#2B5C60",
+  series: ["#00F0FF", "#00FFA8", "#8AB4FF", "#FFB86C"],
 };
 
 export function getChartPalette(theme: ResolvedTheme): ChartPalette {
-  return chartPalettes[theme];
+  return theme === "dark" ? DARK_CHART_PALETTE : LIGHT_CHART_PALETTE;
 }
 
 function hexToRgb(hex: string) {

--- a/frontend/src/lib/theme/index.ts
+++ b/frontend/src/lib/theme/index.ts
@@ -4,4 +4,9 @@ export {
   THEME_STORAGE_KEY,
 } from "./constants";
 export type { ResolvedTheme, ThemePreference } from "./constants";
-export { getChartPalette, getContrastRatio } from "./chart-palette";
+export {
+  DARK_CHART_PALETTE,
+  LIGHT_CHART_PALETTE,
+  getChartPalette,
+  getContrastRatio,
+} from "./chart-palette";


### PR DESCRIPTION
## Summary

Audits `frontend/src/lib/theme/` for tree-shaking correctness and fixes the one structural blocker.

## Problem

`chartPalettes` was a single module-level `Record<ResolvedTheme, ChartPalette>` object. Because the key is a runtime value, bundlers (webpack/Rollup/Turbopack) cannot statically determine which theme is used and must include **both** palettes in every bundle that imports `getChartPalette`.

## Changes

### `chart-palette.ts`
- Replace `chartPalettes` record with two named exports: `LIGHT_CHART_PALETTE` and `DARK_CHART_PALETTE`
- `getChartPalette()` uses a ternary referencing the named constants — bundlers can now statically resolve and eliminate the unused branch

### `index.ts`
- Re-export `LIGHT_CHART_PALETTE` and `DARK_CHART_PALETTE` from the barrel

### `frontend/package.json`
- Add `"sideEffects": false` — signals to webpack/Rollup that all modules in this package are side-effect-free and safe to tree-shake

### `chart-palette.test.ts`
- 5 new tree-shake audit tests:
  - Named exports exist and have the correct shape
  - `getChartPalette('light')` returns the **same reference** as `LIGHT_CHART_PALETTE` (no extra allocation)
  - `getChartPalette('dark')` returns the **same reference** as `DARK_CHART_PALETTE`
  - The two constants are distinct objects

## Test results

```
✓ src/lib/theme/chart-palette.test.ts (8 tests) 12ms
  Test Files  1 passed (1)
  Tests       8 passed (8)
```

Closes #811