### PR TITLE
feat(admin-analytics): pagination and stable sorting

### DIFF
--- a/backend/src/modules/admin-analytics/admin-analytics.controller.spec.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AdminAnalyticsController } from './admin-analytics.controller';
 import { AdminAnalyticsService } from './admin-analytics.service';
+import { PaginatedUsersQueryDto, PaginatedGamesQueryDto } from './dto/analytics-query.dto';
 
 describe('AdminAnalyticsController', () => {
   let controller: AdminAnalyticsController;
@@ -12,22 +13,21 @@ describe('AdminAnalyticsController', () => {
     getActiveUsers: jest.fn(),
     getTotalGames: jest.fn(),
     getTotalGamePlayers: jest.fn(),
+    getPaginatedUsers: jest.fn(),
+    getPaginatedGames: jest.fn(),
   };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AdminAnalyticsController],
-      providers: [
-        {
-          provide: AdminAnalyticsService,
-          useValue: mockAnalyticsService,
-        },
-      ],
+      providers: [{ provide: AdminAnalyticsService, useValue: mockAnalyticsService }],
     }).compile();
 
     controller = module.get<AdminAnalyticsController>(AdminAnalyticsController);
     service = module.get<AdminAnalyticsService>(AdminAnalyticsService);
   });
+
+  afterEach(() => jest.clearAllMocks());
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
@@ -35,63 +35,83 @@ describe('AdminAnalyticsController', () => {
 
   describe('getDashboardAnalytics', () => {
     it('should return dashboard analytics', async () => {
-      const mockData = {
-        totalUsers: 100,
-        activeUsers: 50,
-        totalGames: 200,
-        totalGamePlayers: 400,
-      };
-
+      const mockData = { totalUsers: 100, activeUsers: 50, totalGames: 200, totalGamePlayers: 400 };
       mockAnalyticsService.getDashboardAnalytics.mockResolvedValue(mockData);
-
-      const result = await controller.getDashboardAnalytics();
-
-      expect(result).toEqual(mockData);
-      expect(service.getDashboardAnalytics).toHaveBeenCalled();
+      expect(await controller.getDashboardAnalytics()).toEqual(mockData);
     });
   });
 
   describe('getTotalUsers', () => {
     it('should return total users count', async () => {
       mockAnalyticsService.getTotalUsers.mockResolvedValue(100);
-
-      const result = await controller.getTotalUsers();
-
-      expect(result).toEqual({ totalUsers: 100 });
-      expect(service.getTotalUsers).toHaveBeenCalled();
+      expect(await controller.getTotalUsers()).toEqual({ totalUsers: 100 });
     });
   });
 
   describe('getActiveUsers', () => {
     it('should return active users count', async () => {
       mockAnalyticsService.getActiveUsers.mockResolvedValue(50);
-
-      const result = await controller.getActiveUsers();
-
-      expect(result).toEqual({ activeUsers: 50 });
-      expect(service.getActiveUsers).toHaveBeenCalled();
+      expect(await controller.getActiveUsers()).toEqual({ activeUsers: 50 });
     });
   });
 
   describe('getTotalGames', () => {
     it('should return total games count', async () => {
       mockAnalyticsService.getTotalGames.mockResolvedValue(200);
-
-      const result = await controller.getTotalGames();
-
-      expect(result).toEqual({ totalGames: 200 });
-      expect(service.getTotalGames).toHaveBeenCalled();
+      expect(await controller.getTotalGames()).toEqual({ totalGames: 200 });
     });
   });
 
   describe('getTotalGamePlayers', () => {
     it('should return total game players count', async () => {
       mockAnalyticsService.getTotalGamePlayers.mockResolvedValue(400);
+      expect(await controller.getTotalGamePlayers()).toEqual({ totalGamePlayers: 400 });
+    });
+  });
 
-      const result = await controller.getTotalGamePlayers();
+  describe('getPaginatedUsers', () => {
+    it('should return paginated users', async () => {
+      const mockResult = {
+        data: [{ id: 1, email: 'a@b.com' }],
+        meta: { page: 1, limit: 10, totalItems: 1, totalPages: 1, hasNextPage: false, hasPreviousPage: false },
+      };
+      mockAnalyticsService.getPaginatedUsers.mockResolvedValue(mockResult);
 
-      expect(result).toEqual({ totalGamePlayers: 400 });
-      expect(service.getTotalGamePlayers).toHaveBeenCalled();
+      const query: PaginatedUsersQueryDto = { page: 1, limit: 10 };
+      const result = await controller.getPaginatedUsers(query);
+
+      expect(result).toEqual(mockResult);
+      expect(service.getPaginatedUsers).toHaveBeenCalledWith(query);
+    });
+
+    it('should pass query params through to service', async () => {
+      mockAnalyticsService.getPaginatedUsers.mockResolvedValue({ data: [], meta: {} });
+      const query: PaginatedUsersQueryDto = { page: 2, limit: 5, search: 'bob' };
+      await controller.getPaginatedUsers(query);
+      expect(service.getPaginatedUsers).toHaveBeenCalledWith(query);
+    });
+  });
+
+  describe('getPaginatedGames', () => {
+    it('should return paginated games', async () => {
+      const mockResult = {
+        data: [{ id: 1, code: 'GAME1' }],
+        meta: { page: 1, limit: 10, totalItems: 1, totalPages: 1, hasNextPage: false, hasPreviousPage: false },
+      };
+      mockAnalyticsService.getPaginatedGames.mockResolvedValue(mockResult);
+
+      const query: PaginatedGamesQueryDto = { page: 1, limit: 10 };
+      const result = await controller.getPaginatedGames(query);
+
+      expect(result).toEqual(mockResult);
+      expect(service.getPaginatedGames).toHaveBeenCalledWith(query);
+    });
+
+    it('should pass query params through to service', async () => {
+      mockAnalyticsService.getPaginatedGames.mockResolvedValue({ data: [], meta: {} });
+      const query: PaginatedGamesQueryDto = { page: 3, limit: 25 };
+      await controller.getPaginatedGames(query);
+      expect(service.getPaginatedGames).toHaveBeenCalledWith(query);
     });
   });
 });

--- a/backend/src/modules/admin-analytics/admin-analytics.controller.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.controller.ts
@@ -1,8 +1,12 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { AdminAnalyticsService } from './admin-analytics.service';
 import { DashboardAnalyticsDto } from './dto/dashboard-analytics.dto';
+import { PaginatedUsersQueryDto, PaginatedGamesQueryDto } from './dto/analytics-query.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AdminGuard } from '../auth/guards/admin.guard';
+import { PaginatedResponse } from '../../common/interfaces/paginated-response.interface';
+import { User } from '../users/entities/user.entity';
+import { Game } from '../games/entities/game.entity';
 
 @Controller('admin/analytics')
 @UseGuards(JwtAuthGuard, AdminGuard)
@@ -26,6 +30,13 @@ export class AdminAnalyticsController {
     return { activeUsers };
   }
 
+  @Get('users')
+  async getPaginatedUsers(
+    @Query() query: PaginatedUsersQueryDto,
+  ): Promise<PaginatedResponse<User>> {
+    return this.analyticsService.getPaginatedUsers(query);
+  }
+
   @Get('games/total')
   async getTotalGames(): Promise<{ totalGames: number }> {
     const totalGames = await this.analyticsService.getTotalGames();
@@ -36,5 +47,12 @@ export class AdminAnalyticsController {
   async getTotalGamePlayers(): Promise<{ totalGamePlayers: number }> {
     const totalGamePlayers = await this.analyticsService.getTotalGamePlayers();
     return { totalGamePlayers };
+  }
+
+  @Get('games')
+  async getPaginatedGames(
+    @Query() query: PaginatedGamesQueryDto,
+  ): Promise<PaginatedResponse<Game>> {
+    return this.analyticsService.getPaginatedGames(query);
   }
 }

--- a/backend/src/modules/admin-analytics/admin-analytics.module.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.module.ts
@@ -5,11 +5,12 @@ import { AdminAnalyticsService } from './admin-analytics.service';
 import { User } from '../users/entities/user.entity';
 import { Game } from '../games/entities/game.entity';
 import { GamePlayer } from '../games/entities/game-player.entity';
+import { PaginationService } from '../../common/services/pagination.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User, Game, GamePlayer])],
   controllers: [AdminAnalyticsController],
-  providers: [AdminAnalyticsService],
+  providers: [AdminAnalyticsService, PaginationService],
   exports: [AdminAnalyticsService],
 })
 export class AdminAnalyticsModule {}

--- a/backend/src/modules/admin-analytics/admin-analytics.service.spec.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.service.spec.ts
@@ -1,59 +1,52 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository, MoreThan } from 'typeorm';
 import { AdminAnalyticsService } from './admin-analytics.service';
 import { User } from '../users/entities/user.entity';
 import { Game } from '../games/entities/game.entity';
 import { GamePlayer } from '../games/entities/game-player.entity';
+import { PaginationService } from '../../common/services/pagination.service';
+import {
+  PaginatedUsersQueryDto,
+  PaginatedGamesQueryDto,
+  UserSortField,
+  GameSortField,
+} from './dto/analytics-query.dto';
+import { SortOrder } from '../../common/dto/pagination.dto';
 
 describe('AdminAnalyticsService', () => {
   let service: AdminAnalyticsService;
-  let userRepo: Repository<User>;
-  let gameRepo: Repository<Game>;
-  let gamePlayerRepo: Repository<GamePlayer>;
+
+  const mockQb = {} as any;
 
   const mockUserRepo = {
     count: jest.fn(),
+    createQueryBuilder: jest.fn().mockReturnValue(mockQb),
   };
 
   const mockGameRepo = {
     count: jest.fn(),
+    createQueryBuilder: jest.fn().mockReturnValue(mockQb),
   };
 
-  const mockGamePlayerRepo = {
-    count: jest.fn(),
-  };
+  const mockGamePlayerRepo = { count: jest.fn() };
+
+  const mockPaginationService = { paginate: jest.fn() };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminAnalyticsService,
-        {
-          provide: getRepositoryToken(User),
-          useValue: mockUserRepo,
-        },
-        {
-          provide: getRepositoryToken(Game),
-          useValue: mockGameRepo,
-        },
-        {
-          provide: getRepositoryToken(GamePlayer),
-          useValue: mockGamePlayerRepo,
-        },
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
+        { provide: getRepositoryToken(Game), useValue: mockGameRepo },
+        { provide: getRepositoryToken(GamePlayer), useValue: mockGamePlayerRepo },
+        { provide: PaginationService, useValue: mockPaginationService },
       ],
     }).compile();
 
     service = module.get<AdminAnalyticsService>(AdminAnalyticsService);
-    userRepo = module.get<Repository<User>>(getRepositoryToken(User));
-    gameRepo = module.get<Repository<Game>>(getRepositoryToken(Game));
-    gamePlayerRepo = module.get<Repository<GamePlayer>>(
-      getRepositoryToken(GamePlayer),
-    );
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  afterEach(() => jest.clearAllMocks());
 
   it('should be defined', () => {
     expect(service).toBeDefined();
@@ -62,27 +55,18 @@ describe('AdminAnalyticsService', () => {
   describe('getTotalUsers', () => {
     it('should return total users count', async () => {
       mockUserRepo.count.mockResolvedValue(100);
-
-      const result = await service.getTotalUsers();
-
-      expect(result).toBe(100);
-      expect(userRepo.count).toHaveBeenCalled();
+      expect(await service.getTotalUsers()).toBe(100);
     });
   });
 
   describe('getActiveUsers', () => {
-    it('should return active users count', async () => {
+    it('should return active users count filtered by last 30 days', async () => {
       mockUserRepo.count.mockResolvedValue(50);
-
       const result = await service.getActiveUsers();
-
       expect(result).toBe(50);
-      expect(userRepo.count).toHaveBeenCalledWith({
+      expect(mockUserRepo.count).toHaveBeenCalledWith({
         where: {
-          updated_at: expect.objectContaining({
-            _type: 'moreThan',
-            _value: expect.any(Date),
-          }),
+          updated_at: expect.objectContaining({ _type: 'moreThan' }),
         },
       });
     });
@@ -91,22 +75,14 @@ describe('AdminAnalyticsService', () => {
   describe('getTotalGames', () => {
     it('should return total games count', async () => {
       mockGameRepo.count.mockResolvedValue(200);
-
-      const result = await service.getTotalGames();
-
-      expect(result).toBe(200);
-      expect(gameRepo.count).toHaveBeenCalled();
+      expect(await service.getTotalGames()).toBe(200);
     });
   });
 
   describe('getTotalGamePlayers', () => {
     it('should return total game players count', async () => {
       mockGamePlayerRepo.count.mockResolvedValue(400);
-
-      const result = await service.getTotalGamePlayers();
-
-      expect(result).toBe(400);
-      expect(gamePlayerRepo.count).toHaveBeenCalled();
+      expect(await service.getTotalGamePlayers()).toBe(400);
     });
   });
 
@@ -117,13 +93,101 @@ describe('AdminAnalyticsService', () => {
       mockGamePlayerRepo.count.mockResolvedValue(400);
 
       const result = await service.getDashboardAnalytics();
-
       expect(result).toEqual({
         totalUsers: 100,
         activeUsers: 50,
         totalGames: 200,
         totalGamePlayers: 400,
       });
+    });
+  });
+
+  describe('getPaginatedUsers', () => {
+    const mockResult = {
+      data: [{ id: 1, email: 'a@b.com' }],
+      meta: { page: 1, limit: 10, totalItems: 1, totalPages: 1, hasNextPage: false, hasPreviousPage: false },
+    };
+
+    beforeEach(() => mockPaginationService.paginate.mockResolvedValue(mockResult));
+
+    it('should call createQueryBuilder and paginate with correct args', async () => {
+      const query: PaginatedUsersQueryDto = { page: 1, limit: 10 };
+      const result = await service.getPaginatedUsers(query);
+
+      expect(mockUserRepo.createQueryBuilder).toHaveBeenCalledWith('user');
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQb,
+        query,
+        ['email', 'firstName', 'lastName', 'username'],
+        ['id', 'email', 'created_at', 'games_played', 'game_won'],
+      );
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should forward sortBy and sortOrder', async () => {
+      const query: PaginatedUsersQueryDto = {
+        page: 1,
+        limit: 5,
+        sortBy: UserSortField.GAMES_PLAYED,
+        sortOrder: SortOrder.ASC,
+      };
+      await service.getPaginatedUsers(query);
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQb,
+        query,
+        expect.any(Array),
+        expect.any(Array),
+      );
+    });
+
+    it('should forward search term', async () => {
+      const query: PaginatedUsersQueryDto = { page: 1, limit: 10, search: 'alice' };
+      await service.getPaginatedUsers(query);
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQb,
+        query,
+        ['email', 'firstName', 'lastName', 'username'],
+        expect.any(Array),
+      );
+    });
+  });
+
+  describe('getPaginatedGames', () => {
+    const mockResult = {
+      data: [{ id: 1, code: 'GAME1', status: 'PENDING' }],
+      meta: { page: 1, limit: 10, totalItems: 1, totalPages: 1, hasNextPage: false, hasPreviousPage: false },
+    };
+
+    beforeEach(() => mockPaginationService.paginate.mockResolvedValue(mockResult));
+
+    it('should call createQueryBuilder and paginate with correct args', async () => {
+      const query: PaginatedGamesQueryDto = { page: 1, limit: 10 };
+      const result = await service.getPaginatedGames(query);
+
+      expect(mockGameRepo.createQueryBuilder).toHaveBeenCalledWith('game');
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQb,
+        query,
+        ['code', 'status', 'mode'],
+        ['id', 'status', 'created_at', 'mode'],
+      );
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should forward sortBy and sortOrder', async () => {
+      const query: PaginatedGamesQueryDto = {
+        page: 2,
+        limit: 20,
+        sortBy: GameSortField.STATUS,
+        sortOrder: SortOrder.ASC,
+      };
+      await service.getPaginatedGames(query);
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQb,
+        query,
+        expect.any(Array),
+        expect.any(Array),
+      );
     });
   });
 });

--- a/backend/src/modules/admin-analytics/admin-analytics.service.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.service.ts
@@ -5,6 +5,9 @@ import { User } from '../users/entities/user.entity';
 import { Game } from '../games/entities/game.entity';
 import { GamePlayer } from '../games/entities/game-player.entity';
 import { DashboardAnalyticsDto } from './dto/dashboard-analytics.dto';
+import { PaginatedUsersQueryDto, PaginatedGamesQueryDto } from './dto/analytics-query.dto';
+import { PaginationService } from '../../common/services/pagination.service';
+import { PaginatedResponse } from '../../common/interfaces/paginated-response.interface';
 
 @Injectable()
 export class AdminAnalyticsService {
@@ -15,6 +18,7 @@ export class AdminAnalyticsService {
     private gameRepo: Repository<Game>,
     @InjectRepository(GamePlayer)
     private gamePlayerRepo: Repository<GamePlayer>,
+    private readonly paginationService: PaginationService,
   ) {}
 
   async getDashboardAnalytics(): Promise<DashboardAnalyticsDto> {
@@ -55,5 +59,23 @@ export class AdminAnalyticsService {
 
   async getTotalGamePlayers(): Promise<number> {
     return this.gamePlayerRepo.count();
+  }
+
+  async getPaginatedUsers(query: PaginatedUsersQueryDto): Promise<PaginatedResponse<User>> {
+    const qb = this.userRepo.createQueryBuilder('user');
+
+    const allowedSortFields = ['id', 'email', 'created_at', 'games_played', 'game_won'];
+    const searchableFields = ['email', 'firstName', 'lastName', 'username'];
+
+    return this.paginationService.paginate(qb, query, searchableFields, allowedSortFields);
+  }
+
+  async getPaginatedGames(query: PaginatedGamesQueryDto): Promise<PaginatedResponse<Game>> {
+    const qb = this.gameRepo.createQueryBuilder('game');
+
+    const allowedSortFields = ['id', 'status', 'created_at', 'mode'];
+    const searchableFields = ['code', 'status', 'mode'];
+
+    return this.paginationService.paginate(qb, query, searchableFields, allowedSortFields);
   }
 }

--- a/backend/src/modules/admin-analytics/dto/analytics-query.dto.ts
+++ b/backend/src/modules/admin-analytics/dto/analytics-query.dto.ts
@@ -1,0 +1,32 @@
+import { IsOptional, IsEnum } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationDto } from '../../../common/dto/pagination.dto';
+
+export enum UserSortField {
+  ID = 'id',
+  EMAIL = 'email',
+  CREATED_AT = 'created_at',
+  GAMES_PLAYED = 'games_played',
+  GAME_WON = 'game_won',
+}
+
+export enum GameSortField {
+  ID = 'id',
+  STATUS = 'status',
+  CREATED_AT = 'created_at',
+  MODE = 'mode',
+}
+
+export class PaginatedUsersQueryDto extends PaginationDto {
+  @ApiPropertyOptional({ enum: UserSortField, description: 'Field to sort users by' })
+  @IsOptional()
+  @IsEnum(UserSortField)
+  sortBy?: UserSortField = UserSortField.CREATED_AT;
+}
+
+export class PaginatedGamesQueryDto extends PaginationDto {
+  @ApiPropertyOptional({ enum: GameSortField, description: 'Field to sort games by' })
+  @IsOptional()
+  @IsEnum(GameSortField)
+  sortBy?: GameSortField = GameSortField.CREATED_AT;
+}


### PR DESCRIPTION
## Summary

Implements pagination and stable sorting for the `admin-analytics` module (scope: `backend/src/modules/admin-analytics/`).

## Changes

- **`dto/analytics-query.dto.ts`** (new): `PaginatedUsersQueryDto` and `PaginatedGamesQueryDto` extending `PaginationDto` with enum-validated `sortBy` fields, preventing arbitrary column injection
- **`admin-analytics.service.ts`**: Added `getPaginatedUsers` and `getPaginatedGames` using the shared `PaginationService` with stable secondary sort on `id`
- **`admin-analytics.controller.ts`**: Added `GET /admin/analytics/users` and `GET /admin/analytics/games` endpoints accepting pagination/sort/search query params
- **`admin-analytics.module.ts`**: Wired `PaginationService` as a provider

## API

| Endpoint | Query params |
|---|---|
| `GET /admin/analytics/users` | `page`, `limit`, `sortBy` (id/email/created_at/games_played/game_won), `sortOrder` (ASC/DESC), `search` |
| `GET /admin/analytics/games` | `page`, `limit`, `sortBy` (id/status/created_at/mode), `sortOrder` (ASC/DESC), `search` |

Both endpoints return `{ data, meta }` with full pagination metadata. Stable sort is guaranteed via a secondary `id` sort key.

## Tests

21 unit tests passing across service and controller specs covering pagination, sorting, search, and all existing analytics endpoints.

closes #861