### PR TITLE
docs(token): complete security review checklist header and sign-off

### DIFF
--- a/contract/contracts/tycoon-token/SECURITY_REVIEW_CHECKLIST.md
+++ b/contract/contracts/tycoon-token/SECURITY_REVIEW_CHECKLIST.md
@@ -1,5 +1,11 @@
 # Security Review Checklist — tycoon-token (SW-CON-TOKEN-001)
 
+**Issue:** #1028
+**Contract:** `contract/contracts/tycoon-token/src/lib.rs`
+**SDK:** soroban-sdk 23
+**Reviewer:** (assign before merge)
+**Status:** All checklist items below verified against current source.
+
 ## Authorization & Access Control
 
 - [x] `initialize` — one-time guard via `Initialized` key; no auth required by design


### PR DESCRIPTION
## Summary

- Add the formal review header (issue link, contract path, SDK version, reviewer sign-off line) to the tycoon-token security review checklist, matching the header convention used by the reward-system checklist.
- Checklist items were re-verified against the current `tycoon-token/src/lib.rs`; no findings changed.

## Validation

- Markdown-only change; no Rust sources modified, so build/format/lint/typecheck outputs are unaffected.
- Security behaviors enumerated in the checklist remain covered by `security_review_tests.rs`, `invariant_tests.rs`, and `access_control_tests.rs`.

Closes #1028