### PR TITLE
3 issues

### DIFF
--- a/contract/contracts/tycoon-boost-system/SECURITY_REVIEW_CHECKLIST.md
+++ b/contract/contracts/tycoon-boost-system/SECURITY_REVIEW_CHECKLIST.md
@@ -26,7 +26,7 @@
 ## Arithmetic Safety
 
 - [x] `apply_stacking_rules` — multiplicative chain uses `u64` intermediate: `multiplicative_total as u64 * boost.value as u64 / 10000`. Max intermediate value is `u32::MAX * u32::MAX ≈ 1.8 × 10¹⁹` which fits in `u64::MAX ≈ 1.8 × 10¹⁹`. Tight but safe for realistic values; the final `as u32` cast truncates silently if the chain product exceeds `u32::MAX`.
-- [ ] **FINDING SEC-02** — `additive_total += boost.value` uses wrapping addition on `u32`. With 10 boosts each at `value = u32::MAX / 10 + 1` the sum wraps, producing a lower-than-expected total. Covered by test `test_additive_overflow_wraps` in `security_review_tests.rs` (documents current behavior; fix tracked separately).
+- [x] **FINDING SEC-02 (corrected)** — `additive_total += boost.value` uses the checked `+=` operator. This workspace's `[profile.release]` (`contract/Cargo.toml`) explicitly sets `overflow-checks = true`, so exceeding `u32::MAX` **panics** in production, not wraps. With 10 boosts each at `value = u32::MAX / 10 + 1`, `calculate_total_boost` panics for that player. This is a DoS/availability concern (any caller can trigger it on their own data), not a silent-miscalculation one. Covered by test `test_additive_overflow_panics` in `security_review_tests.rs`; fix (e.g. saturating sum or a lower per-boost value cap) tracked separately.
 - [ ] **FINDING SEC-03** — Final mixed formula `(multiplicative_total as u64 * (10000 + additive_total as u64) / 10000) as u32` silently truncates to `u32` if the result exceeds `u32::MAX`. Covered by test `test_mixed_overflow_truncates` (documents current behavior).
 - [x] `prune_expired` — no arithmetic; only ledger sequence comparison.
 - [x] `calculate_total_boost` — delegates entirely to `apply_stacking_rules`; no independent arithmetic.
@@ -77,6 +77,6 @@
 | ID | Severity | Finding | Status |
 |----|----------|---------|--------|
 | SEC-01 | Low | `admin_grant_boost` / `admin_revoke_boost` auth rejection not tested without `mock_all_auths` | Tested in `security_review_tests.rs` |
-| SEC-02 | Low | `additive_total += boost.value` wraps on `u32` overflow | Documented by test; fix tracked |
+| SEC-02 | Low | `additive_total += boost.value` panics on `u32` overflow (corrected from "wraps" — `overflow-checks = true` in release profile) | Documented by test; fix tracked |
 | SEC-03 | Low | Final mixed-stacking cast `as u32` silently truncates | Documented by test; fix tracked |
 | SEC-04 | Info | Admin key is immutable — no rotation path | Accepted for current scope |

--- a/contract/contracts/tycoon-boost-system/src/security_review_tests.rs
+++ b/contract/contracts/tycoon-boost-system/src/security_review_tests.rs
@@ -462,30 +462,30 @@ mod tests {
         assert_eq!(client.get_boosts(&player).len(), 1);
     }
 
-    // ── SEC-02: additive_total u32 wrapping overflow ──────────────────────────
+    // ── SEC-02: additive_total u32 overflow panics (does not wrap) ────────────
 
-    /// Documents that additive_total wraps on u32 overflow.
-    /// Pins current (wrapping) behavior so any future fix is visible.
+    /// `additive_total += boost.value` uses the checked `+=` operator, and this
+    /// workspace's `[profile.release]` sets `overflow-checks = true` (see
+    /// `contract/Cargo.toml`), so this overflow panics in both debug and
+    /// release builds — it does NOT silently wrap. This is a DoS/availability
+    /// concern (any caller can make `calculate_total_boost` panic for a player
+    /// with enough additive boosts stacked), not a silent-miscalculation one.
+    /// Pins the panic so a future change to the arithmetic (e.g. switching to
+    /// `wrapping_add` or a saturating sum) is visible here.
     #[test]
-    #[should_panic]
-    fn test_additive_overflow_wraps() {
+    #[should_panic(expected = "attempt to add with overflow")]
+    fn test_additive_overflow_panics() {
         let env = make_env();
         let (client, _, player) = setup(&env);
 
-        // Each value = 429_496_730 (≈ u32::MAX / 10 + 1)
-        // 10 × 429_496_730 = 4_294_967_300 which wraps to 4 in u32
+        // Each value = 429_496_730 (≈ u32::MAX / 10 + 1); summing 10 of them
+        // exceeds u32::MAX and panics under overflow-checks=true.
         let per_boost: u32 = u32::MAX / 10 + 1;
         for i in 0..10u128 {
             client.add_boost(&player, &nb(i, per_boost));
         }
 
-        let total = client.calculate_total_boost(&player);
-        let correct_additive_sum = (per_boost as u64) * 10;
-        let expected_if_no_overflow = (10000u64 * (10000 + correct_additive_sum) / 10000) as u32;
-        assert_ne!(
-            total, expected_if_no_overflow,
-            "SEC-02: additive overflow no longer wraps — update checklist"
-        );
+        client.calculate_total_boost(&player);
     }
 
     // ── SEC-03: mixed-stacking final cast truncation ──────────────────────────


### PR DESCRIPTION

closes #1043 
closes #1042 
closes #1041 




fix(tycoon-boost-system): correct SEC-02 finding from wraps to panics

SECURITY_REVIEW_CHECKLIST.md and test_additive_overflow_wraps both claimed additive_total += boost.value silently wraps on u32 overflow. That's wrong for this codebase: contract/Cargo.toml's [profile.release] explicitly sets overflow-checks = true, so this += panics in both debug and release builds -- it never wraps. The old test's #[should_panic] (no message) already proved this; the dead assert_ne! code after it that compared against a 'wrapped' value was unreachable.

Renamed to test_additive_overflow_panics, pinned the exact panic message, and removed the unreachable comparison code. Updated the checklist's SEC-02 entry and Findings Summary row to describe this accurately as a DoS/availability concern (callable by anyone on their own data) rather than a silent-miscalculation one. Left the historical CHANGELOG.md reference to the old test name untouched -- it documents what was true at that past release, not current behavior.