### PR TITLE
test(tycoon-game): expand test coverage for #1057-#1060

### DIFF
--- a/contract/contracts/tycoon-game/src/admin_access_control_tests.rs
+++ b/contract/contracts/tycoon-game/src/admin_access_control_tests.rs
@@ -18,6 +18,8 @@
 /// | ACT-11  | Deprecated shims still work (backward-compat) |
 /// | ACT-12  | `remove_player_from_game` rejects address that is neither owner nor controller |
 /// | ACT-13  | `remove_player_from_game` accepts backend controller |
+/// | ACT-14  | `admin_transfer_ownership` rejects non-owner |
+/// | ACT-15  | `remove_player_from_game` accepts owner directly (no controller set) |
 #[cfg(test)]
 mod tests {
     use crate::{TycoonContract, TycoonContractClient};
@@ -292,5 +294,42 @@ mod tests {
         let player = Address::generate(&env);
         // Must not panic
         client.remove_player_from_game(&controller, &42, &player, &7);
+    }
+
+    // ── ACT-14: admin_transfer_ownership rejects non-owner ───────────────────
+
+    #[test]
+    #[should_panic]
+    fn act_14_transfer_ownership_rejects_non_owner() {
+        let env = Env::default();
+        let (contract_id, client, _owner, _tyc_id, _usdc_id) = setup(&env);
+
+        let attacker = Address::generate(&env);
+        let new_owner = Address::generate(&env);
+
+        env.mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "admin_transfer_ownership",
+                args: (&new_owner,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        client.admin_transfer_ownership(&new_owner);
+    }
+
+    // ── ACT-15: remove_player_from_game accepts owner directly ───────────────
+
+    #[test]
+    fn act_15_remove_player_accepts_owner_directly() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, owner, _, _) = setup(&env);
+
+        // No backend controller set — owner must still be accepted.
+        let player = Address::generate(&env);
+        client.remove_player_from_game(&owner, &10, &player, &3);
     }
 }

--- a/contract/contracts/tycoon-game/src/deprecated_entrypoints_tests.rs
+++ b/contract/contracts/tycoon-game/src/deprecated_entrypoints_tests.rs
@@ -75,11 +75,7 @@ mod tests {
 
     /// DEP-02: `withdraw_funds` shim transfers the requested amount and emits
     /// a `FundsWithdrawn` event, identical to `admin_withdraw_funds`.
-    // TODO: event assertion disabled — env.events().all() returns empty in this
-    // test module context despite the snapshot confirming emission. Investigate
-    // soroban-sdk v23 event collection behaviour across #[no_std] test modules.
     #[test]
-    #[ignore]
     fn dep_02_withdraw_funds_shim_transfers_tokens() {
         let env = Env::default();
         env.mock_all_auths();

--- a/contract/contracts/tycoon-game/src/events.rs
+++ b/contract/contracts/tycoon-game/src/events.rs
@@ -39,3 +39,106 @@ pub fn emit_ownership_transferred(env: &Env, old_owner: &Address, new_owner: &Ad
     #[allow(deprecated)]
     env.events().publish(topics, ());
 }
+
+/// # Events Unit Tests
+///
+/// Verifies that each emit helper publishes exactly one event and that the
+/// event data field contains the expected value.
+///
+/// | ID     | Scenario |
+/// |--------|----------|
+/// | EVT-01 | `emit_funds_withdrawn` publishes event with amount as data |
+/// | EVT-02 | `emit_player_removed_from_game` publishes event with turn_count as data |
+/// | EVT-03 | `emit_controller_updated` publishes one event |
+/// | EVT-04 | `emit_player_registered` publishes one event |
+/// | EVT-05 | `emit_ownership_transferred` publishes one event |
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Events},
+        Address, Env,
+    };
+
+    // ── EVT-01 ────────────────────────────────────────────────────────────────
+
+    /// EVT-01: `emit_funds_withdrawn` publishes one event whose data equals the amount.
+    #[test]
+    fn evt_01_emit_funds_withdrawn_data_equals_amount() {
+        let env = Env::default();
+        let token = Address::generate(&env);
+        let to = Address::generate(&env);
+
+        emit_funds_withdrawn(&env, &token, &to, 1_500);
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1, "EVT-01: exactly one event must be emitted");
+
+        let (_, _, data) = events.first().unwrap();
+        let emitted_amount: u128 = soroban_sdk::FromVal::from_val(&env, &data);
+        assert_eq!(emitted_amount, 1_500, "EVT-01: data must equal the amount");
+    }
+
+    // ── EVT-02 ────────────────────────────────────────────────────────────────
+
+    /// EVT-02: `emit_player_removed_from_game` publishes one event whose data equals turn_count.
+    #[test]
+    fn evt_02_emit_player_removed_data_equals_turn_count() {
+        let env = Env::default();
+        let player = Address::generate(&env);
+
+        emit_player_removed_from_game(&env, 42, &player, 7);
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1, "EVT-02: exactly one event must be emitted");
+
+        let (_, _, data) = events.first().unwrap();
+        let emitted_turns: u32 = soroban_sdk::FromVal::from_val(&env, &data);
+        assert_eq!(emitted_turns, 7, "EVT-02: data must equal turn_count");
+    }
+
+    // ── EVT-03 ────────────────────────────────────────────────────────────────
+
+    /// EVT-03: `emit_controller_updated` publishes exactly one event.
+    #[test]
+    fn evt_03_emit_controller_updated_publishes_event() {
+        let env = Env::default();
+        let controller = Address::generate(&env);
+
+        emit_controller_updated(&env, &controller);
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1, "EVT-03: exactly one event must be emitted");
+    }
+
+    // ── EVT-04 ────────────────────────────────────────────────────────────────
+
+    /// EVT-04: `emit_player_registered` publishes exactly one event.
+    #[test]
+    fn evt_04_emit_player_registered_publishes_event() {
+        let env = Env::default();
+        let player = Address::generate(&env);
+
+        emit_player_registered(&env, &player);
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1, "EVT-04: exactly one event must be emitted");
+    }
+
+    // ── EVT-05 ────────────────────────────────────────────────────────────────
+
+    /// EVT-05: `emit_ownership_transferred` publishes exactly one event.
+    #[test]
+    fn evt_05_emit_ownership_transferred_publishes_event() {
+        let env = Env::default();
+        let old_owner = Address::generate(&env);
+        let new_owner = Address::generate(&env);
+
+        emit_ownership_transferred(&env, &old_owner, &new_owner);
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1, "EVT-05: exactly one event must be emitted");
+    }
+}

--- a/contract/contracts/tycoon-game/src/game_coverage_tests.rs
+++ b/contract/contracts/tycoon-game/src/game_coverage_tests.rs
@@ -18,6 +18,13 @@
 /// | GCT-08 | `admin_set_cash_tier_value` stores and retrieves multiple tiers |
 /// | GCT-09 | `get_user` returns None for unregistered address |
 /// | GCT-10 | `register_player` emits an event |
+/// | GCT-11 | `initialize` rejects self-address for tyc_token |
+/// | GCT-12 | `register_player` rejects username shorter than 3 chars |
+/// | GCT-13 | `register_player` rejects username longer than 20 chars |
+/// | GCT-14 | `get_collectible_info` panics for nonexistent token_id |
+/// | GCT-15 | `get_cash_tier_value` panics for nonexistent tier |
+/// | GCT-16 | `admin_withdraw_funds` panics for invalid token address |
+/// | GCT-17 | `admin_withdraw_funds` panics when contract balance is insufficient |
 #[cfg(test)]
 mod tests {
     extern crate std;
@@ -336,5 +343,116 @@ mod tests {
             !events.is_empty(),
             "GCT-10: register_player must emit at least one event"
         );
+    }
+
+    // ── GCT-11 ───────────────────────────────────────────────────────────────
+
+    /// GCT-11: `initialize` rejects a token address that equals the contract address.
+    #[test]
+    #[should_panic(expected = "Invalid address: cannot be the contract itself")]
+    fn gct_11_initialize_rejects_self_address_as_tyc_token() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(TycoonContract, ());
+        let client = TycoonContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let usdc_id = env
+            .register_stellar_asset_contract_v2(Address::generate(&env))
+            .address();
+        let reward = Address::generate(&env);
+
+        // Pass the contract's own address as tyc_token — must panic.
+        client.initialize(&contract_id, &usdc_id, &owner, &reward);
+    }
+
+    // ── GCT-12 ───────────────────────────────────────────────────────────────
+
+    /// GCT-12: `register_player` rejects a username shorter than 3 characters.
+    #[test]
+    #[should_panic(expected = "Username must be 3-20 characters")]
+    fn gct_12_register_player_rejects_short_username() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, _, _) = setup(&env);
+
+        let player = Address::generate(&env);
+        client.register_player(&soroban_sdk::String::from_str(&env, "ab"), &player);
+    }
+
+    // ── GCT-13 ───────────────────────────────────────────────────────────────
+
+    /// GCT-13: `register_player` rejects a username longer than 20 characters.
+    #[test]
+    #[should_panic(expected = "Username must be 3-20 characters")]
+    fn gct_13_register_player_rejects_long_username() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, _, _) = setup(&env);
+
+        let player = Address::generate(&env);
+        // 21 characters — one over the limit.
+        client.register_player(
+            &soroban_sdk::String::from_str(&env, "abcdefghijklmnopqrstu"),
+            &player,
+        );
+    }
+
+    // ── GCT-14 ───────────────────────────────────────────────────────────────
+
+    /// GCT-14: `get_collectible_info` panics when the token_id has never been set.
+    #[test]
+    #[should_panic(expected = "Collectible does not exist")]
+    fn gct_14_get_collectible_info_nonexistent_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, _, _) = setup(&env);
+
+        client.get_collectible_info(&9999);
+    }
+
+    // ── GCT-15 ───────────────────────────────────────────────────────────────
+
+    /// GCT-15: `get_cash_tier_value` panics when the tier has never been set.
+    #[test]
+    #[should_panic(expected = "Cash tier does not exist")]
+    fn gct_15_get_cash_tier_value_nonexistent_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, _, _) = setup(&env);
+
+        client.get_cash_tier_value(&9999);
+    }
+
+    // ── GCT-16 ───────────────────────────────────────────────────────────────
+
+    /// GCT-16: `admin_withdraw_funds` panics when the token is not TYC or USDC.
+    #[test]
+    #[should_panic(expected = "Invalid token address")]
+    fn gct_16_withdraw_funds_invalid_token_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, _, _) = setup(&env);
+
+        let unknown_token = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        client.admin_withdraw_funds(&unknown_token, &recipient, &100);
+    }
+
+    // ── GCT-17 ───────────────────────────────────────────────────────────────
+
+    /// GCT-17: `admin_withdraw_funds` panics when the contract balance is lower
+    /// than the requested amount.
+    #[test]
+    #[should_panic(expected = "Insufficient contract balance")]
+    fn gct_17_withdraw_funds_insufficient_balance_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, _, tyc_id, _) = setup(&env);
+
+        // Mint only 100 tokens but try to withdraw 500.
+        fund(&env, &tyc_id, &contract_id, 100);
+        let recipient = Address::generate(&env);
+        client.admin_withdraw_funds(&tyc_id, &recipient, &500);
     }
 }


### PR DESCRIPTION
Closes #1057,  closes #1058,  closes #1059,  closes #1060

## Changes

**admin_access_control_tests.rs** (#1057)
- ACT-14: `admin_transfer_ownership` rejects non-owner
- ACT-15: `remove_player_from_game` accepts owner directly (no controller set)

**deprecated_entrypoints_tests.rs** (#1058)
- DEP-02: removed `#[ignore]` and stale TODO — test now runs and verifies token transfer + FundsWithdrawn event

**events.rs** (#1059)
- EVT-01–05: unit tests for each emit helper (correct event count + data field)

**game_coverage_tests.rs** (#1060)
- GCT-11: `initialize` rejects self-address as tyc_token
- GCT-12/13: `register_player` rejects too-short / too-long username
- GCT-14: `get_collectible_info` panics for nonexistent token_id
- GCT-15: `get_cash_tier_value` panics for nonexistent tier
- GCT-16: `admin_withdraw_funds` panics for invalid token
- GCT-17: `admin_withdraw_funds` panics on insufficient balance