### PR TITLE
Platform/mux audit community chest improvements

### DIFF
--- a/backend/src/modules/community-chest/community-chest-dto-validation.spec.ts
+++ b/backend/src/modules/community-chest/community-chest-dto-validation.spec.ts
@@ -1,0 +1,141 @@
+import { validate } from 'class-validator';
+import { CreateCommunityChestDto } from './dto/create-community-chest.dto';
+import { UpdateCommunityChestDto } from './dto/update-community-chest.dto';
+import { ChanceType } from '../chance/enums/chance-type.enum';
+
+describe('Community Chest DTO Validation', () => {
+  describe('CreateCommunityChestDto', () => {
+    it('should pass with valid data', async () => {
+      const dto = new CreateCommunityChestDto();
+      dto.instruction = 'Advance to Go';
+      dto.type = ChanceType.MOVE;
+      dto.amount = 200;
+
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should fail when instruction is missing', async () => {
+      const dto = new CreateCommunityChestDto();
+      dto.type = ChanceType.REWARD;
+
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => e.property === 'instruction')).toBe(true);
+    });
+
+    it('should fail when instruction exceeds 500 characters', async () => {
+      const dto = new CreateCommunityChestDto();
+      dto.instruction = 'a'.repeat(501);
+      dto.type = ChanceType.REWARD;
+
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'instruction')).toBe(true);
+    });
+
+    it('should fail when type is missing', async () => {
+      const dto = new CreateCommunityChestDto();
+      dto.instruction = 'Go to Jail';
+
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'type')).toBe(true);
+    });
+
+    it('should fail when type is invalid', async () => {
+      const dto = new CreateCommunityChestDto();
+      dto.instruction = 'Test';
+      (dto as any).type = 'invalid_type';
+
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'type')).toBe(true);
+    });
+
+    it('should fail when amount is negative', async () => {
+      const dto = new CreateCommunityChestDto();
+      dto.instruction = 'Pay fine';
+      dto.type = ChanceType.PENALTY;
+      dto.amount = -100;
+
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'amount')).toBe(true);
+    });
+
+    it('should pass with optional fields omitted', async () => {
+      const dto = new CreateCommunityChestDto();
+      dto.instruction = 'Draw again';
+      dto.type = ChanceType.REWARD;
+
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass with amount as zero', async () => {
+      const dto = new CreateCommunityChestDto();
+      dto.instruction = 'Move to start';
+      dto.type = ChanceType.MOVE;
+      dto.amount = 0;
+
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should fail when position is negative', async () => {
+      const dto = new CreateCommunityChestDto();
+      dto.instruction = 'Go back';
+      dto.type = ChanceType.MOVE;
+      dto.position = -1;
+
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'position')).toBe(true);
+    });
+  });
+
+  describe('UpdateCommunityChestDto', () => {
+    it('should pass with valid partial data', async () => {
+      const dto = new UpdateCommunityChestDto();
+      dto.instruction = 'Updated instruction';
+
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass with all fields empty (all optional)', async () => {
+      const dto = new UpdateCommunityChestDto();
+
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should fail when instruction exceeds max length', async () => {
+      const dto = new UpdateCommunityChestDto();
+      dto.instruction = 'x'.repeat(501);
+
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'instruction')).toBe(true);
+    });
+
+    it('should fail when type is invalid', async () => {
+      const dto = new UpdateCommunityChestDto();
+      (dto as any).type = 'bad_type';
+
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'type')).toBe(true);
+    });
+
+    it('should fail when amount is negative', async () => {
+      const dto = new UpdateCommunityChestDto();
+      dto.amount = -50;
+
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'amount')).toBe(true);
+    });
+
+    it('should pass with valid type update', async () => {
+      const dto = new UpdateCommunityChestDto();
+      dto.type = ChanceType.PENALTY;
+
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/backend/src/modules/community-chest/community-chest-error-mapper.service.spec.ts
+++ b/backend/src/modules/community-chest/community-chest-error-mapper.service.spec.ts
@@ -1,0 +1,170 @@
+import { HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ValidationError } from 'class-validator';
+import {
+  CommunityChestErrorMapperService,
+  CommunityChestErrorCode,
+} from './community-chest-error-mapper.service';
+
+describe('CommunityChestErrorMapperService', () => {
+  let service: CommunityChestErrorMapperService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CommunityChestErrorMapperService],
+    }).compile();
+
+    service = module.get<CommunityChestErrorMapperService>(
+      CommunityChestErrorMapperService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('mapError', () => {
+    it('should map VALIDATION_ERROR to 400', () => {
+      const result = service.mapError(CommunityChestErrorCode.VALIDATION_ERROR);
+
+      expect(result.statusCode).toBe(HttpStatus.BAD_REQUEST);
+      expect(result.message).toBe('Validation failed');
+      expect(result.error).toBe(CommunityChestErrorCode.VALIDATION_ERROR);
+    });
+
+    it('should map NOT_FOUND to 404', () => {
+      const result = service.mapError(CommunityChestErrorCode.NOT_FOUND);
+
+      expect(result.statusCode).toBe(HttpStatus.NOT_FOUND);
+      expect(result.message).toContain('not found');
+    });
+
+    it('should map DUPLICATE_INSTRUCTION to 409', () => {
+      const result = service.mapError(
+        CommunityChestErrorCode.DUPLICATE_INSTRUCTION,
+      );
+
+      expect(result.statusCode).toBe(HttpStatus.CONFLICT);
+      expect(result.message).toContain('already exists');
+    });
+
+    it('should map INVALID_TYPE to 400', () => {
+      const result = service.mapError(CommunityChestErrorCode.INVALID_TYPE);
+
+      expect(result.statusCode).toBe(HttpStatus.BAD_REQUEST);
+      expect(result.message).toContain('Invalid card type');
+    });
+
+    it('should map INVALID_AMOUNT to 400', () => {
+      const result = service.mapError(CommunityChestErrorCode.INVALID_AMOUNT);
+
+      expect(result.statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('should map CREATE_FAILED to 500', () => {
+      const result = service.mapError(CommunityChestErrorCode.CREATE_FAILED);
+
+      expect(result.statusCode).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+    });
+
+    it('should map UPDATE_FAILED to 500', () => {
+      const result = service.mapError(CommunityChestErrorCode.UPDATE_FAILED);
+
+      expect(result.statusCode).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+    });
+
+    it('should include details when provided', () => {
+      const details = { instruction: ['must be a string'] };
+      const result = service.mapError(
+        CommunityChestErrorCode.VALIDATION_ERROR,
+        details,
+      );
+
+      expect(result.details).toEqual(details);
+    });
+  });
+
+  describe('mapValidationErrors', () => {
+    it('should format simple validation errors', () => {
+      const errors: ValidationError[] = [
+        {
+          property: 'instruction',
+          constraints: {
+            isString: 'instruction must be a string',
+            maxLength: 'instruction must be shorter than 500 characters',
+          },
+          children: [],
+          target: undefined,
+          value: undefined,
+        },
+      ];
+
+      const result = service.mapValidationErrors(errors);
+
+      expect(result.statusCode).toBe(HttpStatus.BAD_REQUEST);
+      expect(result.error).toBe(CommunityChestErrorCode.VALIDATION_ERROR);
+      expect(result.details).toBeDefined();
+      expect(result.details!['instruction']).toHaveLength(2);
+    });
+
+    it('should format nested validation errors', () => {
+      const errors: ValidationError[] = [
+        {
+          property: 'extra',
+          constraints: undefined,
+          children: [
+            {
+              property: 'nested',
+              constraints: { isString: 'nested must be a string' },
+              children: [],
+              target: undefined,
+              value: undefined,
+            },
+          ],
+          target: undefined,
+          value: undefined,
+        },
+      ];
+
+      const result = service.mapValidationErrors(errors);
+
+      expect(result.details).toBeDefined();
+      expect(result.details!['extra.nested']).toBeDefined();
+    });
+
+    it('should handle empty error list', () => {
+      const result = service.mapValidationErrors([]);
+
+      expect(result.statusCode).toBe(HttpStatus.BAD_REQUEST);
+      expect(result.details).toEqual({});
+    });
+  });
+
+  describe('getStatusCode', () => {
+    it('should return correct status code for known errors', () => {
+      expect(
+        service.getStatusCode(CommunityChestErrorCode.NOT_FOUND),
+      ).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it('should return 500 for unknown errors', () => {
+      expect(
+        service.getStatusCode('UNKNOWN' as CommunityChestErrorCode),
+      ).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe('getMessage', () => {
+    it('should return correct message for known errors', () => {
+      expect(
+        service.getMessage(CommunityChestErrorCode.DUPLICATE_INSTRUCTION),
+      ).toContain('already exists');
+    });
+
+    it('should return fallback for unknown errors', () => {
+      expect(
+        service.getMessage('UNKNOWN' as CommunityChestErrorCode),
+      ).toBe('An unexpected error occurred');
+    });
+  });
+});

--- a/backend/src/modules/community-chest/community-chest-error-mapper.service.ts
+++ b/backend/src/modules/community-chest/community-chest-error-mapper.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, HttpStatus } from '@nestjs/common';
+import { ValidationError } from 'class-validator';
+
+export interface CommunityChestMappedError {
+  statusCode: number;
+  message: string;
+  error: string;
+  details?: Record<string, string[]>;
+}
+
+export enum CommunityChestErrorCode {
+  VALIDATION_ERROR = 'COMMUNITY_CHEST_VALIDATION_ERROR',
+  NOT_FOUND = 'COMMUNITY_CHEST_NOT_FOUND',
+  DUPLICATE_INSTRUCTION = 'COMMUNITY_CHEST_DUPLICATE_INSTRUCTION',
+  INVALID_TYPE = 'COMMUNITY_CHEST_INVALID_TYPE',
+  INVALID_AMOUNT = 'COMMUNITY_CHEST_INVALID_AMOUNT',
+  CREATE_FAILED = 'COMMUNITY_CHEST_CREATE_FAILED',
+  UPDATE_FAILED = 'COMMUNITY_CHEST_UPDATE_FAILED',
+}
+
+@Injectable()
+export class CommunityChestErrorMapperService {
+  private readonly statusCodeMap: Record<string, number> = {
+    [CommunityChestErrorCode.VALIDATION_ERROR]: HttpStatus.BAD_REQUEST,
+    [CommunityChestErrorCode.NOT_FOUND]: HttpStatus.NOT_FOUND,
+    [CommunityChestErrorCode.DUPLICATE_INSTRUCTION]: HttpStatus.CONFLICT,
+    [CommunityChestErrorCode.INVALID_TYPE]: HttpStatus.BAD_REQUEST,
+    [CommunityChestErrorCode.INVALID_AMOUNT]: HttpStatus.BAD_REQUEST,
+    [CommunityChestErrorCode.CREATE_FAILED]: HttpStatus.INTERNAL_SERVER_ERROR,
+    [CommunityChestErrorCode.UPDATE_FAILED]: HttpStatus.INTERNAL_SERVER_ERROR,
+  };
+
+  private readonly messageMap: Record<string, string> = {
+    [CommunityChestErrorCode.VALIDATION_ERROR]: 'Validation failed',
+    [CommunityChestErrorCode.NOT_FOUND]: 'Community Chest card not found',
+    [CommunityChestErrorCode.DUPLICATE_INSTRUCTION]:
+      'A Community Chest card with this instruction already exists',
+    [CommunityChestErrorCode.INVALID_TYPE]:
+      'Invalid card type. Must be one of: reward, penalty, move',
+    [CommunityChestErrorCode.INVALID_AMOUNT]:
+      'Amount must be a non-negative integer',
+    [CommunityChestErrorCode.CREATE_FAILED]:
+      'Failed to create Community Chest card',
+    [CommunityChestErrorCode.UPDATE_FAILED]:
+      'Failed to update Community Chest card',
+  };
+
+  mapError(
+    errorCode: CommunityChestErrorCode,
+    details?: Record<string, string[]>,
+  ): CommunityChestMappedError {
+    return {
+      statusCode:
+        this.statusCodeMap[errorCode] ?? HttpStatus.INTERNAL_SERVER_ERROR,
+      message: this.messageMap[errorCode] ?? 'An unexpected error occurred',
+      error: errorCode,
+      details,
+    };
+  }
+
+  mapValidationErrors(errors: ValidationError[]): CommunityChestMappedError {
+    const details = this.formatValidationErrors(errors);
+
+    return {
+      statusCode: HttpStatus.BAD_REQUEST,
+      message: 'Validation failed',
+      error: CommunityChestErrorCode.VALIDATION_ERROR,
+      details,
+    };
+  }
+
+  private formatValidationErrors(
+    errors: ValidationError[],
+  ): Record<string, string[]> {
+    const formatted: Record<string, string[]> = {};
+
+    for (const error of errors) {
+      if (error.constraints) {
+        formatted[error.property] = Object.values(error.constraints);
+      }
+
+      if (error.children && error.children.length > 0) {
+        const nested = this.formatValidationErrors(error.children);
+        for (const key of Object.keys(nested)) {
+          formatted[`${error.property}.${key}`] = nested[key];
+        }
+      }
+    }
+
+    return formatted;
+  }
+
+  getStatusCode(errorCode: CommunityChestErrorCode): number {
+    return this.statusCodeMap[errorCode] ?? HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+
+  getMessage(errorCode: CommunityChestErrorCode): string {
+    return this.messageMap[errorCode] ?? 'An unexpected error occurred';
+  }
+}

--- a/backend/src/modules/community-chest/community-chest-pagination.spec.ts
+++ b/backend/src/modules/community-chest/community-chest-pagination.spec.ts
@@ -1,0 +1,261 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CommunityChestService } from './community-chest.service';
+import { CommunityChest } from './entities/community-chest.entity';
+import { CommunityChestErrorMapperService } from './community-chest-error-mapper.service';
+import {
+  GetCommunityChestListDto,
+  CommunityChestSortBy,
+  SortOrder,
+} from './dto/get-community-chest-list.dto';
+
+jest.mock('../../common/crypto-secure-random', () => ({
+  secureRandomInt: jest.fn(() => 0),
+}));
+
+const mockCards = [
+  { id: 1, instruction: 'Advance to Go', type: 'reward', amount: 200 },
+  { id: 2, instruction: 'Go to Jail', type: 'penalty', amount: 0 },
+  { id: 3, instruction: 'Pay fine', type: 'penalty', amount: 50 },
+];
+
+describe('CommunityChestService — Pagination & Stable Sorting', () => {
+  let service: CommunityChestService;
+  let mockQueryBuilder: {
+    andWhere: jest.Mock;
+    orderBy: jest.Mock;
+    addOrderBy: jest.Mock;
+    skip: jest.Mock;
+    take: jest.Mock;
+    getManyAndCount: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    mockQueryBuilder = {
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([mockCards, 3]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommunityChestService,
+        CommunityChestErrorMapperService,
+        {
+          provide: getRepositoryToken(CommunityChest),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+            count: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CommunityChestService>(CommunityChestService);
+  });
+
+  describe('pagination', () => {
+    it('should return paginated response with meta', async () => {
+      const query: GetCommunityChestListDto = { page: 1, limit: 10 };
+
+      const result = await service.findAll(query);
+
+      expect(result.data).toEqual(mockCards);
+      expect(result.meta).toBeDefined();
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(10);
+      expect(result.meta.totalItems).toBe(3);
+      expect(result.meta.totalPages).toBe(1);
+      expect(result.meta.hasNextPage).toBe(false);
+      expect(result.meta.hasPreviousPage).toBe(false);
+    });
+
+    it('should apply skip and take based on page and limit', async () => {
+      const query: GetCommunityChestListDto = { page: 2, limit: 2 };
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([
+        [mockCards[2]],
+        3,
+      ]);
+
+      const result = await service.findAll(query);
+
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(2);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(2);
+      expect(result.meta.page).toBe(2);
+      expect(result.meta.hasNextPage).toBe(false);
+      expect(result.meta.hasPreviousPage).toBe(true);
+    });
+
+    it('should clamp limit to max 100', async () => {
+      const query: GetCommunityChestListDto = { page: 1, limit: 500 };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(100);
+    });
+
+    it('should clamp limit minimum to 1', async () => {
+      const query: GetCommunityChestListDto = { page: 1, limit: 0 };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(1);
+    });
+
+    it('should default page to 1 and limit to 10', async () => {
+      const query: GetCommunityChestListDto = {};
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(0);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
+    });
+
+    it('should calculate totalPages correctly', async () => {
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([
+        mockCards.slice(0, 2),
+        5,
+      ]);
+      const query: GetCommunityChestListDto = { page: 1, limit: 2 };
+
+      const result = await service.findAll(query);
+
+      expect(result.meta.totalPages).toBe(3);
+      expect(result.meta.hasNextPage).toBe(true);
+    });
+  });
+
+  describe('stable sorting', () => {
+    it('should add secondary sort by id when sorting by non-id column', async () => {
+      const query: GetCommunityChestListDto = {
+        sortBy: CommunityChestSortBy.CREATED_AT,
+        sortOrder: SortOrder.DESC,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.createdAt',
+        'DESC',
+      );
+      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith(
+        'community_chest.id',
+        'DESC',
+      );
+    });
+
+    it('should not add secondary sort when sorting by id', async () => {
+      const query: GetCommunityChestListDto = {
+        sortBy: CommunityChestSortBy.ID,
+        sortOrder: SortOrder.ASC,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.id',
+        'ASC',
+      );
+      expect(mockQueryBuilder.addOrderBy).not.toHaveBeenCalled();
+    });
+
+    it('should use stable sort with type column', async () => {
+      const query: GetCommunityChestListDto = {
+        sortBy: CommunityChestSortBy.TYPE,
+        sortOrder: SortOrder.ASC,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.type',
+        'ASC',
+      );
+      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith(
+        'community_chest.id',
+        'ASC',
+      );
+    });
+
+    it('should use stable sort with amount column', async () => {
+      const query: GetCommunityChestListDto = {
+        sortBy: CommunityChestSortBy.AMOUNT,
+        sortOrder: SortOrder.DESC,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith(
+        'community_chest.id',
+        'DESC',
+      );
+    });
+
+    it('should default invalid sortBy to id', async () => {
+      const query: GetCommunityChestListDto = {
+        sortBy: 'badField' as CommunityChestSortBy,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.id',
+        'ASC',
+      );
+      expect(mockQueryBuilder.addOrderBy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('filter + pagination combined', () => {
+    it('should apply type filter with pagination', async () => {
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([
+        [mockCards[0]],
+        1,
+      ]);
+      const query: GetCommunityChestListDto = {
+        type: 'reward',
+        page: 1,
+        limit: 5,
+      };
+
+      const result = await service.findAll(query);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'community_chest.type = :type',
+        { type: 'reward' },
+      );
+      expect(result.meta.totalItems).toBe(1);
+    });
+
+    it('should combine type filter with stable sorting and pagination', async () => {
+      const query: GetCommunityChestListDto = {
+        type: 'penalty',
+        sortBy: CommunityChestSortBy.AMOUNT,
+        sortOrder: SortOrder.DESC,
+        page: 1,
+        limit: 10,
+      };
+
+      await service.findAll(query);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalled();
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'community_chest.amount',
+        'DESC',
+      );
+      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith(
+        'community_chest.id',
+        'DESC',
+      );
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(0);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
+    });
+  });
+});

--- a/backend/src/modules/community-chest/community-chest.controller.ts
+++ b/backend/src/modules/community-chest/community-chest.controller.ts
@@ -9,12 +9,15 @@ import {
   ParseIntPipe,
   Query,
   UseInterceptors,
+  Patch,
 } from '@nestjs/common';
 import { CommunityChestService } from './community-chest.service';
 import { CommunityChest } from './entities/community-chest.entity';
 import { CreateCommunityChestDto } from './dto/create-community-chest.dto';
+import { UpdateCommunityChestDto } from './dto/update-community-chest.dto';
 import { GetCommunityChestListDto } from './dto/get-community-chest-list.dto';
 import { CommunityChestObservabilityInterceptor } from './community-chest-observability.interceptor';
+import { PaginatedResponse } from '../../common/interfaces/paginated-response.interface';
 
 @Controller('community-chest')
 @UseInterceptors(CommunityChestObservabilityInterceptor)
@@ -37,7 +40,7 @@ export class CommunityChestController {
   @Get()
   async findAll(
     @Query() query: GetCommunityChestListDto,
-  ): Promise<CommunityChest[]> {
+  ): Promise<PaginatedResponse<CommunityChest>> {
     return this.communityChestService.findAll(query);
   }
 
@@ -46,5 +49,13 @@ export class CommunityChestController {
     @Param('id', ParseIntPipe) id: number,
   ): Promise<CommunityChest | null> {
     return this.communityChestService.findOne(id);
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateDto: UpdateCommunityChestDto,
+  ): Promise<CommunityChest> {
+    return this.communityChestService.update(id, updateDto);
   }
 }

--- a/backend/src/modules/community-chest/community-chest.module.ts
+++ b/backend/src/modules/community-chest/community-chest.module.ts
@@ -5,6 +5,7 @@ import { CommunityChestService } from './community-chest.service';
 import { CommunityChestController } from './community-chest.controller';
 import { CommunityChestObservabilityService } from './community-chest-observability.service';
 import { CommunityChestObservabilityInterceptor } from './community-chest-observability.interceptor';
+import { CommunityChestErrorMapperService } from './community-chest-error-mapper.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([CommunityChest])],
@@ -12,8 +13,9 @@ import { CommunityChestObservabilityInterceptor } from './community-chest-observ
     CommunityChestService,
     CommunityChestObservabilityService,
     CommunityChestObservabilityInterceptor,
+    CommunityChestErrorMapperService,
   ],
   controllers: [CommunityChestController],
-  exports: [CommunityChestService, TypeOrmModule, CommunityChestObservabilityService],
+  exports: [CommunityChestService, TypeOrmModule, CommunityChestObservabilityService, CommunityChestErrorMapperService],
 })
 export class CommunityChestModule {}

--- a/backend/src/modules/community-chest/community-chest.service.ts
+++ b/backend/src/modules/community-chest/community-chest.service.ts
@@ -10,7 +10,9 @@ import { UpdateCommunityChestDto } from './dto/update-community-chest.dto';
 import {
   GetCommunityChestListDto,
   CommunityChestSortBy,
+  COMMUNITY_CHEST_MAX_LIMIT,
 } from './dto/get-community-chest-list.dto';
+import { PaginatedResponse } from '../../common/interfaces/paginated-response.interface';
 import { secureRandomInt } from '../../common/crypto-secure-random';
 import {
   CommunityChestErrorMapperService,
@@ -105,23 +107,26 @@ export class CommunityChestService {
     }
   }
 
-  /**
-   * Get all Community Chest cards with optional filtering and ordering
-   * Supports flexible ordering by any field and type filtering
-   * Optimized query with index on type and createdAt for efficient filtering/sorting
-   */
-  async findAll(query: GetCommunityChestListDto): Promise<CommunityChest[]> {
-    const { sortBy = CommunityChestSortBy.ID, sortOrder = 'ASC', type } = query;
+  async findAll(
+    query: GetCommunityChestListDto,
+  ): Promise<PaginatedResponse<CommunityChest>> {
+    const {
+      page = 1,
+      limit: rawLimit = 10,
+      sortBy = CommunityChestSortBy.ID,
+      sortOrder = 'ASC',
+      type,
+    } = query;
+
+    const limit = Math.min(Math.max(1, rawLimit), COMMUNITY_CHEST_MAX_LIMIT);
 
     const qb =
       this.communityChestRepository.createQueryBuilder('community_chest');
 
-    // Apply type filter if provided
     if (type) {
       qb.andWhere('community_chest.type = :type', { type });
     }
 
-    // Apply ordering - validate sortBy is a valid column
     const validSortColumns = Object.values(CommunityChestSortBy);
     const sortColumn = validSortColumns.includes(sortBy)
       ? sortBy
@@ -129,7 +134,27 @@ export class CommunityChestService {
 
     qb.orderBy(`community_chest.${sortColumn}`, sortOrder);
 
-    return await qb.getMany();
+    if (sortColumn !== CommunityChestSortBy.ID) {
+      qb.addOrderBy('community_chest.id', sortOrder);
+    }
+
+    const skip = (page - 1) * limit;
+    qb.skip(skip).take(limit);
+
+    const [data, totalItems] = await qb.getManyAndCount();
+    const totalPages = Math.ceil(totalItems / limit);
+
+    return {
+      data,
+      meta: {
+        page,
+        limit,
+        totalItems,
+        totalPages,
+        hasNextPage: page < totalPages,
+        hasPreviousPage: page > 1,
+      },
+    };
   }
 
   async findOne(id: number): Promise<CommunityChest | null> {

--- a/backend/src/modules/community-chest/community-chest.service.ts
+++ b/backend/src/modules/community-chest/community-chest.service.ts
@@ -1,23 +1,28 @@
 import {
   Injectable,
-  ConflictException,
-  InternalServerErrorException,
+  HttpException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CommunityChest } from './entities/community-chest.entity';
 import { CreateCommunityChestDto } from './dto/create-community-chest.dto';
+import { UpdateCommunityChestDto } from './dto/update-community-chest.dto';
 import {
   GetCommunityChestListDto,
   CommunityChestSortBy,
 } from './dto/get-community-chest-list.dto';
 import { secureRandomInt } from '../../common/crypto-secure-random';
+import {
+  CommunityChestErrorMapperService,
+  CommunityChestErrorCode,
+} from './community-chest-error-mapper.service';
 
 @Injectable()
 export class CommunityChestService {
   constructor(
     @InjectRepository(CommunityChest)
     private readonly communityChestRepository: Repository<CommunityChest>,
+    private readonly errorMapper: CommunityChestErrorMapperService,
   ) {}
 
   async drawCard(): Promise<CommunityChest | null> {
@@ -35,19 +40,18 @@ export class CommunityChestService {
   }
 
   async create(createDto: CreateCommunityChestDto): Promise<CommunityChest> {
+    const existingCard = await this.communityChestRepository.findOne({
+      where: { instruction: createDto.instruction },
+    });
+
+    if (existingCard) {
+      const mapped = this.errorMapper.mapError(
+        CommunityChestErrorCode.DUPLICATE_INSTRUCTION,
+      );
+      throw new HttpException(mapped, mapped.statusCode);
+    }
+
     try {
-      // Check for duplicate instruction
-      const existingCard = await this.communityChestRepository.findOne({
-        where: { instruction: createDto.instruction },
-      });
-
-      if (existingCard) {
-        throw new ConflictException(
-          'A Community Chest card with this instruction already exists',
-        );
-      }
-
-      // Create and save the new card
       const communityChest = this.communityChestRepository.create({
         instruction: createDto.instruction,
         type: createDto.type,
@@ -57,14 +61,47 @@ export class CommunityChestService {
       });
 
       return await this.communityChestRepository.save(communityChest);
-    } catch (error) {
-      if (error instanceof ConflictException) {
-        throw error;
-      }
-
-      throw new InternalServerErrorException(
-        'Failed to create Community Chest card',
+    } catch {
+      const mapped = this.errorMapper.mapError(
+        CommunityChestErrorCode.CREATE_FAILED,
       );
+      throw new HttpException(mapped, mapped.statusCode);
+    }
+  }
+
+  async update(
+    id: number,
+    updateDto: UpdateCommunityChestDto,
+  ): Promise<CommunityChest> {
+    const card = await this.communityChestRepository.findOne({ where: { id } });
+
+    if (!card) {
+      const mapped = this.errorMapper.mapError(
+        CommunityChestErrorCode.NOT_FOUND,
+      );
+      throw new HttpException(mapped, mapped.statusCode);
+    }
+
+    if (updateDto.instruction !== undefined) {
+      const duplicate = await this.communityChestRepository.findOne({
+        where: { instruction: updateDto.instruction },
+      });
+      if (duplicate && duplicate.id !== id) {
+        const mapped = this.errorMapper.mapError(
+          CommunityChestErrorCode.DUPLICATE_INSTRUCTION,
+        );
+        throw new HttpException(mapped, mapped.statusCode);
+      }
+    }
+
+    try {
+      Object.assign(card, updateDto);
+      return await this.communityChestRepository.save(card);
+    } catch {
+      const mapped = this.errorMapper.mapError(
+        CommunityChestErrorCode.UPDATE_FAILED,
+      );
+      throw new HttpException(mapped, mapped.statusCode);
     }
   }
 

--- a/backend/src/modules/community-chest/dto/get-community-chest-list.dto.ts
+++ b/backend/src/modules/community-chest/dto/get-community-chest-list.dto.ts
@@ -1,4 +1,5 @@
-import { IsOptional, IsEnum, IsString } from 'class-validator';
+import { IsOptional, IsEnum, IsString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export enum CommunityChestSortBy {
   ID = 'id',
@@ -14,7 +15,22 @@ export enum SortOrder {
   DESC = 'DESC',
 }
 
+export const COMMUNITY_CHEST_MAX_LIMIT = 100;
+
 export class GetCommunityChestListDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(COMMUNITY_CHEST_MAX_LIMIT)
+  limit?: number = 10;
+
   @IsOptional()
   @IsEnum(CommunityChestSortBy)
   sortBy?: CommunityChestSortBy = CommunityChestSortBy.ID;

--- a/backend/src/modules/community-chest/dto/update-community-chest.dto.ts
+++ b/backend/src/modules/community-chest/dto/update-community-chest.dto.ts
@@ -1,0 +1,35 @@
+import {
+  IsString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsObject,
+  Min,
+  MaxLength,
+} from 'class-validator';
+import { ChanceType } from '../../chance/enums/chance-type.enum';
+
+export class UpdateCommunityChestDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  instruction?: string;
+
+  @IsOptional()
+  @IsEnum(ChanceType)
+  type?: ChanceType;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  amount?: number | null;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  position?: number | null;
+
+  @IsOptional()
+  @IsObject()
+  extra?: Record<string, any> | null;
+}

--- a/backend/src/modules/mux-protocol/mux-audit.service.spec.ts
+++ b/backend/src/modules/mux-protocol/mux-audit.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MuxAuditService } from './mux-audit.service';
+import { MuxAuditAction, MuxAuditEvent, MuxPermission } from './mux-protocol.types';
+
+describe('MuxAuditService', () => {
+  let service: MuxAuditService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MuxAuditService],
+    }).compile();
+
+    service = module.get<MuxAuditService>(MuxAuditService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('emit', () => {
+    it('should store audit events', () => {
+      const event: MuxAuditEvent = {
+        action: MuxAuditAction.PERMISSION_GRANTED,
+        channelId: 'ch-1',
+        userId: 1,
+        permission: MuxPermission.READ,
+        granted: true,
+        timestamp: new Date(),
+      };
+
+      service.emit(event);
+
+      expect(service.getAuditLog()).toHaveLength(1);
+      expect(service.getAuditLog()[0]).toEqual(event);
+    });
+
+    it('should log the event', () => {
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      service.emit({
+        action: MuxAuditAction.CHANNEL_OPENED,
+        channelId: 'ch-1',
+        userId: 1,
+        timestamp: new Date(),
+      });
+
+      expect(logSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('emitPermissionCheck', () => {
+    it('should emit PERMISSION_GRANTED for granted=true', () => {
+      service.emitPermissionCheck('ch-1', 1, MuxPermission.READ, true);
+
+      const log = service.getAuditLog();
+      expect(log).toHaveLength(1);
+      expect(log[0].action).toBe(MuxAuditAction.PERMISSION_GRANTED);
+      expect(log[0].granted).toBe(true);
+    });
+
+    it('should emit PERMISSION_DENIED for granted=false', () => {
+      service.emitPermissionCheck('ch-1', 1, MuxPermission.ADMIN, false);
+
+      const log = service.getAuditLog();
+      expect(log[0].action).toBe(MuxAuditAction.PERMISSION_DENIED);
+      expect(log[0].granted).toBe(false);
+    });
+
+    it('should include ipAddress when provided', () => {
+      service.emitPermissionCheck(
+        'ch-1',
+        1,
+        MuxPermission.WRITE,
+        true,
+        '192.168.1.1',
+      );
+
+      expect(service.getAuditLog()[0].ipAddress).toBe('192.168.1.1');
+    });
+  });
+
+  describe('emitChannelOpened', () => {
+    it('should emit CHANNEL_OPENED with permissions in metadata', () => {
+      service.emitChannelOpened('ch-1', 1, [MuxPermission.READ, MuxPermission.WRITE]);
+
+      const log = service.getAuditLog();
+      expect(log[0].action).toBe(MuxAuditAction.CHANNEL_OPENED);
+      expect(log[0].metadata).toEqual({
+        permissions: [MuxPermission.READ, MuxPermission.WRITE],
+      });
+    });
+  });
+
+  describe('emitChannelClosed', () => {
+    it('should emit CHANNEL_CLOSED event', () => {
+      service.emitChannelClosed('ch-1', 1);
+
+      const log = service.getAuditLog();
+      expect(log[0].action).toBe(MuxAuditAction.CHANNEL_CLOSED);
+      expect(log[0].channelId).toBe('ch-1');
+    });
+  });
+
+  describe('getAuditLogForUser', () => {
+    it('should filter events by userId', () => {
+      service.emitPermissionCheck('ch-1', 1, MuxPermission.READ, true);
+      service.emitPermissionCheck('ch-2', 2, MuxPermission.READ, true);
+      service.emitPermissionCheck('ch-3', 1, MuxPermission.WRITE, false);
+
+      const user1Log = service.getAuditLogForUser(1);
+      expect(user1Log).toHaveLength(2);
+      expect(user1Log.every((e) => e.userId === 1)).toBe(true);
+    });
+  });
+
+  describe('getAuditLogForChannel', () => {
+    it('should filter events by channelId', () => {
+      service.emitPermissionCheck('ch-1', 1, MuxPermission.READ, true);
+      service.emitPermissionCheck('ch-1', 1, MuxPermission.WRITE, false);
+      service.emitPermissionCheck('ch-2', 2, MuxPermission.READ, true);
+
+      const channelLog = service.getAuditLogForChannel('ch-1');
+      expect(channelLog).toHaveLength(2);
+      expect(channelLog.every((e) => e.channelId === 'ch-1')).toBe(true);
+    });
+  });
+
+  describe('getAuditLog returns copies', () => {
+    it('should return a defensive copy', () => {
+      service.emitPermissionCheck('ch-1', 1, MuxPermission.READ, true);
+
+      const log1 = service.getAuditLog();
+      const log2 = service.getAuditLog();
+
+      expect(log1).not.toBe(log2);
+      expect(log1).toEqual(log2);
+    });
+  });
+});

--- a/backend/src/modules/mux-protocol/mux-audit.service.ts
+++ b/backend/src/modules/mux-protocol/mux-audit.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  MuxAuditAction,
+  MuxAuditEvent,
+  MuxPermission,
+} from './mux-protocol.types';
+
+@Injectable()
+export class MuxAuditService {
+  private readonly logger = new Logger(MuxAuditService.name);
+  private readonly auditLog: MuxAuditEvent[] = [];
+
+  emit(event: MuxAuditEvent): void {
+    this.auditLog.push(event);
+    this.logger.log('Mux audit event', {
+      action: event.action,
+      channelId: event.channelId,
+      userId: event.userId,
+      permission: event.permission,
+      granted: event.granted,
+      timestamp: event.timestamp.toISOString(),
+    });
+  }
+
+  emitPermissionCheck(
+    channelId: string,
+    userId: number,
+    permission: MuxPermission,
+    granted: boolean,
+    ipAddress?: string,
+  ): void {
+    this.emit({
+      action: granted
+        ? MuxAuditAction.PERMISSION_GRANTED
+        : MuxAuditAction.PERMISSION_DENIED,
+      channelId,
+      userId,
+      permission,
+      granted,
+      timestamp: new Date(),
+      ipAddress,
+    });
+  }
+
+  emitChannelOpened(
+    channelId: string,
+    userId: number,
+    permissions: MuxPermission[],
+    ipAddress?: string,
+  ): void {
+    this.emit({
+      action: MuxAuditAction.CHANNEL_OPENED,
+      channelId,
+      userId,
+      timestamp: new Date(),
+      ipAddress,
+      metadata: { permissions },
+    });
+  }
+
+  emitChannelClosed(channelId: string, userId: number): void {
+    this.emit({
+      action: MuxAuditAction.CHANNEL_CLOSED,
+      channelId,
+      userId,
+      timestamp: new Date(),
+    });
+  }
+
+  getAuditLog(): MuxAuditEvent[] {
+    return [...this.auditLog];
+  }
+
+  getAuditLogForUser(userId: number): MuxAuditEvent[] {
+    return this.auditLog.filter((e) => e.userId === userId);
+  }
+
+  getAuditLogForChannel(channelId: string): MuxAuditEvent[] {
+    return this.auditLog.filter((e) => e.channelId === channelId);
+  }
+}

--- a/backend/src/modules/mux-protocol/mux-protocol.module.ts
+++ b/backend/src/modules/mux-protocol/mux-protocol.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MuxProtocolService } from './mux-protocol.service';
+import { MuxAuditService } from './mux-audit.service';
+
+@Module({
+  providers: [MuxProtocolService, MuxAuditService],
+  exports: [MuxProtocolService, MuxAuditService],
+})
+export class MuxProtocolModule {}

--- a/backend/src/modules/mux-protocol/mux-protocol.service.spec.ts
+++ b/backend/src/modules/mux-protocol/mux-protocol.service.spec.ts
@@ -1,0 +1,173 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MuxProtocolService } from './mux-protocol.service';
+import { MuxAuditService } from './mux-audit.service';
+import { MuxAuditAction, MuxPermission } from './mux-protocol.types';
+
+describe('MuxProtocolService', () => {
+  let service: MuxProtocolService;
+  let auditService: MuxAuditService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MuxProtocolService, MuxAuditService],
+    }).compile();
+
+    service = module.get<MuxProtocolService>(MuxProtocolService);
+    auditService = module.get<MuxAuditService>(MuxAuditService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('openChannel', () => {
+    it('should create a channel with given permissions', () => {
+      const channel = service.openChannel(1, [MuxPermission.READ]);
+
+      expect(channel).toBeDefined();
+      expect(channel.id).toBeDefined();
+      expect(channel.userId).toBe(1);
+      expect(channel.permissions).toEqual([MuxPermission.READ]);
+    });
+
+    it('should emit CHANNEL_OPENED audit event', () => {
+      const emitSpy = jest.spyOn(auditService, 'emitChannelOpened');
+
+      const channel = service.openChannel(1, [MuxPermission.READ], '127.0.0.1');
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        channel.id,
+        1,
+        [MuxPermission.READ],
+        '127.0.0.1',
+      );
+    });
+  });
+
+  describe('closeChannel', () => {
+    it('should close an existing channel', () => {
+      const channel = service.openChannel(1, [MuxPermission.READ]);
+
+      service.closeChannel(channel.id, 1);
+
+      expect(service.getChannel(channel.id)).toBeUndefined();
+    });
+
+    it('should emit CHANNEL_CLOSED audit event', () => {
+      const emitSpy = jest.spyOn(auditService, 'emitChannelClosed');
+      const channel = service.openChannel(1, [MuxPermission.READ]);
+
+      service.closeChannel(channel.id, 1);
+
+      expect(emitSpy).toHaveBeenCalledWith(channel.id, 1);
+    });
+
+    it('should throw ForbiddenException for wrong user', () => {
+      const channel = service.openChannel(1, [MuxPermission.READ]);
+
+      expect(() => service.closeChannel(channel.id, 999)).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should emit denied audit event for wrong user', () => {
+      const emitSpy = jest.spyOn(auditService, 'emitPermissionCheck');
+      const channel = service.openChannel(1, [MuxPermission.READ]);
+
+      try {
+        service.closeChannel(channel.id, 999);
+      } catch {}
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        channel.id,
+        999,
+        MuxPermission.READ,
+        false,
+      );
+    });
+  });
+
+  describe('checkPermission', () => {
+    it('should return true for granted permission', () => {
+      const channel = service.openChannel(1, [
+        MuxPermission.READ,
+        MuxPermission.WRITE,
+      ]);
+
+      expect(service.checkPermission(channel.id, 1, MuxPermission.READ)).toBe(
+        true,
+      );
+    });
+
+    it('should return false for denied permission', () => {
+      const channel = service.openChannel(1, [MuxPermission.READ]);
+
+      expect(
+        service.checkPermission(channel.id, 1, MuxPermission.ADMIN),
+      ).toBe(false);
+    });
+
+    it('should return false for wrong user', () => {
+      const channel = service.openChannel(1, [MuxPermission.READ]);
+
+      expect(
+        service.checkPermission(channel.id, 999, MuxPermission.READ),
+      ).toBe(false);
+    });
+
+    it('should emit audit event for each check', () => {
+      const channel = service.openChannel(1, [MuxPermission.READ]);
+      const emitSpy = jest.spyOn(auditService, 'emitPermissionCheck');
+
+      service.checkPermission(channel.id, 1, MuxPermission.READ, '10.0.0.1');
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        channel.id,
+        1,
+        MuxPermission.READ,
+        true,
+        '10.0.0.1',
+      );
+    });
+
+    it('should return false for non-existent channel', () => {
+      expect(
+        service.checkPermission('nonexistent', 1, MuxPermission.READ),
+      ).toBe(false);
+    });
+  });
+
+  describe('requirePermission', () => {
+    it('should not throw when permission is granted', () => {
+      const channel = service.openChannel(1, [MuxPermission.EXECUTE]);
+
+      expect(() =>
+        service.requirePermission(channel.id, 1, MuxPermission.EXECUTE),
+      ).not.toThrow();
+    });
+
+    it('should throw ForbiddenException when permission is denied', () => {
+      const channel = service.openChannel(1, [MuxPermission.READ]);
+
+      expect(() =>
+        service.requirePermission(channel.id, 1, MuxPermission.ADMIN),
+      ).toThrow(ForbiddenException);
+    });
+  });
+
+  describe('getActiveChannelCount', () => {
+    it('should track active channels', () => {
+      expect(service.getActiveChannelCount()).toBe(0);
+
+      const ch1 = service.openChannel(1, [MuxPermission.READ]);
+      const ch2 = service.openChannel(2, [MuxPermission.WRITE]);
+
+      expect(service.getActiveChannelCount()).toBe(2);
+
+      service.closeChannel(ch1.id, 1);
+
+      expect(service.getActiveChannelCount()).toBe(1);
+    });
+  });
+});

--- a/backend/src/modules/mux-protocol/mux-protocol.service.ts
+++ b/backend/src/modules/mux-protocol/mux-protocol.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { MuxAuditService } from './mux-audit.service';
+import { MuxChannel, MuxPermission } from './mux-protocol.types';
+
+@Injectable()
+export class MuxProtocolService {
+  private readonly channels = new Map<string, MuxChannel>();
+
+  constructor(private readonly auditService: MuxAuditService) {}
+
+  openChannel(
+    userId: number,
+    permissions: MuxPermission[],
+    ipAddress?: string,
+  ): MuxChannel {
+    const channel: MuxChannel = {
+      id: uuidv4(),
+      userId,
+      permissions,
+      openedAt: new Date(),
+    };
+
+    this.channels.set(channel.id, channel);
+    this.auditService.emitChannelOpened(
+      channel.id,
+      userId,
+      permissions,
+      ipAddress,
+    );
+
+    return channel;
+  }
+
+  closeChannel(channelId: string, userId: number): void {
+    const channel = this.channels.get(channelId);
+    if (!channel || channel.userId !== userId) {
+      this.auditService.emitPermissionCheck(
+        channelId,
+        userId,
+        MuxPermission.READ,
+        false,
+      );
+      throw new ForbiddenException('Channel not found or access denied');
+    }
+
+    this.channels.delete(channelId);
+    this.auditService.emitChannelClosed(channelId, userId);
+  }
+
+  checkPermission(
+    channelId: string,
+    userId: number,
+    permission: MuxPermission,
+    ipAddress?: string,
+  ): boolean {
+    const channel = this.channels.get(channelId);
+
+    if (!channel || channel.userId !== userId) {
+      this.auditService.emitPermissionCheck(
+        channelId,
+        userId,
+        permission,
+        false,
+        ipAddress,
+      );
+      return false;
+    }
+
+    const granted = channel.permissions.includes(permission);
+    this.auditService.emitPermissionCheck(
+      channelId,
+      userId,
+      permission,
+      granted,
+      ipAddress,
+    );
+
+    return granted;
+  }
+
+  requirePermission(
+    channelId: string,
+    userId: number,
+    permission: MuxPermission,
+    ipAddress?: string,
+  ): void {
+    if (!this.checkPermission(channelId, userId, permission, ipAddress)) {
+      throw new ForbiddenException(
+        `Permission ${permission} denied on channel ${channelId}`,
+      );
+    }
+  }
+
+  getChannel(channelId: string): MuxChannel | undefined {
+    return this.channels.get(channelId);
+  }
+
+  getActiveChannelCount(): number {
+    return this.channels.size;
+  }
+}

--- a/backend/src/modules/mux-protocol/mux-protocol.types.ts
+++ b/backend/src/modules/mux-protocol/mux-protocol.types.ts
@@ -1,0 +1,32 @@
+export enum MuxPermission {
+  READ = 'READ',
+  WRITE = 'WRITE',
+  EXECUTE = 'EXECUTE',
+  ADMIN = 'ADMIN',
+}
+
+export enum MuxAuditAction {
+  PERMISSION_GRANTED = 'MUX_PERMISSION_GRANTED',
+  PERMISSION_DENIED = 'MUX_PERMISSION_DENIED',
+  CHANNEL_OPENED = 'MUX_CHANNEL_OPENED',
+  CHANNEL_CLOSED = 'MUX_CHANNEL_CLOSED',
+}
+
+export interface MuxChannel {
+  id: string;
+  userId: number;
+  permissions: MuxPermission[];
+  openedAt: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MuxAuditEvent {
+  action: MuxAuditAction;
+  channelId: string;
+  userId: number;
+  permission?: MuxPermission;
+  granted?: boolean;
+  timestamp: Date;
+  ipAddress?: string;
+  metadata?: Record<string, unknown>;
+}


### PR DESCRIPTION
closes #886 
closes #887 
closes #885 
Platform improvement for Tycoon (Backend: Module community-chest — idempotency and replay tests). Define scope, implement, and verify in CI or docs. Scope: backend/src/modules/community-chest/.
Tasks
Implement the change in the relevant code paths
Wire or persist state where the feature touches runtime behavior
Add tests (unit, integration, and/or contract/UI as appropriate)
Additional Requirements

Handle stale, disconnected, or invalid states gracefully where applicable
Follow existing patterns in this repository (linting, modules, security)

Acceptance Criteria

Behavior is covered by tests and documented where APIs changed
No regressions in closely related user or API flows


