### PR TITLE
feat(layout): add ShellErrorBoundary for error and empty states

### DIFF
--- a/frontend/src/components/layout/__tests__/SiteShell.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteShell.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { vi, describe, it, expect } from "vitest";
 import { SiteShell } from "../site-shell";
+import { ShellErrorBoundary } from "../shell-error-boundary";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/",
@@ -103,5 +104,78 @@ describe("SiteShell", () => {
       render(<SiteShell><p>x</p></SiteShell>);
       expect(screen.getByRole("contentinfo")).toBeDefined();
     });
+  });
+
+  describe("accessibility", () => {
+    it("main element has outline-none to suppress default focus ring", () => {
+      render(<SiteShell><p>x</p></SiteShell>);
+      const main = screen.getByRole("main");
+      expect(main.className).toContain("outline-none");
+    });
+
+    it("main element has pb-24 for mobile nav clearance", () => {
+      render(<SiteShell><p>x</p></SiteShell>);
+      const main = screen.getByRole("main");
+      expect(main.className).toContain("pb-24");
+    });
+  });
+});
+
+describe("ShellErrorBoundary", () => {
+  function Bomb() {
+    throw new Error("boom");
+  }
+
+  it("renders children when no error", () => {
+    render(
+      <ShellErrorBoundary>
+        <p data-testid="ok">fine</p>
+      </ShellErrorBoundary>
+    );
+    expect(screen.getByTestId("ok")).toBeDefined();
+  });
+
+  it("renders default fallback on render error", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ShellErrorBoundary>
+        <Bomb />
+      </ShellErrorBoundary>
+    );
+    expect(screen.getByTestId("shell-error-fallback")).toBeDefined();
+    expect(screen.getByRole("alert")).toBeDefined();
+    spy.mockRestore();
+  });
+
+  it("renders custom fallback when provided", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ShellErrorBoundary fallback={<p data-testid="custom-fb">oops</p>}>
+        <Bomb />
+      </ShellErrorBoundary>
+    );
+    expect(screen.getByTestId("custom-fb")).toBeDefined();
+    spy.mockRestore();
+  });
+
+  it("renders empty state when children is null", () => {
+    render(<ShellErrorBoundary>{null}</ShellErrorBoundary>);
+    expect(screen.getByTestId("shell-empty-state")).toBeDefined();
+  });
+
+  it("renders empty state when children is undefined", () => {
+    render(<ShellErrorBoundary>{undefined}</ShellErrorBoundary>);
+    expect(screen.getByTestId("shell-empty-state")).toBeDefined();
+  });
+
+  it("SiteShell wraps children in error boundary — shows fallback on crash", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <SiteShell errorFallback={<p data-testid="page-error">page crashed</p>}>
+        <Bomb />
+      </SiteShell>
+    );
+    expect(screen.getByTestId("page-error")).toBeDefined();
+    spy.mockRestore();
   });
 });

--- a/frontend/src/components/layout/shell-error-boundary.tsx
+++ b/frontend/src/components/layout/shell-error-boundary.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React, { Component } from "react";
+import type { ReactNode, ErrorInfo } from "react";
+
+type Props = {
+  children: ReactNode;
+  fallback?: ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+  error: Error | null;
+};
+
+export class ShellErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[ShellErrorBoundary] Uncaught render error:", error, info);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback !== undefined) {
+        return this.props.fallback;
+      }
+      return (
+        <div
+          role="alert"
+          className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center"
+          data-testid="shell-error-fallback"
+        >
+          <p className="text-sm text-[var(--tycoon-text-muted)]">
+            Something went wrong. Please refresh the page.
+          </p>
+        </div>
+      );
+    }
+
+    if (!this.props.children) {
+      return (
+        <div
+          className="flex flex-1 flex-col items-center justify-center p-8 text-center"
+          data-testid="shell-empty-state"
+        >
+          <p className="text-sm text-[var(--tycoon-text-muted)]">
+            No content to display.
+          </p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/layout/site-shell.tsx
+++ b/frontend/src/components/layout/site-shell.tsx
@@ -4,16 +4,18 @@ import type { ReactNode } from "react";
 import Footer from "@/components/shared/Footer";
 import Navbar from "@/components/shared/Navbar";
 import NavbarMobile from "@/components/shared/NavbarMobile";
+import { ShellErrorBoundary } from "./shell-error-boundary";
 
 type SiteShellProps = {
   children: ReactNode;
+  errorFallback?: ReactNode;
 };
 
 /**
  * App shell: sticky header (see Navbar), primary main landmark, global footer, mobile nav.
  * Sticky header keeps wayfinding on-screen; Navbar uses a fixed h-16 so skip-link scroll-mt matches.
  */
-export function SiteShell({ children }: SiteShellProps) {
+export function SiteShell({ children, errorFallback }: SiteShellProps) {
   return (
     <div className="flex min-h-dvh flex-col bg-[var(--tycoon-bg)]">
       <a
@@ -29,7 +31,9 @@ export function SiteShell({ children }: SiteShellProps) {
         tabIndex={-1}
         className="flex-1 min-h-0 scroll-mt-16 outline-none pb-24 md:pb-8"
       >
-        {children}
+        <ShellErrorBoundary fallback={errorFallback}>
+          {children}
+        </ShellErrorBoundary>
       </main>
       <Footer />
       <NavbarMobile />


### PR DESCRIPTION
## Summary

- Adds `ShellErrorBoundary` class component (`layout/shell-error-boundary.tsx`) that catches uncaught child render errors and shows a graceful fallback, and renders an empty-state placeholder when children is null/undefined
- Updates `SiteShell` to wrap its children slot in `ShellErrorBoundary`; accepts an optional `errorFallback` prop for custom recovery UI
- Extends `SiteShell.test.tsx` with `ShellErrorBoundary` describe block: error fallback, custom fallback, empty state (null + undefined children), and end-to-end `SiteShell` crash recovery

## Test plan

- [ ] `pnpm vitest run` in `frontend/` passes all tests
- [ ] Manually throw from a page child; shell renders fallback without crashing the header/footer
- [ ] Pass `null` as children; shell shows empty-state placeholder

Closes #767