### PR TITLE
fix(backend): add webhook observability trace correlation (SW-BE-019)

### DIFF
--- a/backend/src/modules/webhooks/PR_DESCRIPTION_SW_BE_019.md
+++ b/backend/src/modules/webhooks/PR_DESCRIPTION_SW_BE_019.md
@@ -1,0 +1,37 @@
+# SW-BE-019: Webhooks & Signatures — Observability
+
+## Summary
+
+This change improves webhook observability for the backend by adding structured trace correlation for signature verification and webhook processing events. The goal is to make webhook failures and duplicate deliveries easier to investigate without exposing sensitive values in logs.
+
+## What changed
+
+- Added optional trace/request id propagation through webhook verification and processing flows.
+- Extended webhook observability logging with request correlation metadata while preserving secret sanitization.
+- Added regression tests covering successful and failed signature verification paths as well as idempotency and processing failures.
+- Kept the change scoped to the backend webhook module and backward-compatible for existing callers.
+
+## Why this matters
+
+Webhook handlers are security-sensitive and operationally important. Better observability helps operators quickly answer:
+
+- whether a webhook passed signature verification,
+- how long verification and processing took,
+- whether the webhook was a duplicate, and
+- which request/trace identifier to correlate with upstream traffic.
+
+## Testing
+
+Verified with:
+
+- `pnpm exec jest --runInBand src/modules/webhooks/webhooks.service.spec.ts src/modules/webhooks/webhooks-observability.service.spec.ts`
+
+## Rollout / migration notes
+
+- No schema changes are required.
+- No secrets are logged; webhook payloads remain sanitized.
+- Existing webhook consumers remain compatible. Optional trace headers such as `x-trace-id`, `x-request-id`, or `traceparent` are now used when present.
+
+## Notes
+
+closes #63

--- a/backend/src/modules/webhooks/webhooks-observability.service.spec.ts
+++ b/backend/src/modules/webhooks/webhooks-observability.service.spec.ts
@@ -118,6 +118,18 @@ describe('WebhooksObservabilityService', () => {
       );
     });
 
+    it('should include request trace id in structured signature logs', () => {
+      service.logSignatureVerification('stripe', true, 5, undefined, 'trace-123');
+
+      expect(loggerService.logWithMeta).toHaveBeenCalledWith(
+        'debug',
+        'Signature verification',
+        expect.objectContaining({
+          request_id: 'trace-123',
+        }),
+      );
+    });
+
     it('should log failed signature verification with reason', () => {
       service.logSignatureVerification(
         'stripe',
@@ -207,6 +219,24 @@ describe('WebhooksObservabilityService', () => {
           source: 'stripe',
           event: WebhookEventType.PROCESSED,
           processingTimeMs: 150,
+        }),
+      );
+    });
+
+    it('should include request trace id in structured processing logs', () => {
+      const context = {
+        webhookId: 'wh_123',
+        eventType: 'payment.succeeded',
+        source: 'stripe',
+      };
+
+      service.logWebhookProcessed(context, 150, 'trace-456');
+
+      expect(loggerService.logWithMeta).toHaveBeenCalledWith(
+        'info',
+        'Webhook processed',
+        expect.objectContaining({
+          request_id: 'trace-456',
         }),
       );
     });

--- a/backend/src/modules/webhooks/webhooks-observability.service.ts
+++ b/backend/src/modules/webhooks/webhooks-observability.service.ts
@@ -40,6 +40,19 @@ export interface WebhookLogContext {
 }
 
 /**
+ * Trace context for distributed tracing
+ */
+export interface TraceContext {
+  trace_id: string;
+  operation: string;
+  webhook_id?: string;
+  event_type?: string;
+  source?: string;
+  user_id?: string;
+  timestamp: string;
+}
+
+/**
  * Observability service for webhooks & signatures
  * Provides structured logging, metrics, and traces for webhook operations
  *
@@ -103,18 +116,32 @@ export class WebhooksObservabilityService {
   /**
    * Log webhook received event
    * @param context - Webhook context (no secrets)
+   * @param traceId - Optional trace ID for correlation
    */
-  logWebhookReceived(context: WebhookLogContext): void {
+  logWebhookReceived(context: WebhookLogContext, traceId?: string): void {
     const sanitizedContext = this.sanitizeContext(context);
 
+    // Create trace context for distributed tracing
+    const traceContext = this.createTraceContext(
+      'webhook.received',
+      context.webhookId,
+      context.eventType,
+      context.source,
+      undefined,
+      traceId,
+    );
+
     this.logger.log(
-      `Webhook received: ${context.source || 'unknown'} - ${context.eventType || 'unknown'}`,
+      `Webhook received: ${context.source || 'unknown'} - ${context.eventType || 'unknown'}${traceId ? ` [trace_id=${traceId}]` : ''}`,
       'WebhooksObservability',
     );
 
     this.logger.logWithMeta('info', 'Webhook received', {
       ...sanitizedContext,
       event: WebhookEventType.RECEIVED,
+      trace_id: traceContext.trace_id,
+      operation: traceContext.operation,
+      request_id: traceId,
     });
 
     this.webhookEventsTotal.inc({
@@ -136,6 +163,7 @@ export class WebhooksObservabilityService {
     success: boolean,
     durationMs: number,
     failureReason?: string,
+    traceId?: string,
   ): void {
     const result = success ? 'valid' : 'invalid';
     const durationSeconds = durationMs / 1000;
@@ -177,6 +205,7 @@ export class WebhooksObservabilityService {
         result,
         durationMs,
         failureReason: failureReason || undefined,
+        request_id: traceId,
       },
     );
   }
@@ -184,18 +213,32 @@ export class WebhooksObservabilityService {
   /**
    * Log idempotency hit (duplicate webhook detected)
    * @param context - Webhook context
+   * @param traceId - Optional trace ID for correlation
    */
-  logIdempotencyHit(context: WebhookLogContext): void {
+  logIdempotencyHit(context: WebhookLogContext, traceId?: string): void {
     const sanitizedContext = this.sanitizeContext(context);
 
+    // Create trace context for distributed tracing
+    const traceContext = this.createTraceContext(
+      'webhook.idempotency_hit',
+      context.webhookId,
+      context.eventType,
+      context.source,
+      undefined,
+      traceId,
+    );
+
     this.logger.log(
-      `Duplicate webhook detected: ${context.webhookId} (${context.source})`,
+      `Duplicate webhook detected: ${context.webhookId} (${context.source})${traceId ? ` [trace_id=${traceId}]` : ''}`,
       'WebhooksObservability',
     );
 
     this.logger.logWithMeta('info', 'Idempotency hit', {
       ...sanitizedContext,
       event: WebhookEventType.IDEMPOTENCY_HIT,
+      trace_id: traceContext.trace_id,
+      operation: traceContext.operation,
+      request_id: traceId,
     });
 
     this.idempotencyHitsTotal.inc({
@@ -214,12 +257,23 @@ export class WebhooksObservabilityService {
    * Log successful webhook processing
    * @param context - Webhook context
    * @param durationMs - Processing duration in milliseconds
+   * @param traceId - Optional trace ID for correlation
    */
-  logWebhookProcessed(context: WebhookLogContext, durationMs: number): void {
+  logWebhookProcessed(context: WebhookLogContext, durationMs: number, traceId?: string): void {
     const sanitizedContext = this.sanitizeContext(context);
 
+    // Create trace context for distributed tracing
+    const traceContext = this.createTraceContext(
+      'webhook.processed',
+      context.webhookId,
+      context.eventType,
+      context.source,
+      undefined,
+      traceId,
+    );
+
     this.logger.log(
-      `Webhook processed: ${context.webhookId} (${context.source}) in ${durationMs}ms`,
+      `Webhook processed: ${context.webhookId} (${context.source}) in ${durationMs}ms${traceId ? ` [trace_id=${traceId}]` : ''}`,
       'WebhooksObservability',
     );
 
@@ -227,6 +281,9 @@ export class WebhooksObservabilityService {
       ...sanitizedContext,
       event: WebhookEventType.PROCESSED,
       processingTimeMs: durationMs,
+      trace_id: traceContext.trace_id,
+      operation: traceContext.operation,
+      request_id: traceId,
     });
 
     this.webhookProcessingDuration.observe(
@@ -249,16 +306,28 @@ export class WebhooksObservabilityService {
    * @param context - Webhook context
    * @param error - Error that occurred
    * @param durationMs - Processing duration in milliseconds
+   * @param traceId - Optional trace ID for correlation
    */
   logWebhookProcessingFailed(
     context: WebhookLogContext,
     error: Error,
     durationMs: number,
+    traceId?: string,
   ): void {
     const sanitizedContext = this.sanitizeContext(context);
 
+    // Create trace context for distributed tracing
+    const traceContext = this.createTraceContext(
+      'webhook.processing_failed',
+      context.webhookId,
+      context.eventType,
+      context.source,
+      undefined,
+      traceId,
+    );
+
     this.logger.error(
-      `Webhook processing failed: ${context.webhookId} (${context.source}) - ${error.message}`,
+      `Webhook processing failed: ${context.webhookId} (${context.source}) - ${error.message}${traceId ? ` [trace_id=${traceId}]` : ''}`,
       error.stack,
       'WebhooksObservability',
     );
@@ -269,6 +338,9 @@ export class WebhooksObservabilityService {
       error: error.message,
       errorStack: error.stack,
       processingTimeMs: durationMs,
+      trace_id: traceContext.trace_id,
+      operation: traceContext.operation,
+      request_id: traceId,
     });
 
     this.webhookEventsTotal.inc({
@@ -276,6 +348,36 @@ export class WebhooksObservabilityService {
       event_type: context.eventType || 'unknown',
       status: 'failed',
     });
+  }
+
+  /**
+   * Create a trace context for webhook operations
+   * Supports correlation and distributed tracing
+   */
+  createTraceContext(
+    operation: string,
+    webhookId?: string,
+    eventType?: string,
+    source?: string,
+    userId?: string,
+    traceId?: string,
+  ): TraceContext {
+    return {
+      trace_id: traceId || this.generateTraceId(),
+      operation,
+      webhook_id: webhookId,
+      event_type: eventType,
+      source,
+      user_id: userId,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Log trace IDs for debugging purposes
+   */
+  private generateTraceId(): string {
+    return Date.now().toString(36) + Math.random().toString(36).substr(2);
   }
 
   /**
@@ -296,10 +398,12 @@ export class WebhooksObservabilityService {
 
     // Remove any fields that might contain sensitive data
     // (signatures, tokens, etc. should never be in context, but defensive)
-    delete (sanitized as any).signature;
-    delete (sanitized as any).secret;
-    delete (sanitized as any).token;
-    delete (sanitized as any).authorization;
+    const sensitiveFields = ['signature', 'secret', 'token', 'authorization'];
+    sensitiveFields.forEach(field => {
+      if (field in sanitized) {
+        delete (sanitized as any)[field];
+      }
+    });
 
     return sanitized;
   }

--- a/backend/src/modules/webhooks/webhooks.controller.ts
+++ b/backend/src/modules/webhooks/webhooks.controller.ts
@@ -39,6 +39,10 @@ export class WebhooksController {
       const ipAddress =
         req.ip || (req.headers['x-forwarded-for'] as string) || 'unknown';
       const userAgent = req.headers['user-agent'] || 'unknown';
+      const traceId =
+        (req.headers['x-trace-id'] as string) ||
+        (req.headers['x-request-id'] as string) ||
+        (req.headers['traceparent'] as string);
 
       const isValid = await this.webhooksService.verifySignature(
         signature,
@@ -46,6 +50,7 @@ export class WebhooksController {
         req.rawBody,
         'stripe',
         ipAddress,
+        traceId,
       );
 
       if (!isValid) {
@@ -57,6 +62,7 @@ export class WebhooksController {
         'stripe',
         ipAddress,
         userAgent,
+        traceId,
       );
     } catch (error) {
       if (error instanceof UnauthorizedException) {

--- a/backend/src/modules/webhooks/webhooks.service.spec.ts
+++ b/backend/src/modules/webhooks/webhooks.service.spec.ts
@@ -99,12 +99,40 @@ describe('WebhooksService', () => {
       );
 
       expect(result).toBe(true);
-      expect(observability.logSignatureVerification).toHaveBeenCalledWith(
+      expect(observability.logSignatureVerification.mock.calls[0]).toEqual([
         'stripe',
         true,
         expect.any(Number),
         undefined,
+        undefined,
+      ]);
+    });
+
+    it('should forward trace ids to signature verification observability', async () => {
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const body = JSON.stringify({ test: 'data' });
+      const signedPayload = `${timestamp}.${body}`;
+      const signature = require('crypto')
+        .createHmac('sha256', secret)
+        .update(signedPayload)
+        .digest('hex');
+
+      await service.verifySignature(
+        signature,
+        timestamp,
+        Buffer.from(body),
+        'stripe',
+        undefined,
+        'trace-123',
       );
+
+      expect(observability.logSignatureVerification.mock.calls[0]).toEqual([
+        'stripe',
+        true,
+        expect.any(Number),
+        undefined,
+        'trace-123',
+      ]);
     });
 
     it('should reject invalid signature and log failure', async () => {
@@ -120,12 +148,13 @@ describe('WebhooksService', () => {
       );
 
       expect(result).toBe(false);
-      expect(observability.logSignatureVerification).toHaveBeenCalledWith(
+      expect(observability.logSignatureVerification.mock.calls[0]).toEqual([
         'stripe',
         false,
         expect.any(Number),
         'signature_length_mismatch',
-      );
+        undefined,
+      ]);
     });
 
     it('should reject timestamp outside tolerance and log failure', async () => {
@@ -141,12 +170,13 @@ describe('WebhooksService', () => {
         ),
       ).rejects.toThrow('Webhook timestamp outside of tolerance');
 
-      expect(observability.logSignatureVerification).toHaveBeenCalledWith(
+      expect(observability.logSignatureVerification.mock.calls[0]).toEqual([
         'stripe',
         false,
         expect.any(Number),
         'timestamp_outside_tolerance',
-      );
+        undefined,
+      ]);
     });
 
     it('should log failure for missing signature', async () => {
@@ -157,12 +187,13 @@ describe('WebhooksService', () => {
         service.verifySignature('', timestamp, Buffer.from(body), 'stripe'),
       ).rejects.toThrow('Missing webhook signature or timestamp');
 
-      expect(observability.logSignatureVerification).toHaveBeenCalledWith(
+      expect(observability.logSignatureVerification.mock.calls[0]).toEqual([
         'stripe',
         false,
         expect.any(Number),
         'missing_signature_or_timestamp',
-      );
+        undefined,
+      ]);
     });
   });
 
@@ -190,19 +221,23 @@ describe('WebhooksService', () => {
       );
 
       // Verify observability calls
-      expect(observability.logWebhookReceived).toHaveBeenCalledWith({
-        webhookId: 'evt_123',
-        eventType: 'payment.succeeded',
-        source: 'stripe',
-      });
-      expect(observability.logWebhookProcessed).toHaveBeenCalledWith(
+      expect(observability.logWebhookReceived.mock.calls[0]).toEqual([
+        {
+          webhookId: 'evt_123',
+          eventType: 'payment.succeeded',
+          source: 'stripe',
+        },
+        undefined,
+      ]);
+      expect(observability.logWebhookProcessed.mock.calls[0]).toEqual([
         {
           webhookId: 'evt_123',
           eventType: 'payment.succeeded',
           source: 'stripe',
         },
         expect.any(Number),
-      );
+        undefined,
+      ]);
     });
 
     it('should return idempotent response for duplicate webhook and log hit', async () => {
@@ -217,11 +252,38 @@ describe('WebhooksService', () => {
 
       // Verify observability calls
       expect(observability.logWebhookReceived).toHaveBeenCalled();
-      expect(observability.logIdempotencyHit).toHaveBeenCalledWith({
-        webhookId: 'evt_123',
-        eventType: 'test.event',
-        source: 'stripe',
-      });
+      expect(observability.logIdempotencyHit.mock.calls[0]).toEqual([
+        {
+          webhookId: 'evt_123',
+          eventType: 'test.event',
+          source: 'stripe',
+        },
+        undefined,
+      ]);
+    });
+
+    it('should forward trace ids to webhook observability', async () => {
+      const payload = { id: 'evt_123', type: 'test.event' };
+      redisService.get.mockResolvedValue(true);
+
+      await service.processWebhook(payload, 'stripe', undefined, undefined, 'trace-456');
+
+      expect(observability.logWebhookReceived.mock.calls[0]).toEqual([
+        {
+          webhookId: 'evt_123',
+          eventType: 'test.event',
+          source: 'stripe',
+        },
+        'trace-456',
+      ]);
+      expect(observability.logIdempotencyHit.mock.calls[0]).toEqual([
+        {
+          webhookId: 'evt_123',
+          eventType: 'test.event',
+          source: 'stripe',
+        },
+        'trace-456',
+      ]);
     });
 
     it('should reject webhook without ID and log failure', async () => {
@@ -232,14 +294,15 @@ describe('WebhooksService', () => {
       );
 
       expect(observability.logWebhookReceived).toHaveBeenCalled();
-      expect(observability.logWebhookProcessingFailed).toHaveBeenCalledWith(
+      expect(observability.logWebhookProcessingFailed.mock.calls[0]).toEqual([
         expect.objectContaining({
           eventType: 'test.event',
           source: 'stripe',
         }),
         expect.any(Error),
         expect.any(Number),
-      );
+        undefined,
+      ]);
     });
 
     it('should log processing failure on database error', async () => {
@@ -254,7 +317,7 @@ describe('WebhooksService', () => {
         dbError,
       );
 
-      expect(observability.logWebhookProcessingFailed).toHaveBeenCalledWith(
+      expect(observability.logWebhookProcessingFailed.mock.calls[0]).toEqual([
         {
           webhookId: 'evt_123',
           eventType: 'payment.succeeded',
@@ -262,7 +325,8 @@ describe('WebhooksService', () => {
         },
         dbError,
         expect.any(Number),
-      );
+        undefined,
+      ]);
     });
   });
 

--- a/backend/src/modules/webhooks/webhooks.service.ts
+++ b/backend/src/modules/webhooks/webhooks.service.ts
@@ -41,6 +41,7 @@ export class WebhooksService {
     rawBody: Buffer,
     source = 'stripe',
     ipAddress?: string,
+    traceId?: string,
   ): Promise<boolean> {
     const startTime = Date.now();
     let failureReason: string | undefined;
@@ -53,6 +54,7 @@ export class WebhooksService {
           false,
           Date.now() - startTime,
           failureReason,
+          traceId,
         );
         await this.auditService.auditSignatureVerification(
           undefined,
@@ -77,6 +79,7 @@ export class WebhooksService {
           false,
           Date.now() - startTime,
           failureReason,
+          traceId,
         );
         await this.auditService.auditSignatureVerification(
           undefined,
@@ -124,6 +127,7 @@ export class WebhooksService {
         isValid,
         Date.now() - startTime,
         failureReason,
+        traceId,
       );
 
       // Audit verification result (audit trail)
@@ -145,6 +149,7 @@ export class WebhooksService {
           false,
           Date.now() - startTime,
           'unexpected_error',
+          traceId,
         );
         await this.auditService.auditSignatureVerification(
           undefined,
@@ -164,17 +169,21 @@ export class WebhooksService {
     source = 'stripe',
     ipAddress?: string,
     userAgent?: string,
+    traceId?: string,
   ) {
     const startTime = Date.now();
     const webhookId = payload.id;
     const eventType = payload.type ?? 'unknown';
 
     // Log webhook received (observability)
-    this.observability.logWebhookReceived({
-      webhookId,
-      eventType,
-      source,
-    });
+    this.observability.logWebhookReceived(
+      {
+        webhookId,
+        eventType,
+        source,
+      },
+      traceId,
+    );
 
     // Audit webhook received (audit trail)
     await this.auditService.auditWebhookReceived(
@@ -206,11 +215,14 @@ export class WebhooksService {
 
       if (isProcessed) {
         // Log idempotency hit (observability)
-        this.observability.logIdempotencyHit({
-          webhookId,
-          eventType,
-          source,
-        });
+        this.observability.logIdempotencyHit(
+          {
+            webhookId,
+            eventType,
+            source,
+          },
+          traceId,
+        );
         return { received: true, idempotent: true };
       }
 
@@ -242,6 +254,7 @@ export class WebhooksService {
           source,
         },
         Date.now() - startTime,
+        traceId,
       );
 
       // Audit successful processing
@@ -263,6 +276,7 @@ export class WebhooksService {
         },
         error as Error,
         Date.now() - startTime,
+        traceId,
       );
 
       // Audit processing failure


### PR DESCRIPTION
# SW-BE-019: Webhooks & Signatures — Observability

## Summary

This change improves webhook observability for the backend by adding structured trace correlation for signature verification and webhook processing events. The goal is to make webhook failures and duplicate deliveries easier to investigate without exposing sensitive values in logs.

## What changed

- Added optional trace/request id propagation through webhook verification and processing flows.
- Extended webhook observability logging with request correlation metadata while preserving secret sanitization.
- Added regression tests covering successful and failed signature verification paths as well as idempotency and processing failures.
- Kept the change scoped to the backend webhook module and backward-compatible for existing callers.

## Why this matters

Webhook handlers are security-sensitive and operationally important. Better observability helps operators quickly answer:

- whether a webhook passed signature verification,
- how long verification and processing took,
- whether the webhook was a duplicate, and
- which request/trace identifier to correlate with upstream traffic.

## Testing

Verified with:

- `pnpm exec jest --runInBand src/modules/webhooks/webhooks.service.spec.ts src/modules/webhooks/webhooks-observability.service.spec.ts`

## Rollout / migration notes

- No schema changes are required.
- No secrets are logged; webhook payloads remain sanitized.
- Existing webhook consumers remain compatible. Optional trace headers such as `x-trace-id`, `x-request-id`, or `traceparent` are now used when present.

## Notes

closes #63
