### PR TITLE
feat(tycoon-lib): fix broken test structure and expand unit/integration coverage

### DIFF
--- a/contract/contracts/tycoon-lib/src/fees_coverage_tests.rs
+++ b/contract/contracts/tycoon-lib/src/fees_coverage_tests.rs
@@ -1,16 +1,22 @@
-/// # tycoon-lib fees — coverage gap tests (SW-001)
+/// # tycoon-lib fees — coverage gap tests
 ///
 /// Fills branches not exercised by the existing `fees::tests` module:
 ///
 /// | Gap | Test(s) |
 /// |-----|---------|
 /// | All fees sum to exactly 10 000 bps (100%) — residue is zero | `test_fees_sum_to_100_pct_no_residue` |
-/// | Total fees exceed 10 000 bps — saturating_sub prevents underflow | `test_fees_exceed_100_pct_residue_saturates` |
+/// | Total fees exceed 10 000 bps — invalid config returns all as residue | `test_fees_exceed_100_pct_handled_gracefully` |
 /// | Large amount near u128 ceiling — no overflow in multiplication | `test_large_amount_no_overflow` |
 /// | Single fee component, others zero | `test_single_fee_component_only` |
 /// | Amount = 1 (minimum unit) — floor division produces correct residue | `test_amount_one_floor_division` |
 /// | All three fees are equal (symmetric split) | `test_symmetric_three_way_split` |
 /// | platform_fee_bps = 10 000 (100%) — full amount to platform | `test_platform_takes_all` |
+/// | creator_fee_bps = 10 000 (100%) — full amount to creator | `test_creator_takes_all` |
+/// | pool_fee_bps = 10 000 (100%) — full amount to pool | `test_pool_takes_all` |
+/// | Amount zero — all outputs are zero | `test_amount_zero_handled_gracefully` |
+/// | All bps zero — residue equals input | `test_fees_all_zero_bps` |
+/// | Boundary validity: exactly 10 000 valid, 10 001 invalid | `test_fee_config_edge_case_validity` |
+/// | Table-driven invariant: split + residue == input | `test_invariant_sum_equals_input_table` |
 #[cfg(test)]
 mod tests {
     use crate::fees::{calculate_fee_split, FeeConfig};
@@ -24,16 +30,6 @@ mod tests {
             platform_address: soroban_sdk::Address::generate(env),
             pool_address: soroban_sdk::Address::generate(env),
         }
-    }
-
-    #[test]
-    fn test_fee_config_is_valid() {
-        let env = Env::default();
-        let valid_config = cfg(&env, 2500, 2500, 5000);
-        assert!(valid_config.is_valid());
-
-        let invalid_config = cfg(&env, 6000, 6000, 6000);
-        assert!(!invalid_config.is_valid());
     }
 
     #[test]
@@ -62,20 +58,22 @@ mod tests {
         );
     }
 
-    /// Total fees exceed 10 000 bps — saturating_sub must prevent underflow.
+    /// Total fees exceed 10 000 bps — invalid config returns entire amount as residue.
     #[test]
     fn test_fees_exceed_100_pct_handled_gracefully() {
         let env = Env::default();
         // 60% + 60% + 60% = 180% — invalid config
         let config = cfg(&env, 6000, 6000, 6000);
         let split = calculate_fee_split(100, &config);
-        
-        // Due to graceful handling of invalid configs, all goes to residue
+
         assert_eq!(split.platform_amount, 0);
         assert_eq!(split.creator_amount, 0);
         assert_eq!(split.pool_amount, 0);
-        assert_eq!(split.residue, 100, "Invalid fee config must gracefully return amount as residue");
-        
+        assert_eq!(
+            split.residue, 100,
+            "Invalid fee config must gracefully return amount as residue"
+        );
+
         let sum = split.platform_amount + split.creator_amount + split.pool_amount + split.residue;
         assert_eq!(sum, 100);
     }
@@ -87,7 +85,7 @@ mod tests {
         // Use 1% fees to keep amounts well within u128
         let config = cfg(&env, 100, 100, 100);
         // u128::MAX / 10000 ≈ 3.4e34 — safe for 1% fee
-        let large: u128 = u128::MAX / 10_001; // stays within safe range
+        let large: u128 = u128::MAX / 10_001;
         let split = calculate_fee_split(large, &config);
         let sum = split.platform_amount + split.creator_amount + split.pool_amount + split.residue;
         assert_eq!(sum, large, "sum must equal input for large amounts");
@@ -111,7 +109,6 @@ mod tests {
         let env = Env::default();
         let config = cfg(&env, 250, 500, 1000); // 2.5% + 5% + 10%
         let split = calculate_fee_split(1, &config);
-        // 1 * anything / 10000 = 0 (floor)
         assert_eq!(split.platform_amount, 0);
         assert_eq!(split.creator_amount, 0);
         assert_eq!(split.pool_amount, 0);
@@ -144,29 +141,6 @@ mod tests {
         assert_eq!(split.residue, 0);
     }
 
-    /// Table-driven: invariant holds for a range of amounts and fee configs.
-    #[test]
-    fn test_invariant_sum_equals_input_table() {
-        let env = Env::default();
-        let cases: &[(u32, u32, u32, u128)] = &[
-            (100, 200, 300, 0),
-            (100, 200, 300, 1),
-            (100, 200, 300, 9999),
-            (100, 200, 300, 10_000),
-            (100, 200, 300, 1_000_000),
-            (0, 0, 0, 999_999_999),
-            (5000, 3000, 2000, 10_000), // exactly 100%
-        ];
-        for &(p, c, pool, amount) in cases {
-            let config = cfg(&env, p, c, pool);
-            let split = calculate_fee_split(amount, &config);
-            let sum =
-                split.platform_amount + split.creator_amount + split.pool_amount + split.residue;
-            assert_eq!(
-                sum, amount,
-                "invariant failed: p={p} c={c} pool={pool} amount={amount}"
-            );
-        }
     #[test]
     fn test_creator_takes_all() {
         let env = Env::default();
@@ -221,5 +195,61 @@ mod tests {
         // 10001 should be invalid
         let config_over = cfg(&env, 3334, 3334, 3333);
         assert!(!config_over.is_valid());
+    }
+
+    /// Table-driven: invariant holds for a range of amounts and fee configs.
+    #[test]
+    fn test_invariant_sum_equals_input_table() {
+        let env = Env::default();
+        let cases: &[(u32, u32, u32, u128)] = &[
+            (100, 200, 300, 0),
+            (100, 200, 300, 1),
+            (100, 200, 300, 9999),
+            (100, 200, 300, 10_000),
+            (100, 200, 300, 1_000_000),
+            (0, 0, 0, 999_999_999),
+            (5000, 3000, 2000, 10_000), // exactly 100%
+        ];
+        for &(p, c, pool, amount) in cases {
+            let config = cfg(&env, p, c, pool);
+            let split = calculate_fee_split(amount, &config);
+            let sum =
+                split.platform_amount + split.creator_amount + split.pool_amount + split.residue;
+            assert_eq!(
+                sum, amount,
+                "invariant failed: p={p} c={c} pool={pool} amount={amount}"
+            );
+        }
+    }
+
+    /// Integration: fee split result fields are never individually larger than the input.
+    #[test]
+    fn test_each_field_never_exceeds_input() {
+        let env = Env::default();
+        let config = cfg(&env, 3000, 3000, 3000);
+        let amount = 9999u128;
+        let split = calculate_fee_split(amount, &config);
+        assert!(split.platform_amount <= amount);
+        assert!(split.creator_amount <= amount);
+        assert!(split.pool_amount <= amount);
+        assert!(split.residue <= amount);
+    }
+
+    /// Integration: is_valid is consistent with calculate_fee_split behaviour.
+    #[test]
+    fn test_is_valid_consistent_with_split() {
+        let env = Env::default();
+        let valid = cfg(&env, 1000, 2000, 3000);
+        assert!(valid.is_valid());
+        let split = calculate_fee_split(10_000, &valid);
+        assert!(split.platform_amount > 0 || split.creator_amount > 0 || split.pool_amount > 0);
+
+        let invalid = cfg(&env, 5000, 5000, 5000);
+        assert!(!invalid.is_valid());
+        let split_invalid = calculate_fee_split(10_000, &invalid);
+        assert_eq!(split_invalid.platform_amount, 0);
+        assert_eq!(split_invalid.creator_amount, 0);
+        assert_eq!(split_invalid.pool_amount, 0);
+        assert_eq!(split_invalid.residue, 10_000);
     }
 }

--- a/contract/contracts/tycoon-lib/src/lib.rs
+++ b/contract/contracts/tycoon-lib/src/lib.rs
@@ -89,6 +89,77 @@ pub enum PlayerSymbol {
 }
 
 // ============================================================
+// Integration tests
+// ============================================================
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+
+    /// GameStatus transitions follow the expected Pending → Ongoing → Ended sequence.
+    #[test]
+    fn test_game_status_lifecycle_order() {
+        let lifecycle = [GameStatus::Pending, GameStatus::Ongoing, GameStatus::Ended];
+        assert_eq!(lifecycle[0], GameStatus::Pending);
+        assert_eq!(lifecycle[1], GameStatus::Ongoing);
+        assert_eq!(lifecycle[2], GameStatus::Ended);
+        assert_ne!(lifecycle[0], lifecycle[1]);
+        assert_ne!(lifecycle[1], lifecycle[2]);
+    }
+
+    /// A public game does not require a join code; a private game does.
+    #[test]
+    fn test_game_type_access_logic() {
+        let requires_code = |gt: GameType| matches!(gt, GameType::PrivateGame);
+        assert!(!requires_code(GameType::PublicGame));
+        assert!(requires_code(GameType::PrivateGame));
+    }
+
+    /// All eight PlayerSymbol variants are reachable and unique.
+    #[test]
+    fn test_all_player_symbols_unique() {
+        let symbols = [
+            PlayerSymbol::Hat,
+            PlayerSymbol::Car,
+            PlayerSymbol::Dog,
+            PlayerSymbol::Thimble,
+            PlayerSymbol::Iron,
+            PlayerSymbol::Battleship,
+            PlayerSymbol::Boot,
+            PlayerSymbol::Wheelbarrow,
+        ];
+        for (i, a) in symbols.iter().enumerate() {
+            for (j, b) in symbols.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+
+    /// Copy semantics: types can be moved and used again without explicit clone.
+    #[test]
+    fn test_copy_semantics() {
+        let status = GameStatus::Ongoing;
+        let a = status;
+        let b = status;
+        assert_eq!(a, b);
+
+        let gt = GameType::PublicGame;
+        let x = gt;
+        let y = gt;
+        assert_eq!(x, y);
+
+        let sym = PlayerSymbol::Car;
+        let p = sym;
+        let q = sym;
+        assert_eq!(p, q);
+    }
+}
+
+// ============================================================
 // Tests
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Fixes duplicate `test_fee_config_is_valid` function in `fees_coverage_tests.rs` (compile error)
- Fixes malformed `test_invariant_sum_equals_input_table` where subsequent tests were nested inside it due to missing closing braces
- Adds `integration_tests` module in `lib.rs` covering GameStatus lifecycle, GameType access logic, PlayerSymbol uniqueness, and Copy semantics
- Adds two new integration tests to `fees_coverage_tests` for field bounds and is_valid/split consistency

## Test plan
- [ ] All tests in `fees_coverage_tests` compile and pass
- [ ] New `integration_tests` module in lib.rs covers enum domain logic and Copy semantics
- [ ] No regressions in `fees::tests` or existing tests

Closes #1009