### PR TITLE
feat(reward-system): strengthen overflow_rounding_tests with edge-cas…

### DIFF
--- a/contract/contracts/tycoon-reward-system/src/overflow_rounding_tests.rs
+++ b/contract/contracts/tycoon-reward-system/src/overflow_rounding_tests.rs
@@ -187,7 +187,7 @@ fn test_tier_matrix_multiple_tiers_per_user() {
 /// Overflow: minting a second voucher of the same token_id to the same user
 /// when their balance is already u64::MAX must panic with "Balance overflow".
 #[test]
-#[should_panic]
+#[should_panic(expected = "Balance overflow")]
 fn test_overflow_voucher_balance_u64_max() {
     let h = Harness::new();
     let user = Address::generate(&h.env);
@@ -229,6 +229,42 @@ fn test_overflow_large_voucher_value_exact_transfer() {
     h.client.redeem_voucher_from(&user, &token_id);
 
     assert_eq!(h.tyc_balance_of(&user), large_value as i128);
+}
+
+/// Overflow: minting to bring a balance to u64::MAX - 1 and then exactly u64::MAX
+/// succeeds — no off-by-one at the ceiling boundary.
+#[test]
+fn test_overflow_near_u64_max_succeeds() {
+    let h = Harness::new();
+    let user = Address::generate(&h.env);
+    let token_id: u128 = 43;
+
+    h.client.test_mint(&user, &token_id, &(u64::MAX - 1));
+    assert_eq!(h.client.get_balance(&user, &token_id), u64::MAX - 1);
+
+    // One more unit reaches exactly u64::MAX — must not overflow
+    h.client.test_mint(&user, &token_id, &1);
+    assert_eq!(h.client.get_balance(&user, &token_id), u64::MAX);
+}
+
+/// Overflow: a voucher with tyc_value > i128::MAX panics on redeem because the
+/// implicit `u128 as i128` cast produces a negative value, which the token
+/// contract rejects. Documents that [0, i128::MAX] is the valid range for tyc_value.
+#[test]
+#[should_panic]
+fn test_overflow_tyc_value_above_i128_max_panics_on_redeem() {
+    let h = Harness::new();
+    let user = Address::generate(&h.env);
+
+    // (i128::MAX as u128) + 1 wraps to i128::MIN when cast as i128
+    let overflow_value: u128 = (i128::MAX as u128) + 1;
+
+    // Mint succeeds — contract stores the raw u128 without validation
+    let token_id = h.client.mint_voucher(&h.admin, &user, &overflow_value);
+
+    // Redeem must panic: `tyc_value as i128` is i128::MIN (negative), and the
+    // token contract rejects negative transfer amounts.
+    h.client.redeem_voucher_from(&user, &token_id);
 }
 
 /// Overflow: VoucherCount increments correctly across many mints (no u128 overflow
@@ -328,6 +364,17 @@ fn test_zero_balance_withdraw_zero_amount() {
     h.client.withdraw_funds(&h.tyc_token_id, &recipient, &0);
     assert_eq!(h.tyc_balance_of(&recipient), 0);
     assert_eq!(h.tyc_balance_of(&h.contract_id), 1000);
+}
+
+/// Zero-balance: withdraw_funds with amount=0 from an empty contract is a no-op (no balance check for zero).
+#[test]
+fn test_zero_balance_withdraw_zero_from_empty_contract() {
+    let h = Harness::new();
+    let recipient = Address::generate(&h.env);
+    // Contract has 0 TYC — withdrawing 0 must not panic
+    h.client.withdraw_funds(&h.tyc_token_id, &recipient, &0);
+    assert_eq!(h.tyc_balance_of(&recipient), 0);
+    assert_eq!(h.tyc_balance_of(&h.contract_id), 0);
 }
 
 /// Zero-balance: withdraw_funds when contract has no TYC panics ("Insufficient contract balance").
@@ -529,6 +576,28 @@ fn test_accrual_redeem_fails_when_contract_underfunded() {
         res.is_err(),
         "redeem should fail when contract is underfunded"
     );
+}
+
+/// Accrual: voucher value storage entry is cleared after successful redemption,
+/// preventing replay: the second redeem attempt must panic.
+#[test]
+fn test_accrual_voucher_storage_cleared_after_redeem() {
+    let h = Harness::new();
+    let user = Address::generate(&h.env);
+
+    h.fund_contract(TIER_BRONZE as i128);
+    let token_id = h.client.mint_voucher(&h.admin, &user, &TIER_BRONZE);
+    h.client.redeem_voucher_from(&user, &token_id);
+
+    // VoucherValue entry was removed — second attempt must fail
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        h.client.redeem_voucher_from(&user, &token_id);
+    }));
+    assert!(
+        res.is_err(),
+        "second redeem must fail — VoucherValue entry was cleared"
+    );
+    assert_eq!(h.client.get_balance(&user, &token_id), 0);
 }
 
 /// Accrual: minting a voucher with value=0 is stored and redeems 0 TYC.


### PR DESCRIPTION
closes #1071
- Tighten test_overflow_voucher_balance_u64_max panic to expected = "Balance overflow"
- Add test_overflow_near_u64_max_succeeds: no off-by-one at u64::MAX-1 → u64::MAX
- Add test_overflow_tyc_value_above_i128_max_panics_on_redeem: documents u128 as i128 truncation boundary as [0, i128::MAX] valid range for tyc_value
- Add test_zero_balance_withdraw_zero_from_empty_contract: zero withdrawal is no-op
- Add test_accrual_voucher_storage_cleared_after_redeem: VoucherValue entry removed post-redeem, closing replay-attack surface