### PR TITLE
Admin analytics observability and shop analytics reintegration

### DIFF
--- a/backend/src/modules/admin-analytics/README.md
+++ b/backend/src/modules/admin-analytics/README.md
@@ -122,6 +122,14 @@ admin-analytics/
 └── README.md                       # This file
 ```
 
+## Observability
+
+The admin analytics module now records runtime analytics events and duration metrics through the backend observability stack.
+
+- Metrics exposed via Prometheus-style counters and histograms
+- Request lifecycle traces recorded with debug-level logging
+- Admin analytics endpoints can be monitored for success and failure rates
+
 ## Integration
 
 The module is registered in `app.module.ts`:

--- a/backend/src/modules/admin-analytics/README.md
+++ b/backend/src/modules/admin-analytics/README.md
@@ -44,7 +44,32 @@ Returns the number of users active in the last 30 days (based on `updated_at` ti
 }
 ```
 
-#### 4. Total Games
+#### 4. Shop Analytics
+```
+GET /admin/analytics/shop
+```
+Returns shop revenue, purchase, conversion, and retention analytics:
+```json
+{
+  "totalRevenue": 12500,
+  "popularItems": [
+    {
+      "itemId": "item-1",
+      "itemName": "Sword",
+      "purchaseCount": 120,
+      "totalRevenue": 5600
+    }
+  ],
+  "conversionRate": 14.5,
+  "retentionMetrics": {
+    "day1": 82,
+    "day7": 67,
+    "day30": 42
+  }
+}
+```
+
+#### 5. Total Games
 ```
 GET /admin/analytics/games/total
 ```

--- a/backend/src/modules/admin-analytics/admin-analytics-observability.service.spec.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics-observability.service.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminAnalyticsObservabilityService } from './admin-analytics-observability.service';
+import { LoggerService } from '../../common/logger/logger.service';
+
+describe('AdminAnalyticsObservabilityService', () => {
+  let service: AdminAnalyticsObservabilityService;
+  const mockLoggerService = {
+    debug: jest.fn(),
+    logWithMeta: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminAnalyticsObservabilityService,
+        {
+          provide: LoggerService,
+          useValue: mockLoggerService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AdminAnalyticsObservabilityService>(
+      AdminAnalyticsObservabilityService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should record analytics request metrics and log debug details', async () => {
+    service.recordRequest('dashboard', true, 120);
+
+    const metrics = await service.registry.metrics();
+
+    expect(metrics).toContain('tycoon_admin_analytics_requests_total');
+    expect(metrics).toContain('tycoon_admin_analytics_request_duration_seconds');
+    expect(mockLoggerService.debug).toHaveBeenCalledWith(
+      'Admin analytics request completed: dashboard (success)',
+      'AdminAnalyticsObservability',
+    );
+  });
+
+  it('should log endpoint metadata with custom message', () => {
+    service.logEndpoint('users_total', 'Request completed', { userCount: 5 });
+
+    expect(mockLoggerService.logWithMeta).toHaveBeenCalledWith('info',
+      'Request completed',
+      expect.objectContaining({
+        endpoint: 'users_total',
+        userCount: 5,
+      }),
+    );
+  });
+});

--- a/backend/src/modules/admin-analytics/admin-analytics-observability.service.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics-observability.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { Counter, Histogram, Registry } from 'prom-client';
+import { LoggerService } from '../../common/logger/logger.service';
+
+const ADMIN_ANALYTICS_DURATION_BUCKETS = [
+  0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
+];
+
+@Injectable()
+export class AdminAnalyticsObservabilityService {
+  readonly registry = new Registry();
+
+  private readonly analyticsRequestsTotal: Counter<string>;
+  private readonly analyticsRequestDuration: Histogram<string>;
+
+  constructor(private readonly logger: LoggerService) {
+    this.analyticsRequestsTotal = new Counter({
+      name: 'tycoon_admin_analytics_requests_total',
+      help: 'Total admin analytics requests by endpoint and status',
+      labelNames: ['endpoint', 'status'],
+      registers: [this.registry],
+    });
+
+    this.analyticsRequestDuration = new Histogram({
+      name: 'tycoon_admin_analytics_request_duration_seconds',
+      help: 'Duration of admin analytics requests',
+      labelNames: ['endpoint'],
+      buckets: ADMIN_ANALYTICS_DURATION_BUCKETS,
+      registers: [this.registry],
+    });
+  }
+
+  recordRequest(endpoint: string, success: boolean, durationMs: number): void {
+    const status = success ? 'success' : 'failure';
+
+    this.analyticsRequestsTotal.inc({ endpoint, status }, 1);
+    this.analyticsRequestDuration.observe({ endpoint }, durationMs / 1000);
+
+    this.logger.debug(
+      `Admin analytics request completed: ${endpoint} (${status})`,
+      'AdminAnalyticsObservability',
+    );
+  }
+
+  logEndpoint(endpoint: string, message: string, meta?: Record<string, unknown>): void {
+    this.logger.logWithMeta('info', message, {
+      endpoint,
+      ...meta,
+    });
+  }
+}

--- a/backend/src/modules/admin-analytics/admin-analytics.controller.spec.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.controller.spec.ts
@@ -8,6 +8,7 @@ describe('AdminAnalyticsController', () => {
 
   const mockAnalyticsService = {
     getDashboardAnalytics: jest.fn(),
+    getShopAnalytics: jest.fn(),
     getTotalUsers: jest.fn(),
     getActiveUsers: jest.fn(),
     getTotalGames: jest.fn(),
@@ -48,6 +49,31 @@ describe('AdminAnalyticsController', () => {
 
       expect(result).toEqual(mockData);
       expect(service.getDashboardAnalytics).toHaveBeenCalled();
+    });
+  });
+
+  describe('getShopAnalytics', () => {
+    it('should return shop analytics', async () => {
+      const mockData = {
+        totalRevenue: 1000,
+        popularItems: [
+          {
+            itemId: 'item-1',
+            itemName: 'Sword',
+            purchaseCount: 25,
+            totalRevenue: 500,
+          },
+        ],
+        conversionRate: 4.5,
+        retentionMetrics: { day1: 80, day7: 60, day30: 45 },
+      };
+
+      mockAnalyticsService.getShopAnalytics.mockResolvedValue(mockData);
+
+      const result = await controller.getShopAnalytics();
+
+      expect(result).toEqual(mockData);
+      expect(service.getShopAnalytics).toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/admin-analytics/admin-analytics.controller.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { AdminAnalyticsService } from './admin-analytics.service';
 import { DashboardAnalyticsDto } from './dto/dashboard-analytics.dto';
+import { ShopAnalyticsDto } from './dto/shop-analytics.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AdminGuard } from '../auth/guards/admin.guard';
 
@@ -12,6 +13,11 @@ export class AdminAnalyticsController {
   @Get('dashboard')
   async getDashboardAnalytics(): Promise<DashboardAnalyticsDto> {
     return this.analyticsService.getDashboardAnalytics();
+  }
+
+  @Get('shop')
+  async getShopAnalytics(): Promise<ShopAnalyticsDto> {
+    return this.analyticsService.getShopAnalytics();
   }
 
   @Get('users/total')

--- a/backend/src/modules/admin-analytics/admin-analytics.module.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.module.ts
@@ -6,9 +6,19 @@ import { AdminAnalyticsObservabilityService } from './admin-analytics-observabil
 import { User } from '../users/entities/user.entity';
 import { Game } from '../games/entities/game.entity';
 import { GamePlayer } from '../games/entities/game-player.entity';
+import { Transaction } from './entities/transaction.entity';
+import { PlayerActivity } from './entities/player-activity.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Game, GamePlayer])],
+  imports: [
+    TypeOrmModule.forFeature([
+      User,
+      Game,
+      GamePlayer,
+      Transaction,
+      PlayerActivity,
+    ]),
+  ],
   controllers: [AdminAnalyticsController],
   providers: [AdminAnalyticsService, AdminAnalyticsObservabilityService],
   exports: [AdminAnalyticsService],

--- a/backend/src/modules/admin-analytics/admin-analytics.module.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AdminAnalyticsController } from './admin-analytics.controller';
 import { AdminAnalyticsService } from './admin-analytics.service';
+import { AdminAnalyticsObservabilityService } from './admin-analytics-observability.service';
 import { User } from '../users/entities/user.entity';
 import { Game } from '../games/entities/game.entity';
 import { GamePlayer } from '../games/entities/game-player.entity';
@@ -9,7 +10,7 @@ import { GamePlayer } from '../games/entities/game-player.entity';
 @Module({
   imports: [TypeOrmModule.forFeature([User, Game, GamePlayer])],
   controllers: [AdminAnalyticsController],
-  providers: [AdminAnalyticsService],
+  providers: [AdminAnalyticsService, AdminAnalyticsObservabilityService],
   exports: [AdminAnalyticsService],
 })
 export class AdminAnalyticsModule {}

--- a/backend/src/modules/admin-analytics/admin-analytics.service.spec.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.service.spec.ts
@@ -6,6 +6,8 @@ import { AdminAnalyticsObservabilityService } from './admin-analytics-observabil
 import { User } from '../users/entities/user.entity';
 import { Game } from '../games/entities/game.entity';
 import { GamePlayer } from '../games/entities/game-player.entity';
+import { Transaction } from './entities/transaction.entity';
+import { PlayerActivity } from './entities/player-activity.entity';
 
 describe('AdminAnalyticsService', () => {
   let service: AdminAnalyticsService;
@@ -24,6 +26,15 @@ describe('AdminAnalyticsService', () => {
 
   const mockGamePlayerRepo = {
     count: jest.fn(),
+  };
+
+  const mockTransactionRepo = {
+    createQueryBuilder: jest.fn(),
+    count: jest.fn(),
+  };
+
+  const mockActivityRepo = {
+    createQueryBuilder: jest.fn(),
   };
 
   const mockObservabilityService = {
@@ -46,6 +57,14 @@ describe('AdminAnalyticsService', () => {
         {
           provide: getRepositoryToken(GamePlayer),
           useValue: mockGamePlayerRepo,
+        },
+        {
+          provide: getRepositoryToken(Transaction),
+          useValue: mockTransactionRepo,
+        },
+        {
+          provide: getRepositoryToken(PlayerActivity),
+          useValue: mockActivityRepo,
         },
         {
           provide: AdminAnalyticsObservabilityService,
@@ -140,6 +159,51 @@ describe('AdminAnalyticsService', () => {
       });
       expect(observabilityService.recordRequest).toHaveBeenCalledWith(
         'dashboard',
+        true,
+        expect.any(Number),
+      );
+    });
+  });
+
+  describe('getShopAnalytics', () => {
+    it('should return shop analytics data and record observability metrics', async () => {
+      jest.spyOn(service as any, 'getTotalRevenue').mockResolvedValue(1200);
+      jest.spyOn(service as any, 'getPopularItems').mockResolvedValue([
+        {
+          itemId: 'item-1',
+          itemName: 'Sword',
+          purchaseCount: 10,
+          totalRevenue: 500,
+        },
+      ]);
+      jest.spyOn(service as any, 'getConversionRate').mockResolvedValue(50);
+      jest.spyOn(service as any, 'getRetentionMetrics').mockResolvedValue({
+        day1: 80,
+        day7: 60,
+        day30: 40,
+      });
+
+      const result = await service.getShopAnalytics();
+
+      expect(result).toEqual({
+        totalRevenue: 1200,
+        popularItems: [
+          {
+            itemId: 'item-1',
+            itemName: 'Sword',
+            purchaseCount: 10,
+            totalRevenue: 500,
+          },
+        ],
+        conversionRate: 50,
+        retentionMetrics: {
+          day1: 80,
+          day7: 60,
+          day30: 40,
+        },
+      });
+      expect(observabilityService.recordRequest).toHaveBeenCalledWith(
+        'shop',
         true,
         expect.any(Number),
       );

--- a/backend/src/modules/admin-analytics/admin-analytics.service.spec.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, MoreThan } from 'typeorm';
 import { AdminAnalyticsService } from './admin-analytics.service';
+import { AdminAnalyticsObservabilityService } from './admin-analytics-observability.service';
 import { User } from '../users/entities/user.entity';
 import { Game } from '../games/entities/game.entity';
 import { GamePlayer } from '../games/entities/game-player.entity';
@@ -11,6 +12,7 @@ describe('AdminAnalyticsService', () => {
   let userRepo: Repository<User>;
   let gameRepo: Repository<Game>;
   let gamePlayerRepo: Repository<GamePlayer>;
+  let observabilityService: AdminAnalyticsObservabilityService;
 
   const mockUserRepo = {
     count: jest.fn(),
@@ -22,6 +24,11 @@ describe('AdminAnalyticsService', () => {
 
   const mockGamePlayerRepo = {
     count: jest.fn(),
+  };
+
+  const mockObservabilityService = {
+    recordRequest: jest.fn(),
+    logEndpoint: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -40,6 +47,10 @@ describe('AdminAnalyticsService', () => {
           provide: getRepositoryToken(GamePlayer),
           useValue: mockGamePlayerRepo,
         },
+        {
+          provide: AdminAnalyticsObservabilityService,
+          useValue: mockObservabilityService,
+        },
       ],
     }).compile();
 
@@ -48,6 +59,9 @@ describe('AdminAnalyticsService', () => {
     gameRepo = module.get<Repository<Game>>(getRepositoryToken(Game));
     gamePlayerRepo = module.get<Repository<GamePlayer>>(
       getRepositoryToken(GamePlayer),
+    );
+    observabilityService = module.get<AdminAnalyticsObservabilityService>(
+      AdminAnalyticsObservabilityService,
     );
   });
 
@@ -124,6 +138,11 @@ describe('AdminAnalyticsService', () => {
         totalGames: 200,
         totalGamePlayers: 400,
       });
+      expect(observabilityService.recordRequest).toHaveBeenCalledWith(
+        'dashboard',
+        true,
+        expect.any(Number),
+      );
     });
   });
 });

--- a/backend/src/modules/admin-analytics/admin-analytics.service.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.service.ts
@@ -4,7 +4,10 @@ import { Repository, MoreThan } from 'typeorm';
 import { User } from '../users/entities/user.entity';
 import { Game } from '../games/entities/game.entity';
 import { GamePlayer } from '../games/entities/game-player.entity';
+import { Transaction } from './entities/transaction.entity';
+import { PlayerActivity } from './entities/player-activity.entity';
 import { DashboardAnalyticsDto } from './dto/dashboard-analytics.dto';
+import { ShopAnalyticsDto, PopularItemDto } from './dto/shop-analytics.dto';
 import { AdminAnalyticsObservabilityService } from './admin-analytics-observability.service';
 
 @Injectable()
@@ -16,6 +19,10 @@ export class AdminAnalyticsService {
     private gameRepo: Repository<Game>,
     @InjectRepository(GamePlayer)
     private gamePlayerRepo: Repository<GamePlayer>,
+    @InjectRepository(Transaction)
+    private transactionRepo: Repository<Transaction>,
+    @InjectRepository(PlayerActivity)
+    private activityRepo: Repository<PlayerActivity>,
     private readonly observability: AdminAnalyticsObservabilityService,
   ) {}
 
@@ -53,6 +60,25 @@ export class AdminAnalyticsService {
       );
       throw error;
     }
+  }
+
+  async getShopAnalytics(): Promise<ShopAnalyticsDto> {
+    return this.trackRequest('shop', async () => {
+      const [totalRevenue, popularItems, conversionRate, retentionMetrics] =
+        await Promise.all([
+          this.getTotalRevenue(),
+          this.getPopularItems(),
+          this.getConversionRate(),
+          this.getRetentionMetrics(),
+        ]);
+
+      return {
+        totalRevenue,
+        popularItems,
+        conversionRate,
+        retentionMetrics,
+      };
+    });
   }
 
   async getTotalUsers(): Promise<number> {
@@ -95,6 +121,104 @@ export class AdminAnalyticsService {
       );
       throw error;
     }
+  }
+
+  private async getTotalRevenue(): Promise<number> {
+    const result = await this.transactionRepo
+      .createQueryBuilder('transaction')
+      .select('SUM(transaction.amount)', 'total')
+      .getRawOne();
+
+    return parseFloat(result?.total || '0');
+  }
+
+  private async getPopularItems(): Promise<PopularItemDto[]> {
+    const rawItems = await this.transactionRepo
+      .createQueryBuilder('transaction')
+      .select('transaction.itemId', 'itemId')
+      .addSelect('transaction.itemName', 'itemName')
+      .addSelect('COUNT(*)', 'purchaseCount')
+      .addSelect('SUM(transaction.amount)', 'totalRevenue')
+      .groupBy('transaction.itemId')
+      .addGroupBy('transaction.itemName')
+      .orderBy('COUNT(*)', 'DESC')
+      .limit(10)
+      .getRawMany();
+
+    return rawItems.map((item: any) => ({
+      itemId: item.itemId,
+      itemName: item.itemName,
+      purchaseCount: parseInt(item.purchaseCount, 10),
+      totalRevenue: parseFloat(item.totalRevenue),
+    }));
+  }
+
+  private async getConversionRate(): Promise<number> {
+    const totalPlayersRaw = await this.activityRepo
+      .createQueryBuilder('activity')
+      .select('COUNT(DISTINCT activity.playerId)', 'count')
+      .getRawOne();
+
+    const purchasedPlayersRaw = await this.transactionRepo
+      .createQueryBuilder('transaction')
+      .select('COUNT(DISTINCT transaction.playerId)', 'count')
+      .getRawOne();
+
+    const total = parseInt(totalPlayersRaw?.count || '0', 10);
+    const purchased = parseInt(purchasedPlayersRaw?.count || '0', 10);
+
+    return total > 0 ? (purchased / total) * 100 : 0;
+  }
+
+  private async getRetentionMetrics(): Promise<{
+    day1: number;
+    day7: number;
+    day30: number;
+  }> {
+    const now = new Date();
+
+    const [day1, day7, day30] = await Promise.all([
+      this.calculateRetention(1, now),
+      this.calculateRetention(7, now),
+      this.calculateRetention(30, now),
+    ]);
+
+    return { day1, day7, day30 };
+  }
+
+  private async calculateRetention(
+    days: number,
+    now: Date,
+  ): Promise<number> {
+    const startDate = new Date(now);
+    startDate.setDate(startDate.getDate() - days - 1);
+    const endDate = new Date(now);
+    endDate.setDate(endDate.getDate() - days);
+
+    const initialPlayers = await this.activityRepo
+      .createQueryBuilder('activity')
+      .select('DISTINCT activity.playerId', 'playerId')
+      .where('activity.createdAt >= :start AND activity.createdAt < :end', {
+        start: startDate,
+        end: endDate,
+      })
+      .getRawMany();
+
+    if (!initialPlayers?.length) {
+      return 0;
+    }
+
+    const returnedPlayers = await this.activityRepo
+      .createQueryBuilder('activity')
+      .select('COUNT(DISTINCT activity.playerId)', 'count')
+      .where('activity.playerId IN (:...playerIds)', {
+        playerIds: initialPlayers.map((player: any) => player.playerId),
+      })
+      .andWhere('activity.createdAt >= :end', { end: endDate })
+      .getRawOne();
+
+    const returned = parseInt(returnedPlayers?.count || '0', 10);
+    return (returned / initialPlayers.length) * 100;
   }
 
   private async countTotalUsers(): Promise<number> {

--- a/backend/src/modules/admin-analytics/admin-analytics.service.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.service.ts
@@ -5,6 +5,7 @@ import { User } from '../users/entities/user.entity';
 import { Game } from '../games/entities/game.entity';
 import { GamePlayer } from '../games/entities/game-player.entity';
 import { DashboardAnalyticsDto } from './dto/dashboard-analytics.dto';
+import { AdminAnalyticsObservabilityService } from './admin-analytics-observability.service';
 
 @Injectable()
 export class AdminAnalyticsService {
@@ -15,30 +16,92 @@ export class AdminAnalyticsService {
     private gameRepo: Repository<Game>,
     @InjectRepository(GamePlayer)
     private gamePlayerRepo: Repository<GamePlayer>,
+    private readonly observability: AdminAnalyticsObservabilityService,
   ) {}
 
   async getDashboardAnalytics(): Promise<DashboardAnalyticsDto> {
-    const [totalUsers, activeUsers, totalGames, totalGamePlayers] =
-      await Promise.all([
-        this.getTotalUsers(),
-        this.getActiveUsers(),
-        this.getTotalGames(),
-        this.getTotalGamePlayers(),
-      ]);
+    const startedAt = Date.now();
 
-    return {
-      totalUsers,
-      activeUsers,
-      totalGames,
-      totalGamePlayers,
-    };
+    try {
+      const [totalUsers, activeUsers, totalGames, totalGamePlayers] =
+        await Promise.all([
+          this.countTotalUsers(),
+          this.countActiveUsers(),
+          this.countTotalGames(),
+          this.countTotalGamePlayers(),
+        ]);
+
+      const result = {
+        totalUsers,
+        activeUsers,
+        totalGames,
+        totalGamePlayers,
+      };
+
+      this.observability.recordRequest(
+        'dashboard',
+        true,
+        Date.now() - startedAt,
+      );
+
+      return result;
+    } catch (error) {
+      this.observability.recordRequest(
+        'dashboard',
+        false,
+        Date.now() - startedAt,
+      );
+      throw error;
+    }
   }
 
   async getTotalUsers(): Promise<number> {
-    return this.userRepo.count();
+    return this.trackRequest('users_total', () => this.countTotalUsers());
   }
 
   async getActiveUsers(): Promise<number> {
+    return this.trackRequest('users_active', () => this.countActiveUsers());
+  }
+
+  async getTotalGames(): Promise<number> {
+    return this.trackRequest('games_total', () => this.countTotalGames());
+  }
+
+  async getTotalGamePlayers(): Promise<number> {
+    return this.trackRequest('games_players_total', () =>
+      this.countTotalGamePlayers(),
+    );
+  }
+
+  private async trackRequest<T>(
+    endpoint: string,
+    callback: () => Promise<T>,
+  ): Promise<T> {
+    const startedAt = Date.now();
+
+    try {
+      const result = await callback();
+      this.observability.recordRequest(
+        endpoint,
+        true,
+        Date.now() - startedAt,
+      );
+      return result;
+    } catch (error) {
+      this.observability.recordRequest(
+        endpoint,
+        false,
+        Date.now() - startedAt,
+      );
+      throw error;
+    }
+  }
+
+  private async countTotalUsers(): Promise<number> {
+    return this.userRepo.count();
+  }
+
+  private async countActiveUsers(): Promise<number> {
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
@@ -49,11 +112,11 @@ export class AdminAnalyticsService {
     });
   }
 
-  async getTotalGames(): Promise<number> {
+  private async countTotalGames(): Promise<number> {
     return this.gameRepo.count();
   }
 
-  async getTotalGamePlayers(): Promise<number> {
+  private async countTotalGamePlayers(): Promise<number> {
     return this.gamePlayerRepo.count();
   }
 }

--- a/backend/src/modules/admin-analytics/dto/shop-analytics.dto.ts
+++ b/backend/src/modules/admin-analytics/dto/shop-analytics.dto.ts
@@ -1,0 +1,17 @@
+export class PopularItemDto {
+  itemId: string;
+  itemName: string;
+  purchaseCount: number;
+  totalRevenue: number;
+}
+
+export class ShopAnalyticsDto {
+  totalRevenue: number;
+  popularItems: PopularItemDto[];
+  conversionRate: number;
+  retentionMetrics: {
+    day1: number;
+    day7: number;
+    day30: number;
+  };
+}

--- a/backend/src/modules/admin-analytics/entities/player-activity.entity.ts
+++ b/backend/src/modules/admin-analytics/entities/player-activity.entity.ts
@@ -1,0 +1,21 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class PlayerActivity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  playerId: string;
+
+  @Column()
+  action: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/modules/admin-analytics/entities/transaction.entity.ts
+++ b/backend/src/modules/admin-analytics/entities/transaction.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class Transaction {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  playerId: string;
+
+  @Column()
+  itemId: string;
+
+  @Column()
+  itemName: string;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  amount: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}


### PR DESCRIPTION
Fixes issue #860 by adding admin analytics observability metrics and request tracing, and issue #859 by reintegrating shop analytics into the canonical admin-analytics module with a new /admin/analytics/shop endpoint, supporting revenue, popular items, conversion rate, and retention metrics.
closes #859 
closes #860