### PR TITLE
fix(frontend): game settings customStake positive number validation

### DIFF
--- a/frontend/src/lib/validation/schemas.ts
+++ b/frontend/src/lib/validation/schemas.ts
@@ -81,9 +81,14 @@ export const gameSettingsSchema = z.object({
   customStake: z
     .string()
     .optional()
-    .refine((v) => v === undefined || v === "" || (!isNaN(Number(v)) && Number(v) > 0), {
-      message: "Must be a positive number",
-    }),
+    .refine(
+      (v) => {
+        if (v === undefined || v === "") return true;
+        const n = Number(v);
+        return !isNaN(n) && isFinite(n) && n > 0;
+      },
+      { message: "Stake must be a positive number (no negatives or NaN)" }
+    ),
 });
 
 export type LoginFormValues = z.infer<typeof loginSchema>;


### PR DESCRIPTION
Closes #1266

- Tightens customStake validation to reject non-finite and <= 0 values