### PR TITLE
feat(tycoon-lib): upgrade / migration key governance

### DIFF
--- a/contract/contracts/tycoon-lib/src/access_control.rs
+++ b/contract/contracts/tycoon-lib/src/access_control.rs
@@ -1,0 +1,139 @@
+// Admin-only vs public entrypoint formalization for Tycoon contracts.
+//
+// ## Design contract
+//
+// Every Tycoon contract splits its `#[contractimpl]` surface into three tiers:
+//
+// | Tier                | Guard                              | Block label           |
+// |---------------------|------------------------------------|-----------------------|
+// | One-time initializer | None (admin does not exist yet)   | `// ── Initialize ──` |
+// | Admin-only          | `require_admin_auth(admin)`        | `// ── Admin-only ──` |
+// | Public              | `caller.require_auth()` (or none)  | `// ── Public ──`     |
+//
+// Contracts expose this structure via `#[contractimpl]` block comments so
+// that any auditor can identify access tiers by reading top-to-bottom.
+//
+// ## Deprecated shims
+//
+// When entrypoint names are renamed, the old names are kept as thin wrapper
+// shims decorated with `#[deprecated]`.  They delegate to the canonical
+// `admin_*` form and will be removed in the next major version.  See
+// `tycoon-game` for the reference implementation.
+//
+// ## Usage pattern (copy into each contract)
+//
+// ```ignore
+// impl MyContract {
+//     fn require_admin(env: &Env) -> Address {
+//         let admin: Address = env.storage().instance()
+//             .get(&DataKey::Admin)
+//             .expect("Contract not initialized");
+//         tycoon_lib::access_control::require_admin_auth(&admin);
+//         admin
+//     }
+// }
+// ```
+
+use soroban_sdk::Address;
+
+/// Marker documenting the access tier of a Tycoon contract entrypoint.
+///
+/// Attach this type to documentation tables in contract source files to make
+/// access requirements explicit and auditable.  There is no runtime enforcement
+/// in `tycoon-lib` itself — each contract's `require_admin_auth` call is the
+/// enforcement point.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EntrypointKind {
+    /// Called exactly once during deployment.  No admin key exists yet, so no
+    /// `require_auth` is performed at this tier.
+    OneTimeInitializer,
+    /// Callable only by the stored admin/owner address.
+    ///
+    /// Every function in this tier **must** call `require_admin_auth(admin)` as
+    /// its first statement before reading or mutating any state.
+    AdminOnly,
+    /// Callable by any address, subject to the entrypoint's own auth checks.
+    ///
+    /// User-mutating functions **must** call `caller.require_auth()`.
+    /// Pure read-only functions require no auth.
+    Public,
+}
+
+/// Require that `admin` has authorized the current invocation.
+///
+/// This is the canonical guard for admin-only entrypoints.  Contracts define a
+/// private `require_admin(env)` helper that reads the stored admin address from
+/// instance storage and delegates to this function:
+///
+/// ```ignore
+/// fn require_admin(env: &Env) -> Address {
+///     let admin: Address = env.storage().instance()
+///         .get(&DataKey::Admin)
+///         .expect("Contract not initialized");
+///     tycoon_lib::access_control::require_admin_auth(&admin);
+///     admin
+/// }
+/// ```
+///
+/// # Panics
+///
+/// Panics (via the Soroban host) if `admin` has not signed the current
+/// transaction.
+pub fn require_admin_auth(admin: &Address) {
+    admin.require_auth();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn test_entrypoint_kind_variants_are_distinct() {
+        assert_ne!(EntrypointKind::OneTimeInitializer, EntrypointKind::AdminOnly);
+        assert_ne!(EntrypointKind::AdminOnly, EntrypointKind::Public);
+        assert_ne!(EntrypointKind::OneTimeInitializer, EntrypointKind::Public);
+    }
+
+    #[test]
+    fn test_entrypoint_kind_eq_reflexive() {
+        assert_eq!(
+            EntrypointKind::OneTimeInitializer,
+            EntrypointKind::OneTimeInitializer
+        );
+        assert_eq!(EntrypointKind::AdminOnly, EntrypointKind::AdminOnly);
+        assert_eq!(EntrypointKind::Public, EntrypointKind::Public);
+    }
+
+    #[test]
+    fn test_entrypoint_kind_can_be_cloned() {
+        let k = EntrypointKind::AdminOnly;
+        assert_eq!(k, k.clone());
+    }
+
+    #[test]
+    fn test_require_admin_auth_succeeds_when_mocked() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = soroban_sdk::Address::generate(&env);
+        // Must not panic when auth is mocked.
+        require_admin_auth(&admin);
+    }
+
+    #[test]
+    fn test_entrypoint_kind_match_is_exhaustive() {
+        let kinds = [
+            EntrypointKind::OneTimeInitializer,
+            EntrypointKind::AdminOnly,
+            EntrypointKind::Public,
+        ];
+        for kind in &kinds {
+            let label = match kind {
+                EntrypointKind::OneTimeInitializer => "init",
+                EntrypointKind::AdminOnly => "admin",
+                EntrypointKind::Public => "public",
+            };
+            assert!(!label.is_empty());
+        }
+    }
+}

--- a/contract/contracts/tycoon-lib/src/auth.rs
+++ b/contract/contracts/tycoon-lib/src/auth.rs
@@ -1,0 +1,157 @@
+// Cross-contract auth matrix types for Tycoon contracts.
+//
+// ## How cross-contract auth works in Soroban
+//
+// When contract A calls an entrypoint on contract B, the `require_auth()`
+// checks inside B still apply — cross-contract calls do NOT bypass auth.
+// The authorizing address must have pre-signed the invocation in the
+// transaction's auth envelope before the call is made.
+//
+// Example: if the reward-system contract calls `tycoon_token.mint(user, 100)`,
+// the mint function invokes `admin.require_auth()`.  For the call to succeed
+// the admin address must already be present as an authorized invoker in the
+// outer transaction.  The admin can be:
+//   - An account keypair that signed the transaction.
+//   - A multisig / DAO account that satisfied its own auth policy.
+//   - The reward-system contract itself, if it is the stored admin.
+//
+// ## Auth requirement vocabulary
+//
+// | `AuthRequirement` variant    | Guard in code                     |
+// |------------------------------|-----------------------------------|
+// | `None`                       | No `require_auth` call            |
+// | `AdminOnly`                  | `require_admin_auth(admin)`       |
+// | `UserSelf`                   | `caller.require_auth()`           |
+// | `AdminOrPrivilegedCaller`    | owner check OR registered caller  |
+//
+// ## Reference auth table (tycoon-token)
+//
+// | Entrypoint        | Auth requirement           | Notes                          |
+// |-------------------|----------------------------|--------------------------------|
+// | initialize        | None                       | One-time; admin not set yet    |
+// | mint              | AdminOnly                  | Admin must pre-sign            |
+// | set_admin         | AdminOnly                  | Admin key rotation             |
+// | admin             | None (read-only)           | Anyone can query               |
+// | total_supply      | None (read-only)           | Anyone can query               |
+// | transfer          | UserSelf (from)            | Token owner signs              |
+// | transfer_from     | UserSelf (spender)         | Spender contract signs         |
+// | approve           | UserSelf (from)            | Owner grants allowance         |
+// | allowance         | None (read-only)           | Anyone can query               |
+// | balance           | None (read-only)           | Anyone can query               |
+// | burn              | UserSelf (from)            | Token owner signs              |
+// | burn_from         | UserSelf (spender)         | Spender contract signs         |
+// | decimals/name/symbol | None (read-only)        | SEP-41 view functions          |
+//
+// ## Reference auth table (tycoon-game)
+//
+// | Entrypoint                | Auth requirement           | Notes                         |
+// |---------------------------|----------------------------|-------------------------------|
+// | initialize                | None (owner pre-signs)     | One-time setup                |
+// | admin_*                   | AdminOnly                  | Owner must sign               |
+// | register_player           | UserSelf (caller)          | Player registers themselves   |
+// | remove_player_from_game   | AdminOrPrivilegedCaller    | Owner or backend controller   |
+// | get_user / read-only      | None                       | Open view                     |
+
+/// The authentication requirement for a Tycoon contract entrypoint.
+///
+/// Use this type in per-contract documentation tables to make the auth surface
+/// explicit and easy to audit.  It carries no runtime enforcement — each
+/// contract's `require_auth()` calls are the enforcement points.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AuthRequirement {
+    /// No authentication check is performed.
+    ///
+    /// Appropriate for:
+    /// - Pure read-only view functions (balance, total_supply, etc.).
+    /// - One-time initializers where the admin address does not yet exist.
+    None,
+    /// The stored admin/owner address must authorize the invocation.
+    ///
+    /// Implementation: call `tycoon_lib::access_control::require_admin_auth(admin)`
+    /// as the first statement in the function body.
+    AdminOnly,
+    /// The user initiating the action must authorize their own account.
+    ///
+    /// Implementation: call `caller.require_auth()` where `caller` is the
+    /// address whose state is being mutated (token owner, registered player, etc.).
+    UserSelf,
+    /// Either the stored admin/owner **or** a registered privileged caller
+    /// (e.g. the backend game controller) must authorize.
+    ///
+    /// Implementation: read both the admin address and the privileged-caller
+    /// address from storage, call `caller.require_auth()`, then check that
+    /// `caller == admin || caller == privileged_caller`.
+    AdminOrPrivilegedCaller,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_requirement_variants_are_distinct() {
+        assert_ne!(AuthRequirement::None, AuthRequirement::AdminOnly);
+        assert_ne!(AuthRequirement::None, AuthRequirement::UserSelf);
+        assert_ne!(AuthRequirement::None, AuthRequirement::AdminOrPrivilegedCaller);
+        assert_ne!(AuthRequirement::AdminOnly, AuthRequirement::UserSelf);
+        assert_ne!(
+            AuthRequirement::AdminOnly,
+            AuthRequirement::AdminOrPrivilegedCaller
+        );
+        assert_ne!(
+            AuthRequirement::UserSelf,
+            AuthRequirement::AdminOrPrivilegedCaller
+        );
+    }
+
+    #[test]
+    fn test_auth_requirement_eq_reflexive() {
+        assert_eq!(AuthRequirement::None, AuthRequirement::None);
+        assert_eq!(AuthRequirement::AdminOnly, AuthRequirement::AdminOnly);
+        assert_eq!(AuthRequirement::UserSelf, AuthRequirement::UserSelf);
+        assert_eq!(
+            AuthRequirement::AdminOrPrivilegedCaller,
+            AuthRequirement::AdminOrPrivilegedCaller
+        );
+    }
+
+    #[test]
+    fn test_auth_requirement_clone() {
+        let r = AuthRequirement::AdminOrPrivilegedCaller;
+        assert_eq!(r, r.clone());
+    }
+
+    #[test]
+    fn test_auth_requirement_match_is_exhaustive() {
+        let cases = [
+            AuthRequirement::None,
+            AuthRequirement::AdminOnly,
+            AuthRequirement::UserSelf,
+            AuthRequirement::AdminOrPrivilegedCaller,
+        ];
+        for req in &cases {
+            let requires_signature = match req {
+                AuthRequirement::None => false,
+                AuthRequirement::AdminOnly => true,
+                AuthRequirement::UserSelf => true,
+                AuthRequirement::AdminOrPrivilegedCaller => true,
+            };
+            // None is the only variant that does not require a signature.
+            assert_eq!(*req == AuthRequirement::None, !requires_signature);
+        }
+    }
+
+    #[test]
+    fn test_admin_only_is_stricter_than_user_self() {
+        // AdminOnly requires a specific privileged key; UserSelf allows any
+        // authenticated user.  They must be distinct.
+        assert_ne!(AuthRequirement::AdminOnly, AuthRequirement::UserSelf);
+    }
+
+    #[test]
+    fn test_read_only_entrypoints_use_none() {
+        // Verify the None variant is intended for read-only / open entrypoints.
+        let read_only_auth = AuthRequirement::None;
+        assert_eq!(read_only_auth, AuthRequirement::None);
+    }
+}

--- a/contract/contracts/tycoon-lib/src/fees_coverage_tests.rs
+++ b/contract/contracts/tycoon-lib/src/fees_coverage_tests.rs
@@ -36,16 +36,6 @@ mod tests {
         assert!(!invalid_config.is_valid());
     }
 
-    #[test]
-    fn test_fee_config_is_valid() {
-        let env = Env::default();
-        let valid_config = cfg(&env, 2500, 2500, 5000);
-        assert!(valid_config.is_valid());
-
-        let invalid_config = cfg(&env, 6000, 6000, 6000);
-        assert!(!invalid_config.is_valid());
-    }
-
     /// All fees sum to exactly 10 000 bps — residue must be zero.
     #[test]
     fn test_fees_sum_to_100_pct_no_residue() {
@@ -167,6 +157,8 @@ mod tests {
                 "invariant failed: p={p} c={c} pool={pool} amount={amount}"
             );
         }
+    }
+
     #[test]
     fn test_creator_takes_all() {
         let env = Env::default();

--- a/contract/contracts/tycoon-lib/src/lib.rs
+++ b/contract/contracts/tycoon-lib/src/lib.rs
@@ -4,6 +4,15 @@
 // See tycoon-main-game/src/storage.rs for pause implementation example
 pub mod fees;
 
+// Documents storage rent budget and TTL constants for Tycoon contracts.
+pub mod storage_budget;
+
+// Platform improvement modules — formalize shared governance patterns
+pub mod access_control;
+pub mod auth;
+pub mod migration;
+pub mod storage_budget;
+
 #[cfg(test)]
 mod fees_coverage_tests;
 

--- a/contract/contracts/tycoon-lib/src/lib.rs
+++ b/contract/contracts/tycoon-lib/src/lib.rs
@@ -4,6 +4,15 @@
 // See tycoon-main-game/src/storage.rs for pause implementation example
 pub mod fees;
 
+// Shared types and helpers for upgrade/migration key governance.
+pub mod migration;
+
+// Platform improvement modules — formalize shared governance patterns
+pub mod access_control;
+pub mod auth;
+pub mod migration;
+pub mod storage_budget;
+
 #[cfg(test)]
 mod fees_coverage_tests;
 

--- a/contract/contracts/tycoon-lib/src/lib.rs
+++ b/contract/contracts/tycoon-lib/src/lib.rs
@@ -4,6 +4,9 @@
 // See tycoon-main-game/src/storage.rs for pause implementation example
 pub mod fees;
 
+// Formalizes admin-only vs public entrypoint pattern across Tycoon contracts.
+pub mod access_control;
+
 #[cfg(test)]
 mod fees_coverage_tests;
 

--- a/contract/contracts/tycoon-lib/src/lib.rs
+++ b/contract/contracts/tycoon-lib/src/lib.rs
@@ -4,6 +4,15 @@
 // See tycoon-main-game/src/storage.rs for pause implementation example
 pub mod fees;
 
+// Defines the cross-contract auth matrix vocabulary for Tycoon contracts.
+pub mod auth;
+
+// Platform improvement modules — formalize shared governance patterns
+pub mod access_control;
+pub mod auth;
+pub mod migration;
+pub mod storage_budget;
+
 #[cfg(test)]
 mod fees_coverage_tests;
 

--- a/contract/contracts/tycoon-lib/src/migration.rs
+++ b/contract/contracts/tycoon-lib/src/migration.rs
@@ -1,0 +1,205 @@
+// Upgrade / migration key governance for Tycoon contracts.
+//
+// ## Migration pattern
+//
+// Every Tycoon contract stores a monotonically-increasing `StateVersion` in
+// instance storage (key: `DataKey::StateVersion`).  The lifecycle is:
+//
+//   1. `initialize` — sets `StateVersion` to `INITIAL_STATE_VERSION` (1).
+//   2. `admin_migrate` — called by the admin after a WASM upgrade.  Each call
+//      increments the version by exactly 1.  Steps must be sequential.
+//   3. Running at the target version — `admin_migrate` is a no-op (idempotent).
+//
+// ## Key governance rules
+//
+// 1. Only the admin/owner address may call migration entrypoints.
+// 2. Each `admin_migrate` call must advance the version by exactly 1
+//    (`is_valid_migration_step` enforces this).
+// 3. Migration functions must be idempotent — re-running at the current
+//    version must be a safe no-op.
+// 4. After a WASM upgrade the admin should call `admin_migrate` to signal
+//    consumers that state-schema changes have been applied.
+// 5. The admin key used to trigger migration should be rotated after the
+//    upgrade succeeds, using `admin_transfer_ownership`, to limit the blast
+//    radius of a compromised key.
+//
+// ## Implementation template
+//
+// ```ignore
+// pub fn admin_migrate(env: Env) {
+//     Self::require_admin(&env);
+//     let current = storage::get_state_version(&env);
+//     if tycoon_lib::migration::is_migration_needed(current, 2) {
+//         // apply v1 → v2 schema changes here
+//         storage::set_state_version(&env, 2);
+//     }
+//     // already at v2 — safe no-op
+// }
+// ```
+//
+// ## Version table (update in each contract's source)
+//
+// | Version | Change                                              |
+// |---------|-----------------------------------------------------|
+// | 1       | Initial schema set during `initialize`.             |
+// | 2+      | Future: add rows here as migrations are applied.   |
+
+/// Monotonically-increasing version number for a contract's state schema.
+///
+/// Stored as `DataKey::StateVersion` in instance storage.  The Soroban host
+/// refreshes instance TTL on every invocation, so no explicit `extend_ttl`
+/// call is needed for this key.
+pub type StateVersion = u32;
+
+/// The version assigned during `initialize`.  All Tycoon contracts start here.
+pub const INITIAL_STATE_VERSION: StateVersion = 1;
+
+/// Returns `true` when migrating from `from` to `to` is a valid single step.
+///
+/// A valid migration step must increment the version by exactly 1.  Skipping
+/// versions or decrementing is rejected to preserve the sequential invariant.
+///
+/// # Examples
+///
+/// ```
+/// use tycoon_lib::migration::is_valid_migration_step;
+/// assert!(is_valid_migration_step(1, 2));   // v1 → v2: valid
+/// assert!(!is_valid_migration_step(1, 3));  // v1 → v3: skip — invalid
+/// assert!(!is_valid_migration_step(2, 1));  // downgrade — invalid
+/// assert!(!is_valid_migration_step(0, 0));  // no-op at zero — invalid
+/// ```
+pub fn is_valid_migration_step(from: StateVersion, to: StateVersion) -> bool {
+    to == from.saturating_add(1) && to > from
+}
+
+/// Returns `true` when `current` is strictly less than `target`, meaning a
+/// migration to `target` is still required.
+///
+/// Use this inside `admin_migrate` to make each version transition idempotent:
+/// skip the migration body when the contract is already at or beyond `target`.
+///
+/// # Examples
+///
+/// ```
+/// use tycoon_lib::migration::is_migration_needed;
+/// assert!(is_migration_needed(1, 2));   // needs upgrading
+/// assert!(!is_migration_needed(2, 2));  // already at target
+/// assert!(!is_migration_needed(3, 2));  // beyond target — also no-op
+/// ```
+pub fn is_migration_needed(current: StateVersion, target: StateVersion) -> bool {
+    current < target
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── INITIAL_STATE_VERSION ────────────────────────────────────────────────
+
+    #[test]
+    fn test_initial_state_version_is_one() {
+        assert_eq!(INITIAL_STATE_VERSION, 1);
+    }
+
+    // ── is_valid_migration_step ──────────────────────────────────────────────
+
+    #[test]
+    fn test_valid_step_one_to_two() {
+        assert!(is_valid_migration_step(1, 2));
+    }
+
+    #[test]
+    fn test_valid_step_two_to_three() {
+        assert!(is_valid_migration_step(2, 3));
+    }
+
+    #[test]
+    fn test_valid_step_zero_to_one() {
+        assert!(is_valid_migration_step(0, 1));
+    }
+
+    #[test]
+    fn test_invalid_skip_version() {
+        // Skipping from v1 to v3 is not allowed.
+        assert!(!is_valid_migration_step(1, 3));
+    }
+
+    #[test]
+    fn test_invalid_downgrade() {
+        // Downgrading from v2 to v1 is not allowed.
+        assert!(!is_valid_migration_step(2, 1));
+    }
+
+    #[test]
+    fn test_invalid_same_version() {
+        // Staying at the same version is not a valid migration step.
+        assert!(!is_valid_migration_step(1, 1));
+        assert!(!is_valid_migration_step(0, 0));
+    }
+
+    #[test]
+    fn test_invalid_large_skip() {
+        assert!(!is_valid_migration_step(1, 100));
+    }
+
+    #[test]
+    fn test_saturating_add_prevents_overflow() {
+        // u32::MAX + 1 saturates to u32::MAX, which cannot equal u32::MAX + 1.
+        assert!(!is_valid_migration_step(u32::MAX, u32::MAX.saturating_add(1)));
+    }
+
+    // ── is_migration_needed ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_migration_needed_when_current_less_than_target() {
+        assert!(is_migration_needed(1, 2));
+        assert!(is_migration_needed(0, 1));
+        assert!(is_migration_needed(1, 10));
+    }
+
+    #[test]
+    fn test_no_migration_needed_when_at_target() {
+        assert!(!is_migration_needed(2, 2));
+        assert!(!is_migration_needed(1, 1));
+    }
+
+    #[test]
+    fn test_no_migration_needed_when_beyond_target() {
+        // Already past target — also a safe no-op.
+        assert!(!is_migration_needed(3, 2));
+        assert!(!is_migration_needed(10, 5));
+    }
+
+    // ── Idempotency invariant ────────────────────────────────────────────────
+
+    #[test]
+    fn test_idempotent_migration_pattern() {
+        // Simulates the pattern used inside admin_migrate.
+        let mut current: StateVersion = INITIAL_STATE_VERSION;
+        let target: StateVersion = 2;
+
+        if is_migration_needed(current, target) {
+            assert!(is_valid_migration_step(current, target));
+            current = target;
+        }
+
+        // Re-running must be a no-op.
+        let was_needed = is_migration_needed(current, target);
+        assert!(!was_needed, "second call must be a no-op");
+        assert_eq!(current, 2);
+    }
+
+    #[test]
+    fn test_sequential_migrations() {
+        // Three sequential migrations: v1 → v2 → v3 → v4.
+        let mut version: StateVersion = INITIAL_STATE_VERSION;
+        for target in [2, 3, 4] {
+            assert!(is_migration_needed(version, target));
+            assert!(is_valid_migration_step(version, target));
+            version = target;
+        }
+        assert_eq!(version, 4);
+        // No further migration needed.
+        assert!(!is_migration_needed(version, 4));
+    }
+}

--- a/contract/contracts/tycoon-lib/src/storage_budget.rs
+++ b/contract/contracts/tycoon-lib/src/storage_budget.rs
@@ -1,0 +1,160 @@
+// Storage rent budget reference for Tycoon contracts.
+//
+// ## Background
+//
+// Soroban persistent storage entries have independent TTL (time-to-live)
+// counters measured in ledgers.  When a persistent entry's TTL reaches zero it
+// is archived and a non-trivial restoration fee is required to read or write it
+// again.  Instance storage is exempt — the Soroban host refreshes the instance
+// TTL on every contract invocation.
+//
+// ## Storage classification
+//
+// | Kind       | When to use                               | TTL management                      |
+// |------------|-------------------------------------------|-------------------------------------|
+// | Instance   | Admin keys, config, version numbers       | Automatic per invocation            |
+// | Persistent | Per-user state: balances, profiles, flags | Implicit on write; extend on access |
+// | Temporary  | Short-lived computation (intra-tx)        | Bounded to transaction lifetime     |
+//
+// ## Recommended constants (calibrated for ~5 seconds/ledger on Soroban mainnet)
+//
+// | Constant                  | Ledgers     | Wall-clock    |
+// |---------------------------|-------------|---------------|
+// | `PERSISTENT_MIN_TTL`      | 17 280      | ≈ 24 hours    |
+// | `PERSISTENT_TARGET_TTL`   | 2 073 600   | ≈ 120 days    |
+// | `TTL_BUMP_THRESHOLD`      | 518 400     | ≈ 30 days     |
+//
+// ## TTL extension policy
+//
+// **Instance keys** (admin address, state version, initialization flag): The
+// Soroban host automatically refreshes the instance TTL on every contract
+// invocation.  No explicit `extend_ttl` call is needed.
+//
+// **Persistent keys** (user balances, profiles, registrations): Every
+// `storage().persistent().set(...)` call implicitly grants a baseline TTL.
+// To prevent archival during periods of inactivity, call `extend_ttl` when
+// the remaining TTL falls below `TTL_BUMP_THRESHOLD`.  Active users (those
+// who transact regularly) receive an implicit TTL refresh on every write.
+//
+// ## Cost budget by operation (approximate, Soroban mainnet)
+//
+// | Operation    | Instance writes | Persistent writes | Approx cost |
+// |--------------|-----------------|-------------------|-------------|
+// | initialize   | 3               | 1 (admin balance) | ~0.005 XLM  |
+// | mint         | 1 (supply)      | 1 (balance)       | ~0.003 XLM  |
+// | transfer     | 0               | 2 (from, to)      | ~0.004 XLM  |
+// | approve      | 0               | 1 (allowance)     | ~0.002 XLM  |
+// | burn         | 1 (supply)      | 1 (balance)       | ~0.003 XLM  |
+// | read-only    | 0               | 0                 | ~0.001 XLM  |
+
+/// Minimum acceptable TTL for persistent storage entries.
+///
+/// At ~5 seconds per ledger this corresponds to approximately 24 hours.
+/// Entries whose remaining TTL is below this value should be bumped immediately.
+pub const PERSISTENT_MIN_TTL: u32 = 17_280;
+
+/// Recommended target TTL when extending a persistent storage entry.
+///
+/// At ~5 seconds per ledger this corresponds to approximately 120 days, giving
+/// inactive accounts a comfortable window before their state is archived.
+pub const PERSISTENT_TARGET_TTL: u32 = 2_073_600;
+
+/// Proactive bump threshold for persistent entries.
+///
+/// When the remaining TTL of a persistent entry falls below this value the
+/// contract should extend it to `PERSISTENT_TARGET_TTL`.  At ~5 seconds per
+/// ledger this corresponds to approximately 30 days.
+pub const TTL_BUMP_THRESHOLD: u32 = 518_400;
+
+/// Classifies a storage key by its cost and lifetime characteristics.
+///
+/// Use this in per-contract storage documentation tables to make the TTL
+/// strategy for each key explicit and auditable.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StorageKind {
+    /// Bundled with the contract instance.  The Soroban host refreshes the
+    /// instance TTL on every invocation — no manual `extend_ttl` call is
+    /// required.  Use for: admin address, config, state version, init flag.
+    Instance,
+    /// Stored independently with its own TTL counter.  Must be extended on
+    /// every write (via the implicit TTL grant) and proactively bumped when
+    /// `remaining_ttl < TTL_BUMP_THRESHOLD`.  Use for: user balances,
+    /// profiles, allowances, registrations.
+    Persistent,
+    /// Lives only for the duration of a single transaction.  Cannot be read
+    /// across ledger boundaries.  Use for: ephemeral computation state.
+    Temporary,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constants_are_ordered() {
+        assert!(PERSISTENT_MIN_TTL < TTL_BUMP_THRESHOLD);
+        assert!(TTL_BUMP_THRESHOLD < PERSISTENT_TARGET_TTL);
+    }
+
+    #[test]
+    fn test_persistent_min_ttl_value() {
+        // 17_280 ledgers × 5 s/ledger = 86_400 s = 24 hours
+        assert_eq!(PERSISTENT_MIN_TTL, 17_280);
+    }
+
+    #[test]
+    fn test_persistent_target_ttl_value() {
+        // 2_073_600 ledgers × 5 s/ledger = 10_368_000 s ≈ 120 days
+        assert_eq!(PERSISTENT_TARGET_TTL, 2_073_600);
+    }
+
+    #[test]
+    fn test_ttl_bump_threshold_value() {
+        // 518_400 ledgers × 5 s/ledger = 2_592_000 s = 30 days
+        assert_eq!(TTL_BUMP_THRESHOLD, 518_400);
+    }
+
+    #[test]
+    fn test_storage_kind_variants_are_distinct() {
+        assert_ne!(StorageKind::Instance, StorageKind::Persistent);
+        assert_ne!(StorageKind::Persistent, StorageKind::Temporary);
+        assert_ne!(StorageKind::Instance, StorageKind::Temporary);
+    }
+
+    #[test]
+    fn test_storage_kind_eq_reflexive() {
+        assert_eq!(StorageKind::Instance, StorageKind::Instance);
+        assert_eq!(StorageKind::Persistent, StorageKind::Persistent);
+        assert_eq!(StorageKind::Temporary, StorageKind::Temporary);
+    }
+
+    #[test]
+    fn test_storage_kind_clone() {
+        let k = StorageKind::Persistent;
+        assert_eq!(k, k.clone());
+    }
+
+    #[test]
+    fn test_storage_kind_match_is_exhaustive() {
+        let kinds = [
+            StorageKind::Instance,
+            StorageKind::Persistent,
+            StorageKind::Temporary,
+        ];
+        for kind in &kinds {
+            let label = match kind {
+                StorageKind::Instance => "instance",
+                StorageKind::Persistent => "persistent",
+                StorageKind::Temporary => "temporary",
+            };
+            assert!(!label.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_bump_threshold_is_fraction_of_target() {
+        // Bump threshold should be roughly 25 % of the target TTL
+        let ratio = PERSISTENT_TARGET_TTL / TTL_BUMP_THRESHOLD;
+        assert!(ratio >= 3 && ratio <= 5, "Expected ratio 3-5, got {}", ratio);
+    }
+}


### PR DESCRIPTION
closes #1013
closes #1014 
closes #1015 
closes #1017
Adds migration module to tycoon-lib with:

    StateVersion type alias (u32) and INITIAL_STATE_VERSION = 1
    is_valid_migration_step(from, to) — enforces strictly sequential increments (v → v+1 only; skipping or downgrading returns false; saturating-add prevents overflow at u32::MAX)
    is_migration_needed(current, target) — idempotent guard for admin_migrate bodies

Documents 5 key governance rules (admin-only, sequential, idempotent, post-upgrade key rotation)
Provides implementation template for admin_migrate
Fixes pre-existing syntax errors in fees_coverage_tests.rs