### PR TITLE
route-improvements

### DIFF
--- a/frontend/docs/SW-FE-753-756-route-settings-shop-a11y-typesafety.md
+++ b/frontend/docs/SW-FE-753-756-route-settings-shop-a11y-typesafety.md
@@ -1,0 +1,19 @@
+# SW-FE-753–756 — Settings and Shop route accessibility & type safety
+
+## What changed
+
+- Settings now has a labelled main landmark, a skip link targeting the settings controls, a polite status announcer, visible keyboard focus styles, and an accessible name for the back button.
+- Shop now has equivalent route landmarks, a deterministic skip-link-first keyboard order, labelled preview articles, and an `aria-live` status for purchase-tracking feedback.
+- Shop purchase telemetry accepts only complete, finite-price preview items. Invalid data is ignored, and analytics provider failures are caught and announced so they cannot interrupt interaction with the remaining controls.
+- Route tests cover landmarks, focus order, normal telemetry, the analytics failure state, and null/invalid preview data.
+
+## Verification
+
+```bash
+cd frontend
+pnpm test -- --run src/app/settings/page.test.tsx src/app/shop/page.test.tsx
+pnpm typecheck
+pnpm lint
+```
+
+No route API or persisted-data contract changed.

--- a/frontend/src/app/settings/page.test.tsx
+++ b/frontend/src/app/settings/page.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import SettingsPage from "./page";
+
+const { back } = vi.hoisted(() => ({ back: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ back }),
+}));
+
+vi.mock("@/components/settings/AccountSettings", () => ({
+  AccountSettings: () => <button type="button">Update email</button>,
+}));
+
+vi.mock("@/components/settings/NotificationSettings", () => ({
+  NotificationSettings: () => <button type="button">Save preferences</button>,
+}));
+
+vi.mock("@/components/settings/DangerZone", () => ({
+  DangerZone: () => <button type="button">Delete account</button>,
+}));
+
+describe("SettingsPage", () => {
+  beforeEach(() => {
+    back.mockReset();
+  });
+
+  test("provides labelled route landmarks and a status announcer", () => {
+    const { container } = render(<SettingsPage />);
+
+    expect(
+      container.querySelector('main[aria-labelledby="settings-page-title"]'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Settings" }),
+    ).toHaveAttribute("id", "settings-page-title");
+
+    const status = container.querySelector("#settings-status-announcer");
+    expect(status).toHaveAttribute("role", "status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveAttribute("aria-atomic", "true");
+  });
+
+  test("puts the skip link before the settings controls and targets the content region", () => {
+    render(<SettingsPage />);
+
+    const skipLink = screen.getByRole("link", { name: "Skip to settings" });
+    const backButton = screen.getByRole("button", { name: "Go back" });
+    const updateEmailButton = screen.getByRole("button", { name: "Update email" });
+    const focusables = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+
+    expect(skipLink).toHaveAttribute("href", "#settings-page-content");
+    expect(focusables.indexOf(skipLink)).toBeLessThan(focusables.indexOf(backButton));
+    expect(focusables.indexOf(backButton)).toBeLessThan(
+      focusables.indexOf(updateEmailButton),
+    );
+    expect(skipLink.className).toContain("focus:not-sr-only");
+    expect(skipLink.className).toContain("focus:ring-2");
+  });
+
+  test("keeps the back control labelled and functional", async () => {
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    await user.click(screen.getByRole("button", { name: "Go back" }));
+
+    expect(back).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import type { JSX } from 'react';
 import { UserSettings } from '@/components/settings/UserSettings';
 import { generateBaseMetadata } from '@/lib/metadata';
 
@@ -7,6 +8,6 @@ export const metadata: Metadata = generateBaseMetadata({
   description: 'Manage your account settings, notifications, and preferences',
 });
 
-export default function SettingsPage() {
+export default function SettingsPage(): JSX.Element {
   return <UserSettings />;
 }

--- a/frontend/src/app/shop/page.test.tsx
+++ b/frontend/src/app/shop/page.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import ShopPage, { isPurchasablePreviewItem } from "./page";
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+
+vi.mock("@/lib/analytics", () => ({ track }));
+
+describe("ShopPage", () => {
+  beforeEach(() => {
+    track.mockReset();
+  });
+
+  test("provides labelled route landmarks and a polite tracking status", () => {
+    const { container } = render(<ShopPage />);
+
+    expect(
+      container.querySelector('main[aria-labelledby="shop-page-title"]'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Analytics Taxonomy Staging Route",
+      }),
+    ).toHaveAttribute("id", "shop-page-title");
+
+    const status = container.querySelector("#shop-status-announcer");
+    expect(status).toHaveAttribute("role", "status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveAttribute("aria-atomic", "true");
+  });
+
+  test("puts the skip link before each purchase control", () => {
+    render(<ShopPage />);
+
+    const skipLink = screen.getByRole("link", { name: "Skip to shop items" });
+    const starterPurchase = screen.getByRole("button", {
+      name: "Track purchase for Starter Pack",
+    });
+    const founderPurchase = screen.getByRole("button", {
+      name: "Track purchase for Founder Badge",
+    });
+    const focusables = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+
+    expect(skipLink).toHaveAttribute("href", "#shop-preview-content");
+    expect(focusables.indexOf(skipLink)).toBeLessThan(
+      focusables.indexOf(starterPurchase),
+    );
+    expect(focusables.indexOf(starterPurchase)).toBeLessThan(
+      focusables.indexOf(founderPurchase),
+    );
+    expect(skipLink.className).toContain("focus:not-sr-only");
+  });
+
+  test("tracks a valid item and announces the result", async () => {
+    const user = userEvent.setup();
+    render(<ShopPage />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Track purchase for Starter Pack" }),
+    );
+
+    expect(track).toHaveBeenCalledWith("purchase_click", {
+      route: "/shop",
+      item_id: "starter-pack",
+      item_name: "Starter Pack",
+      item_category: "bundle",
+      currency: "USD",
+      value: 20,
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Purchase tracking event recorded.",
+    );
+  });
+
+  test("keeps the page usable when analytics is unavailable", async () => {
+    const user = userEvent.setup();
+    track.mockImplementationOnce(() => {
+      throw new Error("analytics unavailable");
+    });
+    render(<ShopPage />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Track purchase for Founder Badge" }),
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Purchase tracking is temporarily unavailable.",
+    );
+    expect(
+      screen.getByRole("button", { name: "Track purchase for Starter Pack" }),
+    ).toBeEnabled();
+  });
+});
+
+describe("isPurchasablePreviewItem", () => {
+  test("rejects missing and invalid preview data before it reaches analytics", () => {
+    expect(isPurchasablePreviewItem(null)).toBe(false);
+    expect(isPurchasablePreviewItem(undefined)).toBe(false);
+    expect(
+      isPurchasablePreviewItem({
+        id: "bad-price",
+        name: "Bad price",
+        category: "bundle",
+        price: Number.NaN,
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/app/shop/page.tsx
+++ b/frontend/src/app/shop/page.tsx
@@ -1,8 +1,18 @@
 "use client";
 
+import { useCallback, useState } from "react";
 import { track } from "@/lib/analytics";
 
-const previewItems = [
+type PreviewItem = Readonly<{
+  id: string;
+  name: string;
+  category: "bundle" | "cosmetic";
+  price: number;
+}>;
+
+type PurchaseTrackingStatus = "idle" | "tracked" | "unavailable";
+
+const previewItems: readonly PreviewItem[] = [
   {
     id: "starter-pack",
     name: "Starter Pack",
@@ -17,26 +27,87 @@ const previewItems = [
   },
 ];
 
-export default function ShopPage() {
-  function handlePurchaseClick(item: (typeof previewItems)[number]) {
-    track("purchase_click", {
-      route: "/shop",
-      item_id: item.id,
-      item_name: item.name,
-      item_category: item.category,
-      currency: "USD",
-      value: item.price,
-    });
-  }
+export function isPurchasablePreviewItem(
+  item: PreviewItem | null | undefined,
+): item is PreviewItem {
+  return (
+    item !== null &&
+    item !== undefined &&
+    item.id.trim().length > 0 &&
+    item.name.trim().length > 0 &&
+    Number.isFinite(item.price) &&
+    item.price >= 0
+  );
+}
+
+export default function ShopPage(): React.JSX.Element {
+  const [purchaseTrackingStatus, setPurchaseTrackingStatus] =
+    useState<PurchaseTrackingStatus>("idle");
+
+  const handlePurchaseClick = useCallback(
+    (item: PreviewItem | null | undefined): void => {
+      if (!isPurchasablePreviewItem(item)) {
+        setPurchaseTrackingStatus("unavailable");
+        return;
+      }
+
+      try {
+        track("purchase_click", {
+          route: "/shop",
+          item_id: item.id,
+          item_name: item.name,
+          item_category: item.category,
+          currency: "USD",
+          value: item.price,
+        });
+        setPurchaseTrackingStatus("tracked");
+      } catch {
+        // Analytics must never make the preview's keyboard controls unusable.
+        setPurchaseTrackingStatus("unavailable");
+      }
+    },
+    [],
+  );
+
+  const purchaseStatusMessage: string =
+    purchaseTrackingStatus === "tracked"
+      ? "Purchase tracking event recorded."
+      : purchaseTrackingStatus === "unavailable"
+        ? "Purchase tracking is temporarily unavailable."
+        : "";
 
   return (
-    <div className="min-h-screen bg-[#010F10] px-6 py-16 text-[#F0F7F7]">
+    <main
+      aria-labelledby="shop-page-title"
+      className="relative min-h-screen bg-[#010F10] px-6 py-16 text-[#F0F7F7]"
+    >
+      <a
+        href="#shop-preview-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-[#00F0FF] focus:px-4 focus:py-2 focus:text-[#010F10] focus:outline-none focus:ring-2 focus:ring-[#00F0FF] focus:ring-offset-2 focus:ring-offset-[#010F10]"
+      >
+        Skip to shop items
+      </a>
+
+      <div
+        id="shop-status-announcer"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label="Shop tracking status"
+        className="sr-only"
+      >
+        {purchaseStatusMessage}
+      </div>
+
       <div className="mx-auto flex max-w-5xl flex-col gap-10">
         <header className="space-y-4">
           <p className="font-orbitron text-sm uppercase tracking-[0.3em] text-[#00F0FF]">
             Shop Preview
           </p>
-          <h1 className="font-orbitron text-4xl font-[800] uppercase text-[#F0F7F7]">
+          <h1
+            id="shop-page-title"
+            className="font-orbitron text-4xl font-[800] uppercase text-[#F0F7F7]"
+          >
             Analytics Taxonomy Staging Route
           </h1>
           <p className="max-w-2xl font-dmSans text-base text-[#F0F7F7]/75">
@@ -46,27 +117,42 @@ export default function ShopPage() {
           </p>
         </header>
 
-        <section className="grid gap-6 md:grid-cols-2">
+        <section
+          id="shop-preview-content"
+          aria-label="Shop preview items"
+          tabIndex={-1}
+          className="grid gap-6 rounded-3xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00F0FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#010F10] md:grid-cols-2 [&_*:focus-visible]:outline-none [&_*:focus-visible]:ring-2 [&_*:focus-visible]:ring-[#00F0FF] [&_*:focus-visible]:ring-offset-2 [&_*:focus-visible]:ring-offset-[#010F10]"
+        >
           {previewItems.map((item) => (
             <article
               key={item.id}
+              aria-labelledby={`shop-item-${item.id}-title`}
               className="rounded-3xl border border-[#00F0FF]/20 bg-[#0A1F21] p-6 shadow-[0_0_30px_rgba(0,240,255,0.08)]"
             >
               <p className="font-dmSans text-sm uppercase tracking-[0.2em] text-[#00F0FF]/80">
                 {item.category}
               </p>
-              <h2 className="mt-3 font-orbitron text-2xl font-[700] text-[#F0F7F7]">
+              <h2
+                id={`shop-item-${item.id}-title`}
+                className="mt-3 font-orbitron text-2xl font-[700] text-[#F0F7F7]"
+              >
                 {item.name}
               </h2>
               <p className="mt-2 font-dmSans text-sm text-[#F0F7F7]/65">
                 Minimal preview item used to validate provider forwarding and taxonomy naming.
               </p>
               <div className="mt-6 flex items-center justify-between">
-                <span className="font-orbitron text-xl text-[#00F0FF]">${item.price}</span>
+                <data
+                  value={item.price}
+                  className="font-orbitron text-xl text-[#00F0FF]"
+                >
+                  ${item.price}
+                </data>
                 <button
                   type="button"
                   onClick={() => handlePurchaseClick(item)}
-                  className="rounded-full bg-[#00F0FF] px-5 py-3 font-orbitron text-sm font-[700] uppercase tracking-[0.15em] text-[#010F10] transition-transform hover:scale-[1.02]"
+                  aria-label={`Track purchase for ${item.name}`}
+                  className="rounded-full bg-[#00F0FF] px-5 py-3 font-orbitron text-sm font-[700] uppercase tracking-[0.15em] text-[#010F10] transition-transform hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00F0FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#010F10]"
                 >
                   Track Purchase
                 </button>
@@ -75,6 +161,6 @@ export default function ShopPage() {
           ))}
         </section>
       </div>
-    </div>
+    </main>
   );
 }

--- a/frontend/src/components/settings/UserSettings.tsx
+++ b/frontend/src/components/settings/UserSettings.tsx
@@ -8,35 +8,67 @@ import { AccountSettings } from './AccountSettings';
 import { NotificationSettings } from './NotificationSettings';
 import { DangerZone } from './DangerZone';
 
-export function UserSettings() {
+export function UserSettings(): React.JSX.Element {
   const router = useRouter();
 
   return (
-    <main className="min-h-screen bg-[var(--tycoon-bg)]">
+    <main
+      aria-labelledby="settings-page-title"
+      className="relative min-h-screen bg-[var(--tycoon-bg)]"
+    >
+      <a
+        href="#settings-page-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-[var(--tycoon-accent)] focus:px-4 focus:py-2 focus:text-[var(--tycoon-bg)] focus:outline-none focus:ring-2 focus:ring-[var(--tycoon-accent)] focus:ring-offset-2 focus:ring-offset-[var(--tycoon-bg)]"
+      >
+        Skip to settings
+      </a>
+
+      <div
+        id="settings-status-announcer"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label="Settings status updates"
+        className="sr-only"
+      >
+        Settings ready.
+      </div>
+
       {/* Header */}
-      <div className="border-b border-[var(--tycoon-border)] bg-[var(--tycoon-card-bg)]/50 backdrop-blur-sm">
+      <header className="border-b border-[var(--tycoon-border)] bg-[var(--tycoon-card-bg)]/50 backdrop-blur-sm">
         <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
           <div className="flex items-center gap-4">
             <Button
               variant="ghost"
               size="icon"
               onClick={() => router.back()}
+              aria-label="Go back"
               className="text-[var(--tycoon-text)] hover:bg-[var(--tycoon-border)]"
             >
-              <ArrowLeft className="h-5 w-5" />
+              <ArrowLeft aria-hidden="true" className="h-5 w-5" />
             </Button>
             <div>
-              <h1 className="text-3xl font-bold text-[var(--tycoon-text)]">Settings</h1>
+              <h1
+                id="settings-page-title"
+                className="text-3xl font-bold text-[var(--tycoon-text)]"
+              >
+                Settings
+              </h1>
               <p className="text-sm text-[var(--tycoon-text)]/60">
                 Manage your account and preferences
               </p>
             </div>
           </div>
         </div>
-      </div>
+      </header>
 
       {/* Content */}
-      <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
+      <section
+        id="settings-page-content"
+        aria-label="Settings options"
+        tabIndex={-1}
+        className="mx-auto max-w-2xl px-4 py-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tycoon-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--tycoon-bg)] sm:px-6 lg:px-8 [&_*:focus-visible]:outline-none [&_*:focus-visible]:ring-2 [&_*:focus-visible]:ring-[var(--tycoon-accent)] [&_*:focus-visible]:ring-offset-2 [&_*:focus-visible]:ring-offset-[var(--tycoon-bg)]"
+      >
         <div className="space-y-8">
           {/* Account Settings Section */}
           <section>
@@ -53,7 +85,7 @@ export function UserSettings() {
             <DangerZone />
           </section>
         </div>
-      </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Closes #753
Closes #754
Closes #755 
Closes #756 

Improves the Settings and Shop routes with accessible landmarks, predictable keyboard focus order, stricter TypeScript typing, and defensive handling for invalid or unavailable runtime states.

## What was implemented

### Settings route

- Added a labelled main landmark and semantic header.
- Added a skip link targeting settings content.
- Added a polite live status announcer.
- Added visible focus styles for settings controls.
- Added an accessible name for the Back button and hid its decorative icon from assistive technology.
- Added explicit React element return typing.

### Shop route

- Added labelled main/content landmarks and skip link navigation.
- Ensured keyboard focus order is deterministic: skip link, then purchase controls.
- Added labelled shop articles and item-specific purchase button names.
- Added a polite live region for purchase-tracking outcomes.
- Added strict `PreviewItem` typing and runtime guards for null, undefined, empty, or invalid-price items.
- Safely handles analytics-provider failures without making shop controls unusable.

## Acceptance criteria

- [x] Relevant route accessibility and focus-order behavior implemented.
- [x] Null/invalid state guards added for Shop purchase tracking.
- [x] Analytics disconnection/failure state is handled gracefully and announced to assistive technology.
- [x] No persisted-data or route API contract changes.
- [x] Documentation added for #753–#756.
- [x] Focused regression coverage added for both routes.

## Tests covered

- Settings landmarks, live announcer, skip-link target/order, visible focus styles, and Back button behavior.
- Shop landmarks, live announcer, skip-link-first focus order, successful purchase telemetry, analytics failure handling, and invalid/null item guards.

Verification completed:

```bash
cd frontend
./node_modules/.bin/vitest run src/app/settings/page.test.tsx src/app/shop/page.test.tsx
./node_modules/.bin/tsc --noEmit
./node_modules/.bin/eslint src/app/settings/page.tsx src/app/shop/page.tsx src/components/settings/UserSettings.tsx src/app/settings/page.test.tsx src/app/shop/page.test.tsx
```