### PR TITLE
feat: expand test coverage for boost-system and collectibles contracts

### DIFF
--- a/contract/contracts/tycoon-boost-system/src/test.rs
+++ b/contract/contracts/tycoon-boost-system/src/test.rs
@@ -205,3 +205,120 @@ fn test_add_boost_requires_admin_auth() {
     let client2 = TycoonBoostSystemClient::new(&env2, &contract_id);
     client2.add_boost(&player, &boost(1, BoostType::Additive, 1000, 0));
 }
+
+// ── add_boost error-path coverage ────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "DuplicateId")]
+fn test_add_boost_duplicate_id_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, player) = setup_with_admin(&env);
+    client.add_boost(&player, &boost(1, BoostType::Additive, 1000, 0));
+    client.add_boost(&player, &boost(1, BoostType::Additive, 500, 0));
+}
+
+#[test]
+#[should_panic(expected = "InvalidValue")]
+fn test_add_boost_zero_value_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, player) = setup_with_admin(&env);
+    client.add_boost(&player, &boost(1, BoostType::Additive, 0, 0));
+}
+
+#[test]
+#[should_panic(expected = "InvalidExpiry")]
+fn test_add_boost_past_expiry_panics() {
+    use soroban_sdk::testutils::{Ledger, LedgerInfo};
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        sequence_number: 100,
+        timestamp: 500,
+        protocol_version: 23,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 100_000,
+    });
+    let (client, _admin, player) = setup_with_admin(&env);
+    client.add_boost(
+        &player,
+        &Boost {
+            id: 1,
+            boost_type: BoostType::Additive,
+            value: 1000,
+            priority: 0,
+            expires_at_ledger: 50,
+        },
+    );
+}
+
+#[test]
+#[should_panic(expected = "CapExceeded")]
+fn test_add_boost_cap_exceeded_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, player) = setup_with_admin(&env);
+    for i in 0..MAX_BOOSTS_PER_PLAYER as u128 {
+        client.add_boost(&player, &boost(i + 1, BoostType::Additive, 100, 0));
+    }
+    client.add_boost(
+        &player,
+        &boost(MAX_BOOSTS_PER_PLAYER as u128 + 1, BoostType::Additive, 100, 0),
+    );
+}
+
+// ── get_active_boosts ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_active_boosts_excludes_expired() {
+    use soroban_sdk::testutils::{Ledger, LedgerInfo};
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        sequence_number: 50,
+        timestamp: 250,
+        protocol_version: 23,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 100_000,
+    });
+    let (client, _admin, player) = setup_with_admin(&env);
+    client.add_boost(
+        &player,
+        &Boost {
+            id: 1,
+            boost_type: BoostType::Additive,
+            value: 1000,
+            priority: 0,
+            expires_at_ledger: 100,
+        },
+    );
+    client.add_boost(&player, &boost(2, BoostType::Additive, 500, 0));
+    env.ledger().set(LedgerInfo {
+        sequence_number: 200,
+        timestamp: 1000,
+        protocol_version: 23,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 100_000,
+    });
+    let active = client.get_active_boosts(&player);
+    assert_eq!(active.len(), 1);
+    assert_eq!(active.get(0).unwrap().id, 2);
+}
+
+#[test]
+fn test_get_active_boosts_empty_when_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, player) = setup_with_admin(&env);
+    assert_eq!(client.get_active_boosts(&player).len(), 0);
+}

--- a/contract/contracts/tycoon-boost-system/src/time_boundary_tests.rs
+++ b/contract/contracts/tycoon-boost-system/src/time_boundary_tests.rs
@@ -219,3 +219,71 @@ fn test_expiry_boundary_at_genesis() {
     set_seq(&env, 1);
     assert_eq!(client.calculate_total_boost(&player), 10000);
 }
+
+// ── get_active_boosts time-aware filtering ────────────────────────────────────
+
+/// `get_active_boosts` excludes boosts whose `expires_at_ledger <= current_ledger`.
+#[test]
+fn test_get_active_boosts_filters_expired() {
+    let env = make_env();
+    let (client, player) = setup(&env);
+
+    set_seq(&env, 50);
+    client.add_boost(&player, &additive(1, 500, 100)); // expires at 100
+    client.add_boost(&player, &additive(2, 200, 0));   // never expires
+
+    set_seq(&env, 100); // boost 1 is now expired (100 <= 100)
+    let active = client.get_active_boosts(&player);
+    assert_eq!(active.len(), 1);
+    assert_eq!(active.get(0).unwrap().id, 2);
+}
+
+/// `get_active_boosts` returns all boosts when none have expired yet.
+#[test]
+fn test_get_active_boosts_all_active() {
+    let env = make_env();
+    let (client, player) = setup(&env);
+
+    set_seq(&env, 50);
+    client.add_boost(&player, &additive(1, 500, 200));
+    client.add_boost(&player, &additive(2, 200, 0));
+
+    set_seq(&env, 100); // both still active
+    assert_eq!(client.get_active_boosts(&player).len(), 2);
+}
+
+// ── prune_expired_boosts return count ────────────────────────────────────────
+
+/// `prune_expired_boosts` returns the exact count of boosts removed.
+#[test]
+fn test_prune_expired_boosts_returns_count() {
+    let env = make_env();
+    let (client, player) = setup(&env);
+
+    set_seq(&env, 50);
+    client.add_boost(&player, &additive(1, 500, 100));  // expires at 100
+    client.add_boost(&player, &additive(2, 300, 150));  // expires at 150
+    client.add_boost(&player, &additive(3, 200, 0));    // never expires
+
+    set_seq(&env, 200); // boosts 1 and 2 are both expired
+    let removed = client.prune_expired_boosts(&player);
+    assert_eq!(removed, 2);
+    assert_eq!(client.get_active_boosts(&player).len(), 1);
+}
+
+// ── multiple boosts with mixed expiry ─────────────────────────────────────────
+
+/// Expired boosts do not contribute to `calculate_total_boost`.
+#[test]
+fn test_mixed_expiry_only_active_contribute() {
+    let env = make_env();
+    let (client, player) = setup(&env);
+
+    set_seq(&env, 50);
+    client.add_boost(&player, &additive(1, 1000, 100)); // expires at 100: +10%
+    client.add_boost(&player, &additive(2, 500, 0));    // never expires: +5%
+
+    set_seq(&env, 100); // boost 1 expired
+    // Only boost 2 active: 10000 * (1 + 0.05) = 10500
+    assert_eq!(client.calculate_total_boost(&player), 10500);
+}

--- a/contract/contracts/tycoon-collectibles/src/coverage_tests.rs
+++ b/contract/contracts/tycoon-collectibles/src/coverage_tests.rs
@@ -258,3 +258,113 @@ fn test_is_contract_paused_reflects_state() {
     client.set_pause(&false);
     assert!(!client.is_contract_paused());
 }
+
+// ── restock_collectible ───────────────────────────────────────────────────────
+
+/// `restock_collectible` adds to the existing stock of a collectible.
+#[test]
+fn test_restock_collectible_increases_stock() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TycoonCollectibles, ());
+    let client = TycoonCollectiblesClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_id = client.stock_shop(&3, &1, &1, &0, &0);
+    assert_eq!(client.get_stock(&token_id), 3);
+
+    client.restock_collectible(&token_id, &5);
+    assert_eq!(client.get_stock(&token_id), 8);
+}
+
+// ── buy_collectible_from_shop with USDC ──────────────────────────────────────
+
+/// `buy_collectible_from_shop` with `use_usdc=true` deducts USDC from the buyer.
+#[test]
+fn test_buy_with_usdc_deducts_usdc_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TycoonCollectibles, ());
+    let client = TycoonCollectiblesClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let tyc_token = make_token(&env, &admin);
+    let usdc_token = make_token(&env, &admin);
+    client.init_shop(&tyc_token, &usdc_token);
+
+    // perk=2 TaxRefund (tiered), strength=2, usdc_price=300
+    let token_id = client.stock_shop(&5, &2, &2, &0, &300);
+
+    let buyer = Address::generate(&env);
+    StellarAssetClient::new(&env, &usdc_token).mint(&buyer, &1000);
+
+    client.buy_collectible_from_shop(&buyer, &token_id, &true);
+
+    assert_eq!(client.balance_of(&buyer, &token_id), 1);
+    // Buyer spent 300 USDC
+    assert_eq!(TokenClient::new(&env, &usdc_token).balance(&buyer), 700);
+}
+
+// ── mint_collectible ──────────────────────────────────────────────────────────
+
+/// `mint_collectible` creates a new token and mints it to the recipient.
+#[test]
+fn test_mint_collectible_creates_token_for_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TycoonCollectibles, ());
+    let client = TycoonCollectiblesClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let recipient = Address::generate(&env);
+    // perk=3 RentBoost (non-tiered), strength=0
+    let token_id = client.mint_collectible(&admin, &recipient, &3, &0);
+    assert_eq!(client.balance_of(&recipient, &token_id), 1);
+}
+
+/// `mint_collectible` rejects a non-admin, non-minter caller.
+#[test]
+fn test_mint_collectible_rejects_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TycoonCollectibles, ());
+    let client = TycoonCollectiblesClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let attacker = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    // attacker is neither admin nor minter
+    assert!(client
+        .try_mint_collectible(&attacker, &recipient, &3, &0)
+        .is_err());
+}
+
+// ── burn ─────────────────────────────────────────────────────────────────────
+
+/// `burn` reduces the owner's balance by the specified amount.
+#[test]
+fn test_burn_reduces_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TycoonCollectibles, ());
+    let client = TycoonCollectiblesClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&env);
+    // mint_collectible creates a new token and mints 1 unit to owner
+    let token_id = client.mint_collectible(&admin, &owner, &3, &0);
+    assert_eq!(client.balance_of(&owner, &token_id), 1);
+
+    client.burn(&owner, &token_id, &1);
+    assert_eq!(client.balance_of(&owner, &token_id), 0);
+}

--- a/contract/contracts/tycoon-collectibles/src/entrypoint_auth_tests.rs
+++ b/contract/contracts/tycoon-collectibles/src/entrypoint_auth_tests.rs
@@ -110,3 +110,41 @@ fn test_set_token_metadata_rejects_without_auth() {
         )
         .is_err());
 }
+
+#[test]
+fn test_set_token_perk_rejects_without_auth() {
+    let (env, client, id) = setup();
+    let token_id = client.stock_shop(&1, &3, &0, &0, &0);
+    env.mock_auths(&[]);
+    let c = TycoonCollectiblesClient::new(&env, &id);
+    assert!(c.try_set_token_perk(&token_id, &Perk::ExtraTurn, &0).is_err());
+}
+
+#[test]
+fn test_set_backend_minter_rejects_without_auth() {
+    let (env, _, id) = setup();
+    env.mock_auths(&[]);
+    let c = TycoonCollectiblesClient::new(&env, &id);
+    let dummy = soroban_sdk::Address::generate(&env);
+    assert!(c.try_set_backend_minter(&dummy).is_err());
+}
+
+#[test]
+fn test_stock_shop_rejects_without_auth() {
+    let (env, _, id) = setup();
+    env.mock_auths(&[]);
+    let c = TycoonCollectiblesClient::new(&env, &id);
+    assert!(c.try_stock_shop(&5, &1, &1, &100, &0).is_err());
+}
+
+#[test]
+fn test_mint_collectible_rejects_non_admin_caller() {
+    let (env, _, id) = setup(); // mock_all_auths is active
+    let c = TycoonCollectiblesClient::new(&env, &id);
+    let attacker = soroban_sdk::Address::generate(&env);
+    let recipient = soroban_sdk::Address::generate(&env);
+    // attacker is not admin or minter — Unauthorized even with mocked auth
+    assert!(c
+        .try_mint_collectible(&attacker, &recipient, &3, &0)
+        .is_err());
+}


### PR DESCRIPTION
## Summary

- **tycoon-boost-system / test.rs** (#1045): Added 6 tests covering `DuplicateId`, `InvalidValue`, `InvalidExpiry`, `CapExceeded` error paths for `add_boost`, plus `get_active_boosts` filtering (empty and expired-exclusion cases).
- **tycoon-boost-system / time_boundary_tests.rs** (#1046): Added 4 tests — `get_active_boosts` time-aware filtering (expired and all-active), `prune_expired_boosts` return-count verification, and mixed-expiry boost contribution check.
- **tycoon-collectibles / coverage_tests.rs** (#1047): Added 5 tests — `restock_collectible` stock increase, `buy_collectible_from_shop` with USDC, `mint_collectible` happy path, `mint_collectible` unauthorized rejection, and `burn` balance reduction.
- **tycoon-collectibles / entrypoint_auth_tests.rs** (#1048): Added 4 tests — `set_token_perk`, `set_backend_minter`, `stock_shop` all reject without admin auth; `mint_collectible` rejects a non-admin/non-minter caller.

## Test plan

- [ ] `cargo test` passes in `contract/contracts/tycoon-boost-system`
- [ ] `cargo test` passes in `contract/contracts/tycoon-collectibles`
- [ ] No regressions in existing tests

Closes #1045
Closes #1046
Closes #1047
Closes #1048