### PR TITLE
test(tycoon-token): add full-season lifecycle simulation scenario

### DIFF
--- a/contract/contracts/tycoon-token/src/simulation_scenarios.rs
+++ b/contract/contracts/tycoon-token/src/simulation_scenarios.rs
@@ -85,4 +85,47 @@ mod tests {
 
         assert_eq!(client.balance(&holder), 1_700_000_000_000_000_000_000);
     }
+
+    /// A full season: mint rewards into a pool, distribute to a player, the
+    /// player spends via a delegated game contract, fees are burned from the
+    /// proceeds, and the admin rotates out — verifying total_supply stays
+    /// consistent across the whole chained flow (mint/transfer/approve/
+    /// transfer_from/burn_from/set_admin all interacting on the same state).
+    #[test]
+    fn sim_06_full_season_lifecycle() {
+        let (_, client, _admin) = setup();
+        let pool = Address::generate(&client.env);
+        let player = Address::generate(&client.env);
+        let game = Address::generate(&client.env);
+        let treasury = Address::generate(&client.env);
+        let new_admin = Address::generate(&client.env);
+
+        // Season rewards minted into the pool, then paid out to the player.
+        client.mint(&pool, &8_000_000_000_000_000_000_000);
+        client.transfer(&pool, &player, &8_000_000_000_000_000_000_000);
+        assert_eq!(client.total_supply(), SUPPLY + 8_000_000_000_000_000_000_000);
+
+        // Player delegates spend authority to the game for an in-game purchase.
+        client.approve(&player, &game, &3_000_000_000_000_000_000_000, &0);
+        client.transfer_from(&game, &player, &treasury, &3_000_000_000_000_000_000_000);
+        assert_eq!(client.balance(&player), 5_000_000_000_000_000_000_000);
+        assert_eq!(client.allowance(&player, &game), 0);
+
+        // Treasury burns a protocol fee out of the proceeds via a delegated burn.
+        client.approve(&treasury, &game, &1_000_000_000_000_000_000_000, &0);
+        client.burn_from(&game, &treasury, &600_000_000_000_000_000_000);
+        assert_eq!(client.balance(&treasury), 2_400_000_000_000_000_000_000);
+
+        // Admin rotates at end of season; new admin can still mint.
+        client.set_admin(&new_admin);
+        client.mint(&player, &1_000_000_000_000_000_000_000);
+        assert_eq!(client.admin(), new_admin);
+
+        // Supply reflects every mint/burn across the whole chain, nothing lost.
+        assert_eq!(
+            client.total_supply(),
+            SUPPLY + 8_000_000_000_000_000_000_000 - 600_000_000_000_000_000_000
+                + 1_000_000_000_000_000_000_000
+        );
+    }
 }


### PR DESCRIPTION
Closes #1030

Adds `sim_06_full_season_lifecycle` to `simulation_scenarios.rs`, chaining `mint`/`transfer`/`approve`/`transfer_from`/`burn_from`/`set_admin` in one realistic flow and asserting `total_supply` stays consistent across the whole chain. The existing 5 scenarios each cover one isolated pattern; none exercise multiple operations interacting on shared state in sequence.

**Validation:** no network access to fetch `soroban-sdk` in my sandbox. Verified via `rustc --emit=metadata` partial-resolution checks: identical pre-existing error profile before/after (128 errors, same categories/counts) -- confirms zero new errors introduced.