### PR TITLE
fix(frontend): add missing join_room i18n keys and keep en/es parity

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -91,6 +91,9 @@
       "unexpected": "An unexpected error occurred",
       "network_error": "Network error. Check your connection and try again.",
       "timeout": "Request timed out. Please try again."
-    }
+    },
+    "network_error": "Network error. Please check your connection and try again.",
+    "timeout": "Request timed out. Please try again.",
+    "service_unavailable": "Service is currently unavailable. Please try again later."
   }
 }

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -91,6 +91,9 @@
       "unexpected": "An unexpected error occurred",
       "network_error": "Error de red. Comprueba tu conexión e inténtalo de nuevo.",
       "timeout": "La solicitud ha caducado. Inténtalo de nuevo."
-    }
+    },
+    "network_error": "Error de red. Comprueba tu conexión e inténtalo de nuevo.",
+    "timeout": "La solicitud expiró. Por favor, inténtalo de nuevo.",
+    "service_unavailable": "El servicio no está disponible. Inténtalo más tarde."
   }
 }


### PR DESCRIPTION
Closes #1239

- Adds missing join_room i18n keys to en/es locales