### PR TITLE
feat: board-styles pagination, idempotency, validation & chance observability (#877-880)

### DIFF
--- a/backend/src/modules/board-styles/board-styles-dto-validation.spec.ts
+++ b/backend/src/modules/board-styles/board-styles-dto-validation.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * #879 — board-styles DTO validation and error mapping
+ */
+
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CreateBoardStyleDto } from './dto/create-board-style.dto';
+import { BoardStylesService } from './board-styles.service';
+import { BoardStyle } from './entities/board-style.entity';
+import { PaginationService } from '../../common';
+import { RedisService } from '../redis/redis.service';
+import { HttpExceptionFilter } from '../../common/filters/http-exception.filter';
+import { LoggerService } from '../../common/logger/logger.service';
+
+async function getErrors(DtoClass: new () => object, plain: object) {
+  const instance = plainToInstance(DtoClass as new () => object, plain);
+  const errors = await validate(instance);
+  return errors.flatMap((e) => Object.values(e.constraints ?? {}));
+}
+
+describe('CreateBoardStyleDto validation (#879)', () => {
+  const valid = { name: 'Cyberpunk Theme' };
+
+  it('passes with valid input', async () => {
+    expect(await getErrors(CreateBoardStyleDto, valid)).toHaveLength(0);
+  });
+
+  it('returns 400 message when required name is missing', async () => {
+    const errors = await getErrors(CreateBoardStyleDto, { name: '' });
+    expect(errors.some((m) => m.includes('board style name is required'))).toBe(
+      true,
+    );
+  });
+
+  it('returns 400 when price is below minimum', async () => {
+    const errors = await getErrors(CreateBoardStyleDto, {
+      ...valid,
+      price: -1,
+    });
+    expect(
+      errors.some((m) => m.includes('price must be a non-negative number')),
+    ).toBe(true);
+  });
+
+  it('returns 400 when optional boolean field has invalid type', async () => {
+    const errors = await getErrors(CreateBoardStyleDto, {
+      ...valid,
+      is_premium: 'not-a-boolean',
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('BoardStylesService error mapping (#879)', () => {
+  let service: BoardStylesService;
+
+  const mockBoardStyleRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BoardStylesService,
+        {
+          provide: getRepositoryToken(BoardStyle),
+          useValue: mockBoardStyleRepository,
+        },
+        {
+          provide: PaginationService,
+          useValue: { paginate: jest.fn() },
+        },
+        {
+          provide: RedisService,
+          useValue: { delByPattern: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<BoardStylesService>(BoardStylesService);
+  });
+
+  it('maps missing name to BadRequestException', async () => {
+    await expect(service.create({ name: '   ' })).rejects.toThrow(
+      BadRequestException,
+    );
+    await expect(service.create({ name: '   ' })).rejects.toThrow(
+      'board style name is required',
+    );
+  });
+
+  it('maps not-found to NotFoundException with 404 semantics', async () => {
+    mockBoardStyleRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.findOne(999)).rejects.toThrow(NotFoundException);
+  });
+
+  it('HttpExceptionFilter maps validation errors to standard response shape', () => {
+    const mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const mockRequest = {
+      method: 'POST',
+      url: '/board-styles',
+      ip: '127.0.0.1',
+      headers: {},
+    };
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      logWithMeta: jest.fn(),
+    } as unknown as LoggerService;
+
+    const filter = new HttpExceptionFilter(logger);
+    filter.catch(new BadRequestException('board style name is required'), {
+      switchToHttp: () => ({
+        getResponse: () => mockResponse,
+        getRequest: () => mockRequest,
+      }),
+    } as never);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: 'board style name is required',
+        data: null,
+        statusCode: 400,
+      }),
+    );
+  });
+});

--- a/backend/src/modules/board-styles/board-styles-idempotency-replay.spec.ts
+++ b/backend/src/modules/board-styles/board-styles-idempotency-replay.spec.ts
@@ -1,0 +1,189 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  ExecutionContext,
+  HttpStatus,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
+import { lastValueFrom, of } from 'rxjs';
+import request from 'supertest';
+import { BoardStylesController } from './board-styles.controller';
+import { BoardStylesService } from './board-styles.service';
+import { BoardStyle } from './entities/board-style.entity';
+import { PaginationService } from '../../common';
+import { RedisService } from '../redis/redis.service';
+import { IdempotencyInterceptor } from '../redis/idempotency.interceptor';
+import { IdempotencyService } from '../redis/idempotency.service';
+
+describe('BoardStyles idempotency and replay (#878)', () => {
+  let app: INestApplication;
+  let idempotencyStore: Map<
+    string,
+    { status: 'processing' | 'complete'; response?: unknown; createdAt: number }
+  >;
+  let saveCallCount: number;
+  let savedStyles: BoardStyle[];
+
+  const makeStyle = (overrides: Partial<BoardStyle> = {}): BoardStyle =>
+    ({
+      id: 1,
+      name: 'Cyberpunk Theme',
+      description: null,
+      is_premium: false,
+      price: 0,
+      preview_image: null,
+      config: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+      ...overrides,
+    }) as BoardStyle;
+
+  const mockIdempotencyService = {
+    get: jest.fn(async (key: string) => idempotencyStore.get(key)),
+    markProcessing: jest.fn(async (key: string) => {
+      idempotencyStore.set(key, {
+        status: 'processing',
+        createdAt: Date.now(),
+      });
+    }),
+    markComplete: jest.fn(async (key: string, response: unknown) => {
+      idempotencyStore.set(key, {
+        status: 'complete',
+        response,
+        createdAt: Date.now(),
+      });
+    }),
+    delete: jest.fn(async (key: string) => {
+      idempotencyStore.delete(key);
+    }),
+  };
+
+  const mockBoardStyleRepository = {
+    create: jest.fn((dto: Partial<BoardStyle>) => ({
+      id: savedStyles.length + 1,
+      ...dto,
+    })),
+    save: jest.fn(async (style: BoardStyle) => {
+      saveCallCount += 1;
+      const saved = { ...style, id: saveCallCount };
+      savedStyles.push(saved);
+      return saved;
+    }),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    idempotencyStore = new Map();
+    saveCallCount = 0;
+    savedStyles = [];
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BoardStylesController],
+      providers: [
+        BoardStylesService,
+        IdempotencyInterceptor,
+        { provide: IdempotencyService, useValue: mockIdempotencyService },
+        {
+          provide: getRepositoryToken(BoardStyle),
+          useValue: mockBoardStyleRepository,
+        },
+        {
+          provide: PaginationService,
+          useValue: { paginate: jest.fn() },
+        },
+        {
+          provide: RedisService,
+          useValue: { delByPattern: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  const validPayload = { name: 'Cyberpunk Theme' };
+
+  it('returns identical responses for duplicate POSTs with the same X-Idempotency-Key and creates one record', async () => {
+    const first = await request(app.getHttpServer())
+      .post('/board-styles')
+      .set('X-Idempotency-Key', 'board-style-key-1')
+      .send(validPayload)
+      .expect(HttpStatus.CREATED);
+
+    const second = await request(app.getHttpServer())
+      .post('/board-styles')
+      .set('X-Idempotency-Key', 'board-style-key-1')
+      .send(validPayload)
+      .expect(HttpStatus.CREATED);
+
+    expect(second.body).toEqual(first.body);
+    expect(saveCallCount).toBe(1);
+    expect(savedStyles).toHaveLength(1);
+  });
+
+  it('test_post_without_idempotency_key_creates_duplicate', async () => {
+    await request(app.getHttpServer())
+      .post('/board-styles')
+      .send(validPayload)
+      .expect(HttpStatus.CREATED);
+
+    await request(app.getHttpServer())
+      .post('/board-styles')
+      .send(validPayload)
+      .expect(HttpStatus.CREATED);
+
+    expect(saveCallCount).toBe(2);
+    expect(savedStyles).toHaveLength(2);
+  });
+
+  it('processes the same key again after the idempotency window expires', async () => {
+    const interceptor = app.get(IdempotencyInterceptor);
+    const idempotency = app.get(
+      IdempotencyService,
+    ) as jest.Mocked<IdempotencyService>;
+
+    idempotency.get.mockImplementation(async (key: string) => {
+      const record = idempotencyStore.get(key);
+      if (!record) {
+        return undefined;
+      }
+      if (Date.now() - record.createdAt > 50) {
+        return undefined;
+      }
+      return record;
+    });
+
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          method: 'POST',
+          headers: { 'x-idempotency-key': 'stale-key' },
+        }),
+        getResponse: () => ({ setHeader: jest.fn() }),
+      }),
+    } as unknown as ExecutionContext;
+
+    const handler = {
+      handle: () => of(makeStyle({ id: 1, name: 'First' })),
+    };
+
+    await lastValueFrom(await interceptor.intercept(ctx, handler));
+    await new Promise((r) => setTimeout(r, 60));
+    await lastValueFrom(await interceptor.intercept(ctx, handler));
+
+    expect(idempotency.markProcessing).toHaveBeenCalledTimes(2);
+    expect(idempotency.markComplete).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/modules/board-styles/board-styles.controller.ts
+++ b/backend/src/modules/board-styles/board-styles.controller.ts
@@ -8,8 +8,10 @@ import {
   Delete,
   Query,
   UseInterceptors,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiQuery, ApiHeader } from '@nestjs/swagger';
 import { BoardStylesService } from './board-styles.service';
 import { AdvancedCacheInterceptor } from '../../common/interceptors/advanced-cache.interceptor';
 import { CacheOptions } from '../../common/decorators/cache-options.decorator';
@@ -18,14 +20,23 @@ import { UpdateBoardStyleDto } from './dto/update-board-style.dto';
 import { BoardStylesPaginationDto } from './dto/board-styles-pagination.dto';
 import { PaginatedResponse } from '../../common';
 import { BoardStyle } from './entities/board-style.entity';
+import { IdempotencyInterceptor } from '../redis/idempotency.interceptor';
 
 @ApiTags('board-styles')
 @Controller('board-styles')
+@UseInterceptors(IdempotencyInterceptor)
 export class BoardStylesController {
   constructor(private readonly boardStylesService: BoardStylesService) {}
 
   @Post()
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Create a new board style (Admin)' })
+  @ApiHeader({
+    name: 'X-Idempotency-Key',
+    required: false,
+    description:
+      'Optional idempotency key; duplicate POSTs with the same key return the cached response',
+  })
   create(@Body() createBoardStyleDto: CreateBoardStyleDto) {
     return this.boardStylesService.create(createBoardStyleDto);
   }

--- a/backend/src/modules/board-styles/board-styles.controller.ts
+++ b/backend/src/modules/board-styles/board-styles.controller.ts
@@ -15,6 +15,9 @@ import { AdvancedCacheInterceptor } from '../../common/interceptors/advanced-cac
 import { CacheOptions } from '../../common/decorators/cache-options.decorator';
 import { CreateBoardStyleDto } from './dto/create-board-style.dto';
 import { UpdateBoardStyleDto } from './dto/update-board-style.dto';
+import { BoardStylesPaginationDto } from './dto/board-styles-pagination.dto';
+import { PaginatedResponse } from '../../common';
+import { BoardStyle } from './entities/board-style.entity';
 
 @ApiTags('board-styles')
 @Controller('board-styles')
@@ -29,6 +32,26 @@ export class BoardStylesController {
 
   @Get()
   @ApiOperation({ summary: 'Get all board styles' })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })
+  @ApiQuery({
+    name: 'sortBy',
+    required: false,
+    type: String,
+    example: 'created_at',
+  })
+  @ApiQuery({
+    name: 'sortOrder',
+    required: false,
+    enum: ['ASC', 'DESC'],
+    example: 'DESC',
+  })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description: 'Search by name or description',
+  })
   @ApiQuery({
     name: 'is_premium',
     required: false,
@@ -37,12 +60,10 @@ export class BoardStylesController {
   })
   @UseInterceptors(AdvancedCacheInterceptor)
   @CacheOptions({ ttl: 600, keyPrefix: 'board-styles', useUserPrefix: false })
-  findAll(@Query('is_premium') is_premium?: string) {
-    let isPremiumBool: boolean | undefined;
-    if (is_premium !== undefined) {
-      isPremiumBool = is_premium === 'true';
-    }
-    return this.boardStylesService.findAll(isPremiumBool);
+  findAll(
+    @Query() paginationDto: BoardStylesPaginationDto,
+  ): Promise<PaginatedResponse<BoardStyle>> {
+    return this.boardStylesService.findAll(paginationDto);
   }
 
   @Get(':id')

--- a/backend/src/modules/board-styles/board-styles.service.spec.ts
+++ b/backend/src/modules/board-styles/board-styles.service.spec.ts
@@ -1,0 +1,194 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BoardStylesService } from './board-styles.service';
+import { BoardStyle } from './entities/board-style.entity';
+import {
+  PaginationService,
+  SortOrder,
+  PAGINATION_MAX_LIMIT,
+} from '../../common';
+import { RedisService } from '../redis/redis.service';
+
+describe('BoardStylesService', () => {
+  let service: BoardStylesService;
+
+  const mockBoardStyleRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const mockPaginationService = {
+    paginate: jest.fn(),
+  };
+
+  const mockRedisService = {
+    delByPattern: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BoardStylesService,
+        {
+          provide: getRepositoryToken(BoardStyle),
+          useValue: mockBoardStyleRepository,
+        },
+        {
+          provide: PaginationService,
+          useValue: mockPaginationService,
+        },
+        {
+          provide: RedisService,
+          useValue: mockRedisService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<BoardStylesService>(BoardStylesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findAll pagination', () => {
+    const buildQueryBuilder = () => ({
+      andWhere: jest.fn().mockReturnThis(),
+    });
+
+    it('returns the first page slice', async () => {
+      const mockQb = buildQueryBuilder();
+      mockBoardStyleRepository.createQueryBuilder.mockReturnValue(mockQb);
+      mockPaginationService.paginate.mockResolvedValue({
+        data: [{ id: 1 }, { id: 2 }],
+        meta: {
+          page: 1,
+          limit: 2,
+          totalItems: 5,
+          totalPages: 3,
+          hasNextPage: true,
+          hasPreviousPage: false,
+        },
+      });
+
+      const result = await service.findAll({ page: 1, limit: 2 });
+
+      expect(result.data).toHaveLength(2);
+      expect(result.meta.page).toBe(1);
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQb,
+        expect.objectContaining({ page: 1, limit: 2 }),
+        ['name', 'description'],
+        expect.arrayContaining(['created_at', 'id']),
+      );
+    });
+
+    it('returns the second page slice', async () => {
+      const mockQb = buildQueryBuilder();
+      mockBoardStyleRepository.createQueryBuilder.mockReturnValue(mockQb);
+      mockPaginationService.paginate.mockResolvedValue({
+        data: [{ id: 3 }, { id: 4 }],
+        meta: {
+          page: 2,
+          limit: 2,
+          totalItems: 5,
+          totalPages: 3,
+          hasNextPage: true,
+          hasPreviousPage: true,
+        },
+      });
+
+      const result = await service.findAll({ page: 2, limit: 2 });
+
+      expect(result.meta.page).toBe(2);
+      expect(result.data.every((item) => item.id >= 3)).toBe(true);
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQb,
+        expect.objectContaining({ page: 2, limit: 2 }),
+        ['name', 'description'],
+        expect.any(Array),
+      );
+    });
+
+    it(`caps limit at ${PAGINATION_MAX_LIMIT} via PaginationService`, async () => {
+      const mockQb = buildQueryBuilder();
+      mockBoardStyleRepository.createQueryBuilder.mockReturnValue(mockQb);
+      mockPaginationService.paginate.mockResolvedValue({
+        data: [],
+        meta: {
+          page: 1,
+          limit: PAGINATION_MAX_LIMIT,
+          totalItems: 0,
+          totalPages: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      });
+
+      await service.findAll({ page: 1, limit: 9999 });
+
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQb,
+        expect.objectContaining({ limit: 9999 }),
+        ['name', 'description'],
+        expect.any(Array),
+      );
+    });
+
+    it('uses created_at DESC with id tiebreaker for stable sort across pages', async () => {
+      const mockQb = buildQueryBuilder();
+      mockBoardStyleRepository.createQueryBuilder.mockReturnValue(mockQb);
+      mockPaginationService.paginate.mockResolvedValue({
+        data: [],
+        meta: {
+          page: 1,
+          limit: 10,
+          totalItems: 0,
+          totalPages: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      });
+
+      await service.findAll({ page: 1, limit: 10 });
+
+      expect(mockPaginationService.paginate).toHaveBeenCalledWith(
+        mockQb,
+        expect.objectContaining({
+          sortBy: 'created_at',
+          sortOrder: SortOrder.DESC,
+        }),
+        ['name', 'description'],
+        expect.arrayContaining(['id', 'created_at']),
+      );
+    });
+
+    it('applies is_premium filter when provided', async () => {
+      const mockQb = buildQueryBuilder();
+      mockBoardStyleRepository.createQueryBuilder.mockReturnValue(mockQb);
+      mockPaginationService.paginate.mockResolvedValue({
+        data: [],
+        meta: {
+          page: 1,
+          limit: 10,
+          totalItems: 0,
+          totalPages: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      });
+
+      await service.findAll({ page: 1, limit: 10, is_premium: true });
+
+      expect(mockQb.andWhere).toHaveBeenCalledWith(
+        'board_style.is_premium = :isPremium',
+        { isPremium: true },
+      );
+    });
+  });
+});

--- a/backend/src/modules/board-styles/board-styles.service.ts
+++ b/backend/src/modules/board-styles/board-styles.service.ts
@@ -4,13 +4,28 @@ import { Repository } from 'typeorm';
 import { BoardStyle } from './entities/board-style.entity';
 import { CreateBoardStyleDto } from './dto/create-board-style.dto';
 import { UpdateBoardStyleDto } from './dto/update-board-style.dto';
+import { BoardStylesPaginationDto } from './dto/board-styles-pagination.dto';
+import {
+  PaginationService,
+  PaginatedResponse,
+  SortOrder,
+} from '../../common';
 import { RedisService } from '../redis/redis.service';
+
+const BOARD_STYLE_SORT_FIELDS = [
+  'created_at',
+  'updated_at',
+  'name',
+  'price',
+  'id',
+] as const;
 
 @Injectable()
 export class BoardStylesService {
   constructor(
     @InjectRepository(BoardStyle)
     private readonly boardStyleRepository: Repository<BoardStyle>,
+    private readonly paginationService: PaginationService,
     private readonly redisService: RedisService,
   ) {}
 
@@ -21,16 +36,29 @@ export class BoardStylesService {
     return saved;
   }
 
-  async findAll(isPremium?: boolean): Promise<BoardStyle[]> {
+  async findAll(
+    paginationDto: BoardStylesPaginationDto,
+  ): Promise<PaginatedResponse<BoardStyle>> {
     const qb = this.boardStyleRepository.createQueryBuilder('board_style');
 
-    if (isPremium !== undefined) {
-      qb.andWhere('board_style.is_premium = :isPremium', { isPremium });
+    if (paginationDto.is_premium !== undefined) {
+      qb.andWhere('board_style.is_premium = :isPremium', {
+        isPremium: paginationDto.is_premium,
+      });
     }
 
-    qb.orderBy('board_style.created_at', 'DESC');
+    const pagination = {
+      ...paginationDto,
+      sortBy: paginationDto.sortBy ?? 'created_at',
+      sortOrder: paginationDto.sortOrder ?? SortOrder.DESC,
+    };
 
-    return await qb.getMany();
+    return this.paginationService.paginate(
+      qb,
+      pagination,
+      ['name', 'description'],
+      [...BOARD_STYLE_SORT_FIELDS],
+    );
   }
 
   async findOne(id: number): Promise<BoardStyle> {

--- a/backend/src/modules/board-styles/board-styles.service.ts
+++ b/backend/src/modules/board-styles/board-styles.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { BoardStyle } from './entities/board-style.entity';
@@ -30,7 +30,15 @@ export class BoardStylesService {
   ) {}
 
   async create(createBoardStyleDto: CreateBoardStyleDto): Promise<BoardStyle> {
-    const style = this.boardStyleRepository.create(createBoardStyleDto);
+    const trimmedName = createBoardStyleDto.name?.trim();
+    if (!trimmedName) {
+      throw new BadRequestException('board style name is required');
+    }
+
+    const style = this.boardStyleRepository.create({
+      ...createBoardStyleDto,
+      name: trimmedName,
+    });
     const saved = await this.boardStyleRepository.save(style);
     await this.invalidateCache();
     return saved;

--- a/backend/src/modules/board-styles/dto/board-styles-pagination.dto.ts
+++ b/backend/src/modules/board-styles/dto/board-styles-pagination.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsBoolean } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { PaginationDto } from '../../../common';
+
+export class BoardStylesPaginationDto extends PaginationDto {
+  @ApiPropertyOptional({
+    description: 'Filter by premium status',
+    type: Boolean,
+  })
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  is_premium?: boolean;
+}

--- a/backend/src/modules/board-styles/dto/create-board-style.dto.ts
+++ b/backend/src/modules/board-styles/dto/create-board-style.dto.ts
@@ -5,8 +5,11 @@ import {
   IsOptional,
   IsNumber,
   Min,
+  Max,
   IsObject,
+  IsNotEmpty,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class CreateBoardStyleDto {
   @ApiProperty({
@@ -14,6 +17,7 @@ export class CreateBoardStyleDto {
     example: 'Cyberpunk Theme',
   })
   @IsString()
+  @IsNotEmpty({ message: 'board style name is required' })
   name: string;
 
   @ApiProperty({
@@ -37,9 +41,11 @@ export class CreateBoardStyleDto {
     example: 9.99,
     required: false,
   })
-  @IsNumber()
-  @Min(0)
   @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0, { message: 'price must be a non-negative number' })
+  @Max(99999999.99, { message: 'price exceeds maximum allowed value' })
   price?: number;
 
   @ApiProperty({

--- a/backend/src/modules/chance/chance-observability.service.ts
+++ b/backend/src/modules/chance/chance-observability.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { Counter, Histogram, Registry } from 'prom-client';
+import { LoggerService } from '../../common/logger/logger.service';
+
+const ROLL_DURATION_BUCKETS = [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1];
+
+@Injectable()
+export class ChanceObservabilityService {
+  readonly registry = new Registry();
+
+  private readonly chanceRollsTotal: Counter;
+  private readonly chanceRollDuration: Histogram;
+
+  constructor(private readonly logger: LoggerService) {
+    this.chanceRollsTotal = new Counter({
+      name: 'chance_rolls_total',
+      help: 'Total chance card rolls by outcome type',
+      labelNames: ['outcome'],
+      registers: [this.registry],
+    });
+
+    this.chanceRollDuration = new Histogram({
+      name: 'chance_roll_duration_seconds',
+      help: 'Time spent drawing a chance card',
+      labelNames: ['outcome'],
+      buckets: ROLL_DURATION_BUCKETS,
+      registers: [this.registry],
+    });
+  }
+
+  logOperationStart(action: string, input: Record<string, unknown>): void {
+    this.logger.logWithMeta('info', action, { action, input });
+  }
+
+  logOperationSuccess(
+    action: string,
+    durationMs: number,
+    meta: Record<string, unknown> = {},
+  ): void {
+    this.logger.logWithMeta('info', action, {
+      action,
+      result: 'success',
+      duration_ms: durationMs,
+      ...meta,
+    });
+  }
+
+  logOperationError(action: string, error: Error): void {
+    this.logger.logWithMeta('error', action, {
+      action,
+      error: error.message,
+    });
+  }
+
+  recordRoll(outcome: string, durationMs: number): void {
+    this.chanceRollsTotal.inc({ outcome });
+    this.chanceRollDuration.observe({ outcome }, durationMs / 1000);
+  }
+
+  async getMetricsText(): Promise<string> {
+    return this.registry.metrics();
+  }
+}

--- a/backend/src/modules/chance/chance.module.ts
+++ b/backend/src/modules/chance/chance.module.ts
@@ -3,11 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Chance } from './entities/chance.entity';
 import { ChanceService } from './chance.service';
 import { ChanceController } from './chance.controller';
+import { ChanceObservabilityService } from './chance-observability.service';
+import { LoggerModule } from '../../common/logger/logger.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Chance])],
-  providers: [ChanceService],
+  imports: [TypeOrmModule.forFeature([Chance]), LoggerModule],
+  providers: [ChanceService, ChanceObservabilityService],
   controllers: [ChanceController],
-  exports: [TypeOrmModule],
+  exports: [TypeOrmModule, ChanceObservabilityService],
 })
 export class ChanceModule {}

--- a/backend/src/modules/chance/chance.service.spec.ts
+++ b/backend/src/modules/chance/chance.service.spec.ts
@@ -1,0 +1,111 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException } from '@nestjs/common';
+import { ChanceService } from './chance.service';
+import { ChanceObservabilityService } from './chance-observability.service';
+import { Chance } from './entities/chance.entity';
+import { ChanceType } from './enums/chance-type.enum';
+import { LoggerService } from '../../common/logger/logger.service';
+
+describe('ChanceService observability (#880)', () => {
+  let service: ChanceService;
+  let observability: ChanceObservabilityService;
+  let logger: jest.Mocked<Pick<LoggerService, 'logWithMeta'>>;
+
+  const mockChanceRepository = {
+    find: jest.fn(),
+    count: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    logger = {
+      logWithMeta: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChanceService,
+        ChanceObservabilityService,
+        {
+          provide: getRepositoryToken(Chance),
+          useValue: mockChanceRepository,
+        },
+        {
+          provide: LoggerService,
+          useValue: logger,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ChanceService>(ChanceService);
+    observability = module.get<ChanceObservabilityService>(
+      ChanceObservabilityService,
+    );
+    jest.clearAllMocks();
+  });
+
+  it('logs the roll action on successful draw', async () => {
+    const card = {
+      id: 7,
+      type: ChanceType.REWARD,
+      instruction: 'Collect $100',
+    } as Chance;
+
+    mockChanceRepository.count.mockResolvedValue(1);
+    mockChanceRepository.find.mockResolvedValue([card]);
+
+    await service.drawCard();
+
+    expect(logger.logWithMeta).toHaveBeenCalledWith(
+      'info',
+      'chance.roll',
+      expect.objectContaining({ action: 'chance.roll', input: {} }),
+    );
+    expect(logger.logWithMeta).toHaveBeenCalledWith(
+      'info',
+      'chance.roll',
+      expect.objectContaining({
+        action: 'chance.roll',
+        result: 'success',
+        outcome: ChanceType.REWARD,
+      }),
+    );
+  });
+
+  it('logs errors on failed roll', async () => {
+    mockChanceRepository.count.mockResolvedValue(0);
+
+    await expect(service.drawCard()).rejects.toThrow(BadRequestException);
+
+    expect(logger.logWithMeta).toHaveBeenCalledWith(
+      'error',
+      'chance.roll',
+      expect.objectContaining({
+        action: 'chance.roll',
+        error: 'No chance cards available',
+      }),
+    );
+  });
+
+  it('increments chance_rolls_total with the correct outcome label', async () => {
+    const card = {
+      id: 3,
+      type: ChanceType.PENALTY,
+      instruction: 'Pay $50',
+    } as Chance;
+
+    mockChanceRepository.count.mockResolvedValue(2);
+    mockChanceRepository.find.mockResolvedValue([card]);
+
+    const incSpy = jest.spyOn(
+      (observability as any).chanceRollsTotal,
+      'inc',
+    );
+
+    await service.drawCard();
+
+    expect(incSpy).toHaveBeenCalledWith({ outcome: ChanceType.PENALTY });
+  });
+});

--- a/backend/src/modules/chance/chance.service.ts
+++ b/backend/src/modules/chance/chance.service.ts
@@ -1,3 +1,5 @@
+// TODO: add OpenTelemetry tracing when infrastructure is available
+
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -5,102 +7,155 @@ import { Chance } from './entities/chance.entity';
 import { CreateChanceDto } from './dto/create-chance.dto';
 import { ChanceType } from './enums/chance-type.enum';
 import { secureRandomInt } from '../../common/crypto-secure-random';
+import { ChanceObservabilityService } from './chance-observability.service';
 
 @Injectable()
 export class ChanceService {
   constructor(
     @InjectRepository(Chance)
     private readonly chanceRepository: Repository<Chance>,
+    private readonly observability: ChanceObservabilityService,
   ) {}
 
   async findAll(page?: number, limit?: number): Promise<Chance[]> {
-    const take = limit || 20;
+    const action = 'chance.list';
+    const sanitizedInput = { page: page ?? 1, limit: limit ?? 20 };
+    const startedAt = Date.now();
+    this.observability.logOperationStart(action, sanitizedInput);
 
-    const skip = page && page > 0 ? (page - 1) * take : 0;
+    try {
+      const take = limit || 20;
+      const skip = page && page > 0 ? (page - 1) * take : 0;
 
-    return await this.chanceRepository.find({
-      order: { id: 'ASC' },
+      const data = await this.chanceRepository.find({
+        order: { id: 'ASC' },
+        take,
+        skip,
+      });
 
-      take,
-
-      skip,
-    });
+      this.observability.logOperationSuccess(action, Date.now() - startedAt, {
+        count: data.length,
+      });
+      return data;
+    } catch (err) {
+      this.observability.logOperationError(action, err as Error);
+      throw err;
+    }
   }
 
   async drawCard(): Promise<Chance> {
-    const count = await this.chanceRepository.count();
-    if (count === 0) {
-      throw new BadRequestException('No chance cards available');
+    const action = 'chance.roll';
+    const sanitizedInput = {};
+    const startedAt = Date.now();
+    this.observability.logOperationStart(action, sanitizedInput);
+
+    try {
+      const count = await this.chanceRepository.count();
+      if (count === 0) {
+        throw new BadRequestException('No chance cards available');
+      }
+      const randomIndex = secureRandomInt(count);
+      const [card] = await this.chanceRepository.find({
+        order: { id: 'ASC' },
+        skip: randomIndex,
+        take: 1,
+      });
+
+      const outcome = card.type;
+      this.observability.recordRoll(outcome, Date.now() - startedAt);
+      this.observability.logOperationSuccess(action, Date.now() - startedAt, {
+        outcome,
+        cardId: card.id,
+      });
+      return card;
+    } catch (err) {
+      this.observability.logOperationError(action, err as Error);
+      throw err;
     }
-    const randomIndex = secureRandomInt(count);
-    const [card] = await this.chanceRepository.find({
-      order: { id: 'ASC' },
-      skip: randomIndex,
-      take: 1,
-    });
-    return card;
   }
+
   async createChance(createChanceDto: CreateChanceDto): Promise<Chance> {
-    const trimmedInstruction = createChanceDto.instruction.trim();
-    if (!trimmedInstruction || trimmedInstruction.length === 0) {
-      throw new BadRequestException('Instruction cannot be empty');
-    }
-
-    if (
-      createChanceDto.type === ChanceType.REWARD ||
-      createChanceDto.type === ChanceType.PENALTY
-    ) {
-      if (
-        createChanceDto.amount === undefined ||
-        createChanceDto.amount === null
-      ) {
-        throw new BadRequestException(
-          `Amount is required for ${createChanceDto.type} type chance cards`,
-        );
-      }
-      if (createChanceDto.amount < 0) {
-        throw new BadRequestException('Amount must be a non-negative number');
-      }
-    }
-
-    if (createChanceDto.type === ChanceType.MOVE) {
-      if (
-        createChanceDto.position === undefined ||
-        createChanceDto.position === null
-      ) {
-        throw new BadRequestException(
-          'Position is required for move type chance cards',
-        );
-      }
-      if (createChanceDto.position < 0) {
-        throw new BadRequestException('Position must be a non-negative number');
-      }
-    }
-
-    if (
-      createChanceDto.amount !== undefined &&
-      createChanceDto.amount !== null &&
-      createChanceDto.amount < 0
-    ) {
-      throw new BadRequestException('Amount must be a non-negative number');
-    }
-
-    if (
-      createChanceDto.position !== undefined &&
-      createChanceDto.position !== null &&
-      createChanceDto.position < 0
-    ) {
-      throw new BadRequestException('Position must be a non-negative number');
-    }
-
-    const chance = this.chanceRepository.create({
-      instruction: trimmedInstruction,
+    const action = 'chance.create';
+    const sanitizedInput = {
       type: createChanceDto.type,
       amount: createChanceDto.amount ?? null,
       position: createChanceDto.position ?? null,
-      extra: createChanceDto.extra ?? null,
-    });
+    };
+    const startedAt = Date.now();
+    this.observability.logOperationStart(action, sanitizedInput);
 
-    return await this.chanceRepository.save(chance);
+    try {
+      const trimmedInstruction = createChanceDto.instruction.trim();
+      if (!trimmedInstruction || trimmedInstruction.length === 0) {
+        throw new BadRequestException('Instruction cannot be empty');
+      }
+
+      if (
+        createChanceDto.type === ChanceType.REWARD ||
+        createChanceDto.type === ChanceType.PENALTY
+      ) {
+        if (
+          createChanceDto.amount === undefined ||
+          createChanceDto.amount === null
+        ) {
+          throw new BadRequestException(
+            `Amount is required for ${createChanceDto.type} type chance cards`,
+          );
+        }
+        if (createChanceDto.amount < 0) {
+          throw new BadRequestException('Amount must be a non-negative number');
+        }
+      }
+
+      if (createChanceDto.type === ChanceType.MOVE) {
+        if (
+          createChanceDto.position === undefined ||
+          createChanceDto.position === null
+        ) {
+          throw new BadRequestException(
+            'Position is required for move type chance cards',
+          );
+        }
+        if (createChanceDto.position < 0) {
+          throw new BadRequestException(
+            'Position must be a non-negative number',
+          );
+        }
+      }
+
+      if (
+        createChanceDto.amount !== undefined &&
+        createChanceDto.amount !== null &&
+        createChanceDto.amount < 0
+      ) {
+        throw new BadRequestException('Amount must be a non-negative number');
+      }
+
+      if (
+        createChanceDto.position !== undefined &&
+        createChanceDto.position !== null &&
+        createChanceDto.position < 0
+      ) {
+        throw new BadRequestException('Position must be a non-negative number');
+      }
+
+      const chance = this.chanceRepository.create({
+        instruction: trimmedInstruction,
+        type: createChanceDto.type,
+        amount: createChanceDto.amount ?? null,
+        position: createChanceDto.position ?? null,
+        extra: createChanceDto.extra ?? null,
+      });
+
+      const saved = await this.chanceRepository.save(chance);
+      this.observability.logOperationSuccess(action, Date.now() - startedAt, {
+        cardId: saved.id,
+        type: saved.type,
+      });
+      return saved;
+    } catch (err) {
+      this.observability.logOperationError(action, err as Error);
+      throw err;
+    }
   }
 }

--- a/backend/src/modules/redis/idempotency.interceptor.ts
+++ b/backend/src/modules/redis/idempotency.interceptor.ts
@@ -35,7 +35,8 @@ export class IdempotencyInterceptor implements NestInterceptor {
       return next.handle();
     }
 
-    const idempotencyKey = req.headers[IDEMPOTENCY_HEADER];
+    const idempotencyKey =
+      req.headers[IDEMPOTENCY_HEADER] ?? req.headers['x-idempotency-key'];
     if (!idempotencyKey) {
       return next.handle();
     }


### PR DESCRIPTION
## Summary

This PR hardens the board-styles module with paginated listing, optional idempotency on create, and stricter DTO validation, and adds structured logging and Prometheus metrics to the chance module for roll operations.

## Changes

### #877 — board-styles pagination and stable sorting
- Added `BoardStylesPaginationDto` extending the shared `PaginationDto` with an `is_premium` filter
- Updated `findAll` to use `PaginationService.paginate()` with default sort `created_at DESC` and an `id` tiebreaker via the shared pagination service
- Added `@ApiQuery` decorators for `page`, `limit`, `sortBy`, `sortOrder`, and `search`
- Added unit tests for first/second page slices, max limit passthrough, and stable sort configuration

### #878 — board-styles idempotency and replay tests
- Wired the existing Redis `IdempotencyInterceptor` to the board-styles controller (optional `X-Idempotency-Key` header)
- Extended the Redis interceptor to also accept `x-idempotency-key`
- Added replay tests: duplicate key returns cached response with one DB write, no key creates duplicates, stale key re-processes after TTL expiry

### #879 — board-styles DTO validation and error mapping
- Strengthened `CreateBoardStyleDto` with `@IsNotEmpty`, `@Type(() => Number)`, `@Min`, and `@Max` on price
- Added service-layer `BadRequestException` for whitespace-only names
- Added validation and error-mapping tests confirming 400 responses and the global `HttpExceptionFilter` shape

### #880 — chance module observability
- Added `ChanceObservabilityService` with Prometheus `chance_rolls_total` and `chance_roll_duration_seconds` metrics
- Instrumented `ChanceService` with structured `logWithMeta` logging (sanitized input excludes `instruction` and `extra`)
- Added OpenTelemetry tracing TODO stub at the top of the service file
- Added unit tests for success logging, error logging, and counter increment with outcome label

## Notes

- Pagination reuses the shared `PaginationDto` / `PaginationService` pattern (max limit **100** via `PAGINATION_MAX_LIMIT`)
- Paginated response shape follows the existing `{ data, meta: { page, limit, totalItems, ... } }` interface
- Idempotency uses the existing Redis-backed `IdempotencyService` (24h TTL); header is optional — requests without a key are not deduplicated
- Sensitive chance fields (`instruction`, `extra`) are omitted from structured logs
- Metrics registration follows the Prometheus pattern used in the webhooks observability module

Closes #877, Closes #878, Closes #879, Closes #880
