### PR TITLE
feat(frontend): add join-room error and loading boundary tests

### DIFF
--- a/frontend/src/app/join-room/__tests__/error.test.tsx
+++ b/frontend/src/app/join-room/__tests__/error.test.tsx
@@ -1,154 +1,384 @@
+/**
+ * Tests for src/app/join-room/error.tsx
+ *
+ * Covers:
+ *  - Rendering and layout (min-h-screen, bg-[var(--tycoon-bg)], p-4, flex centering)
+ *  - reset prop type-safety: () => void (no return value expected)
+ *  - digest optional on Error (Next.js route error boundary contract)
+ *  - Retry / reset integration with ErrorDisplay
+ *  - Home + Support navigation buttons from ErrorDisplay
+ *  - Error categorization paths (network, auth, server, unknown, not-found, rate-limit)
+ *  - Stale / disconnected / invalid error states
+ *  - dev vs prod showTechnical visibility
+ *  - ARIA: error region landmarks and accessible button labels
+ *
+ * Mock strategy:
+ *  - useErrorReporting: stubbed so ErrorBoundary/ErrorDisplay can render without state
+ *  - sanitizeError / ERROR_MESSAGES / ErrorCategory: fully controlled return values
+ *  - react-i18next: key-passthrough so aria-labels are predictable
+ */
+
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import JoinRoomError from '../error';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
 
-describe('JoinRoomError (Error Boundary)', () => {
-  let mockReset: ReturnType<typeof vi.fn>;
+// ─── Mocks ────────────────────────────────────────────────────────────────────
 
+vi.mock('@/hooks/useErrorReporting', () => ({
+  useErrorReporting: () => ({
+    reportError: vi.fn(),
+    clearErrors: vi.fn(),
+    lastError: null,
+    errorHistory: [],
+  }),
+}));
+
+const mockSanitizeError = vi.fn();
+vi.mock('@/lib/errors/types', () => ({
+  sanitizeError: (...args: unknown[]) => mockSanitizeError(...args),
+  ERROR_MESSAGES: {
+    network: { title: 'Connection Issue', message: 'Check your connection.', action: 'Check Connection', supportLink: '/support/network' },
+    auth: { title: 'Auth Required', message: 'Please sign in.', action: 'Sign In', supportLink: '/support/auth' },
+    validation: { title: 'Invalid Input', message: 'Check your input.', action: 'Review', supportLink: '/support/validation' },
+    server: { title: 'Server Error', message: 'Something went wrong on our end.', action: 'Try Again', supportLink: '/support/server' },
+    not_found: { title: 'Not Found', message: 'Page not found.', action: 'Go Home', supportLink: '/support/not-found' },
+    rate_limit: { title: 'Too Many Requests', message: 'Please wait and try again.', action: 'Wait & Retry', supportLink: '/support/rate-limit' },
+    unknown: { title: 'Something Went Wrong', message: 'An unexpected error occurred.', action: 'Try Again', supportLink: '/support/general' },
+  },
+  ErrorCategory: {
+    NETWORK: 'network',
+    AUTH: 'auth',
+    VALIDATION: 'validation',
+    SERVER: 'server',
+    NOT_FOUND: 'not_found',
+    RATE_LIMIT: 'rate_limit',
+    UNKNOWN: 'unknown',
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeError(message: string, digest?: string): Error & { digest?: string } {
+  const err = new Error(message) as Error & { digest?: string };
+  if (digest !== undefined) err.digest = digest;
+  return err;
+}
+
+function makeReset(): () => void {
+  return vi.fn<[], void>();
+}
+
+function defaultSanitized(overrides: Partial<{
+  category: string;
+  userMessage: string;
+  technicalMessage: string;
+  errorCode: string;
+  recoverable: boolean;
+  suggestedAction: string;
+  supportLink: string;
+}> = {}) {
+  return {
+    category: 'unknown',
+    userMessage: 'An unexpected error occurred.',
+    technicalMessage: 'Error',
+    errorCode: 'TYC-UNKN-ABC123',
+    recoverable: true,
+    suggestedAction: 'Try Again',
+    supportLink: '/support/general',
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('JoinRoomError (route error boundary)', () => {
   beforeEach(() => {
-    mockReset = vi.fn();
+    mockSanitizeError.mockReturnValue(defaultSanitized());
   });
 
-  it('should render error display component', () => {
-    const error = new Error('Test error message');
-    render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
-
-    expect(screen.getByText(/error/i)).toBeInTheDocument();
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('should display the error message from the error object', () => {
-    const error = new Error('Room not found');
-    render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
+  // ── Layout & styling ────────────────────────────────────────────────────────
 
-    expect(screen.getByText(/room not found/i)).toBeInTheDocument();
-  });
-
-  it('should have full-screen layout to prevent jarring visual changes', () => {
-    const error = new Error('Test error');
-    const { container } = render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
-
-    const section = container.querySelector('div');
-    expect(section).toHaveClass('min-h-screen');
-    expect(section).toHaveClass('flex', 'items-center', 'justify-center');
-  });
-
-  it('should use correct background color from theme variables', () => {
-    const error = new Error('Test error');
-    const { container } = render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
-
-    const section = container.querySelector('div');
-    expect(section).toHaveClass('bg-[var(--tycoon-bg)]');
-  });
-
-  it('should show technical error details in development mode', () => {
-    // Mock NODE_ENV as development
-    const originalEnv = process.env.NODE_ENV;
-    Object.defineProperty(process.env, 'NODE_ENV', {
-      value: 'development',
-      configurable: true,
+  describe('Layout and styling', () => {
+    it('renders the outer wrapper with min-h-screen to fill the viewport', () => {
+      const { container } = render(
+        <JoinRoomError error={makeError('test')} reset={makeReset()} />
+      );
+      expect(container.querySelector('div')).toHaveClass('min-h-screen');
     });
 
-    const error = new Error('Technical error details');
-    error.stack = 'Error: Technical error details\n  at testFunction (test.ts:10)';
+    it('uses the tycoon theme background variable', () => {
+      const { container } = render(
+        <JoinRoomError error={makeError('test')} reset={makeReset()} />
+      );
+      expect(container.querySelector('div')).toHaveClass('bg-[var(--tycoon-bg)]');
+    });
 
-    render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
+    it('centers content with flex layout', () => {
+      const { container } = render(
+        <JoinRoomError error={makeError('test')} reset={makeReset()} />
+      );
+      const wrapper = container.querySelector('div');
+      expect(wrapper).toHaveClass('flex', 'items-center', 'justify-center');
+    });
 
-    // In development, stack trace should be shown via ErrorDisplay
-    // (actual display depends on ErrorDisplay implementation)
-    expect(screen.getByText(/error/i)).toBeInTheDocument();
-
-    Object.defineProperty(process.env, 'NODE_ENV', {
-      value: originalEnv,
-      configurable: true,
+    it('adds p-4 padding to prevent content cutoff on small screens', () => {
+      const { container } = render(
+        <JoinRoomError error={makeError('test')} reset={makeReset()} />
+      );
+      expect(container.querySelector('div')).toHaveClass('p-4');
     });
   });
 
-  it('should hide technical details in production mode', () => {
-    const originalEnv = process.env.NODE_ENV;
-    Object.defineProperty(process.env, 'NODE_ENV', {
-      value: 'production',
-      configurable: true,
+  // ── reset prop: must be () => void ──────────────────────────────────────────
+
+  describe('reset prop — () => void contract', () => {
+    it('calls reset exactly once when the retry button is clicked', () => {
+      const reset = makeReset();
+      render(<JoinRoomError error={makeError('test')} reset={reset} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+      expect(reset).toHaveBeenCalledTimes(1);
     });
 
-    const error = new Error('Technical error details');
-    render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
+    it('does not pass a return value expectation — reset returns void', () => {
+      // Asserts the type-level contract: calling reset() must not produce a value
+      const reset = makeReset();
+      render(<JoinRoomError error={makeError('test')} reset={reset} />);
 
-    // ErrorDisplay should handle showing/hiding technical details based on showTechnical prop
-    expect(screen.getByText(/error/i)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+      const callResult = (reset as ReturnType<typeof vi.fn>).mock.results[0];
+      expect(callResult.type).toBe('return');
+      expect(callResult.value).toBeUndefined();
+    });
 
-    Object.defineProperty(process.env, 'NODE_ENV', {
-      value: originalEnv,
-      configurable: true,
+    it('can invoke reset multiple times if user clicks retry repeatedly', async () => {
+      const user = userEvent.setup();
+      const reset = makeReset();
+      render(<JoinRoomError error={makeError('test')} reset={reset} />);
+
+      const btn = screen.getByRole('button', { name: /try again/i });
+      await user.click(btn);
+      await user.click(btn);
+
+      expect(reset).toHaveBeenCalledTimes(2);
     });
   });
 
-  it('should call reset function when retry button is clicked', () => {
-    const error = new Error('Test error');
-    render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
+  // ── digest optional ─────────────────────────────────────────────────────────
 
-    const retryButton = screen.getByRole('button', { name: /retry|try again/i });
-    fireEvent.click(retryButton);
+  describe('digest optional on Error', () => {
+    it('renders correctly when digest is present', () => {
+      const error = makeError('Crash with digest', 'abc123digest');
+      render(<JoinRoomError error={error} reset={makeReset()} />);
+      expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    });
 
-    expect(mockReset).toHaveBeenCalled();
+    it('renders correctly when digest is absent (undefined)', () => {
+      const error = makeError('Crash without digest');
+      expect(error.digest).toBeUndefined();
+      render(<JoinRoomError error={error} reset={makeReset()} />);
+      expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    });
+
+    it('renders correctly when digest is an empty string', () => {
+      const error = makeError('Crash empty digest', '');
+      render(<JoinRoomError error={error} reset={makeReset()} />);
+      expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    });
+
+    it('passes the error object (with digest) through to sanitizeError', () => {
+      const error = makeError('Digest pass-through', 'xyz999');
+      render(<JoinRoomError error={error} reset={makeReset()} />);
+      expect(mockSanitizeError).toHaveBeenCalledWith(error);
+    });
   });
 
-  it('should handle errors with digest property', () => {
-    const error = new Error('Test error');
-    error.digest = 'abc123digest';
-    render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
+  // ── Error categorization ────────────────────────────────────────────────────
 
-    // Error boundary should handle digest for error reporting
-    expect(screen.getByText(/error/i)).toBeInTheDocument();
+  describe('Error category display', () => {
+    it('shows a network error title when sanitizeError returns NETWORK category', () => {
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ category: 'network', userMessage: 'Check your connection.' })
+      );
+      render(<JoinRoomError error={makeError('network')} reset={makeReset()} />);
+      expect(screen.getByText(/connection issue/i)).toBeInTheDocument();
+    });
+
+    it('shows an auth error title when sanitizeError returns AUTH category', () => {
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ category: 'auth', userMessage: 'Please sign in.', recoverable: true })
+      );
+      render(<JoinRoomError error={makeError('auth')} reset={makeReset()} />);
+      expect(screen.getByText(/auth required/i)).toBeInTheDocument();
+    });
+
+    it('shows server error title for 5xx responses', () => {
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ category: 'server', userMessage: 'Something went wrong on our end.' })
+      );
+      render(<JoinRoomError error={makeError('500')} reset={makeReset()} />);
+      expect(screen.getByText(/server error/i)).toBeInTheDocument();
+    });
+
+    it('shows not-found title for 404 errors — and still renders layout', () => {
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ category: 'not_found', userMessage: 'Page not found.', recoverable: false })
+      );
+      const { container } = render(
+        <JoinRoomError error={makeError('404')} reset={makeReset()} />
+      );
+      expect(screen.getByText(/not found/i)).toBeInTheDocument();
+      // Layout preserved even for non-recoverable errors
+      expect(container.querySelector('div')).toHaveClass('min-h-screen');
+    });
+
+    it('shows rate-limit title and retry button', () => {
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ category: 'rate_limit', userMessage: 'Please wait and try again.', recoverable: true })
+      );
+      render(<JoinRoomError error={makeError('429')} reset={makeReset()} />);
+      expect(screen.getByText(/too many requests/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /wait & retry/i })).toBeInTheDocument();
+    });
   });
 
-  it('should provide navigation options in error display', () => {
-    const error = new Error('Something went wrong');
-    render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
+  // ── Stale / disconnected / invalid states ───────────────────────────────────
 
-    // Should have retry button (tested above)
-    expect(screen.getByRole('button', { name: /retry|try again/i })).toBeInTheDocument();
-    
-    // May also have home button depending on ErrorDisplay implementation
-    // Just verify error display is rendered
-    expect(screen.getByText(/error/i)).toBeInTheDocument();
+  describe('Stale, disconnected, and invalid error states', () => {
+    it('handles a stale render: same error object passed multiple times renders consistently', () => {
+      const error = makeError('Stale render test');
+      const reset = makeReset();
+      const { rerender } = render(<JoinRoomError error={error} reset={reset} />);
+      rerender(<JoinRoomError error={error} reset={reset} />);
+      expect(screen.getAllByText(/something went wrong/i)).toHaveLength(1);
+    });
+
+    it('updates the display when a new error is passed (disconnected → reconnect scenario)', () => {
+      const reset = makeReset();
+
+      mockSanitizeError.mockReturnValueOnce(
+        defaultSanitized({ category: 'network', userMessage: 'Check your connection.' })
+      );
+      const { rerender } = render(
+        <JoinRoomError error={makeError('disconnect')} reset={reset} />
+      );
+      expect(screen.getByText(/connection issue/i)).toBeInTheDocument();
+
+      mockSanitizeError.mockReturnValueOnce(
+        defaultSanitized({ category: 'server', userMessage: 'Something went wrong on our end.' })
+      );
+      rerender(
+        <JoinRoomError error={makeError('server crash')} reset={reset} />
+      );
+      expect(screen.getByText(/server error/i)).toBeInTheDocument();
+    });
+
+    it('handles an error with no message gracefully (empty string message)', () => {
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ userMessage: 'An unexpected error occurred.' })
+      );
+      render(<JoinRoomError error={makeError('')} reset={makeReset()} />);
+      expect(screen.getByText(/unexpected error/i)).toBeInTheDocument();
+    });
+
+    it('handles non-recoverable errors by hiding the retry button', () => {
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ recoverable: false })
+      );
+      render(<JoinRoomError error={makeError('unrecoverable')} reset={makeReset()} />);
+      expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+    });
+
+    it('renders the Home navigation button regardless of error type', () => {
+      render(<JoinRoomError error={makeError('any')} reset={makeReset()} />);
+      expect(screen.getByRole('button', { name: /home/i })).toBeInTheDocument();
+    });
+
+    it('renders the Support navigation button regardless of error type', () => {
+      render(<JoinRoomError error={makeError('any')} reset={makeReset()} />);
+      expect(screen.getByRole('button', { name: /support/i })).toBeInTheDocument();
+    });
   });
 
-  it('should have padding to prevent content cutoff on small screens', () => {
-    const error = new Error('Test error');
-    const { container } = render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
+  // ── Dev vs prod: showTechnical ──────────────────────────────────────────────
 
-    const section = container.querySelector('div');
-    expect(section).toHaveClass('p-4');
+  describe('showTechnical visibility (dev vs prod)', () => {
+    it('does not render the technical block in production mode', () => {
+      const originalEnv = process.env.NODE_ENV;
+      Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
+
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ technicalMessage: 'TypeError', errorCode: 'TYC-UNKN-X1' })
+      );
+      render(<JoinRoomError error={makeError('prod')} reset={makeReset()} />);
+
+      // Technical block contains `Error: ...` — should NOT appear in production
+      expect(screen.queryByText(/Error: TypeError/)).not.toBeInTheDocument();
+
+      Object.defineProperty(process.env, 'NODE_ENV', { value: originalEnv, configurable: true });
+    });
+
+    it('renders the error code reference in production mode (for support)', () => {
+      const originalEnv = process.env.NODE_ENV;
+      Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
+
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ errorCode: 'TYC-UNKN-REF99', technicalMessage: 'TypeError' })
+      );
+      render(<JoinRoomError error={makeError('prod-ref')} reset={makeReset()} />);
+
+      expect(screen.getByText(/TYC-UNKN-REF99/)).toBeInTheDocument();
+
+      Object.defineProperty(process.env, 'NODE_ENV', { value: originalEnv, configurable: true });
+    });
+
+    it('shows the technical block in development mode', () => {
+      const originalEnv = process.env.NODE_ENV;
+      Object.defineProperty(process.env, 'NODE_ENV', { value: 'development', configurable: true });
+
+      mockSanitizeError.mockReturnValue(
+        defaultSanitized({ technicalMessage: 'TypeError', errorCode: 'TYC-UNKN-DEV1' })
+      );
+      render(<JoinRoomError error={makeError('dev-error')} reset={makeReset()} />);
+
+      // In dev, ErrorDisplay renders a technical block with `Error: <technicalMessage>`
+      expect(screen.getByText(/Error: TypeError/)).toBeInTheDocument();
+
+      Object.defineProperty(process.env, 'NODE_ENV', { value: originalEnv, configurable: true });
+    });
   });
 
-  it('should pass correct props to ErrorDisplay', () => {
-    const error = new Error('Display error');
-    const { container } = render(
-      <JoinRoomError error={error} reset={mockReset} />
-    );
+  // ── Accessibility ───────────────────────────────────────────────────────────
 
-    // ErrorDisplay should be rendered with the error
-    const errorDisplay = container.querySelector('[class*="error"]');
-    expect(errorDisplay).toBeInTheDocument();
+  describe('Accessibility', () => {
+    it('has a visible heading element in the error card', () => {
+      render(<JoinRoomError error={makeError('a11y test')} reset={makeReset()} />);
+      expect(screen.getByRole('heading')).toBeInTheDocument();
+    });
+
+    it('retry button has an accessible label', () => {
+      render(<JoinRoomError error={makeError('a11y test')} reset={makeReset()} />);
+      const btn = screen.getByRole('button', { name: /try again/i });
+      expect(btn).toBeInTheDocument();
+    });
+
+    it('home button is keyboard-focusable', () => {
+      render(<JoinRoomError error={makeError('a11y')} reset={makeReset()} />);
+      const homeBtn = screen.getByRole('button', { name: /home/i });
+      homeBtn.focus();
+      expect(document.activeElement).toBe(homeBtn);
+    });
   });
 });

--- a/frontend/src/app/join-room/__tests__/loading.test.tsx
+++ b/frontend/src/app/join-room/__tests__/loading.test.tsx
@@ -1,74 +1,257 @@
-import { render, screen, waitFor } from '@testing-library/react';
+/**
+ * Tests for src/app/join-room/loading.tsx
+ *
+ * Covers:
+ *  - Rendering without crash
+ *  - ARIA: aria-busy="true", aria-label via i18n key, role=status/region
+ *  - CLS prevention: min-h-screen, w-full, exact layout classes matching JoinRoomPageContent
+ *  - Theme variables alignment with the real form (bg-[var(--tycoon-bg)] etc.)
+ *  - Skeleton slot count and structural hierarchy
+ *  - Error slot space reservation (min-h-[1.25rem]) — prevents layout shift on error
+ *  - Stale/re-render stability: multiple renders produce consistent output
+ *  - Visibility: component is visible and not hidden by default
+ *  - i18n key coverage: loadingAria resolved via mock t()
+ *  - No interactive elements (loading state must not be interactive)
+ *
+ * Mock strategy:
+ *  - react-i18next: key-passthrough so aria-label is the raw i18n key
+ *    (the component calls t(JOIN_ROOM_I18N.loadingAria) — we assert on the key value)
+ */
+
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
 import JoinRoomLoading from '../loading';
-import { describe, it, expect } from 'vitest';
+import { JOIN_ROOM_I18N } from '@/lib/join-room/i18n-keys';
 
-describe('JoinRoomLoading (Skeleton)', () => {
-  it('should render without crashing', () => {
-    render(<JoinRoomLoading />);
-    const skeleton = screen.getByLabelText('Loading join room form');
-    expect(skeleton).toBeInTheDocument();
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('JoinRoomLoading (Suspense skeleton)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('should have aria-busy="true" to indicate loading state', () => {
-    render(<JoinRoomLoading />);
-    const section = screen.getByLabelText('Loading join room form');
-    expect(section).toHaveAttribute('aria-busy', 'true');
+  // ── Basic rendering ─────────────────────────────────────────────────────────
+
+  describe('Basic rendering', () => {
+    it('renders without crashing', () => {
+      expect(() => render(<JoinRoomLoading />)).not.toThrow();
+    });
+
+    it('renders a <section> as the outermost accessible element', () => {
+      const { container } = render(<JoinRoomLoading />);
+      expect(container.querySelector('section')).toBeInTheDocument();
+    });
+
+    it('is visible and not hidden by default', () => {
+      render(<JoinRoomLoading />);
+      const section = screen.getByLabelText(JOIN_ROOM_I18N.loadingAria);
+      expect(section).toBeVisible();
+    });
   });
 
-  it('should have full screen layout to prevent CLS', () => {
-    const { container } = render(<JoinRoomLoading />);
-    const section = container.querySelector('section');
-    expect(section).toHaveClass('min-h-screen', 'w-full');
+  // ── ARIA / Accessibility ────────────────────────────────────────────────────
+
+  describe('Accessibility (ARIA)', () => {
+    it('sets aria-busy="true" so screen readers announce loading state', () => {
+      render(<JoinRoomLoading />);
+      const section = screen.getByLabelText(JOIN_ROOM_I18N.loadingAria);
+      expect(section).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('sets aria-label to the i18n loadingAria key for screen-reader announcement', () => {
+      render(<JoinRoomLoading />);
+      // getByLabelText will throw if the label is missing — this IS the assertion
+      const section = screen.getByLabelText(JOIN_ROOM_I18N.loadingAria);
+      expect(section).toBeInTheDocument();
+    });
+
+    it('uses the correct i18n key (join_room.loading_aria)', () => {
+      expect(JOIN_ROOM_I18N.loadingAria).toBe('join_room.loading_aria');
+      render(<JoinRoomLoading />);
+      // If the key changes, this test will catch the regression
+      expect(screen.getByLabelText('join_room.loading_aria')).toBeInTheDocument();
+    });
+
+    it('has no interactive elements — loading skeletons must not be focusable', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const interactives = container.querySelectorAll('button, input, a, select, textarea, [tabindex]');
+      expect(interactives.length).toBe(0);
+    });
+
+    it('skeleton divs are aria-hidden to avoid redundant announcements', () => {
+      const { container } = render(<JoinRoomLoading />);
+      // Skeleton component sets aria-hidden="true" on each div
+      const skeletonDivs = container.querySelectorAll('[aria-hidden="true"]');
+      expect(skeletonDivs.length).toBeGreaterThan(0);
+    });
   });
 
-  it('should maintain proper spacing and layout with skeleton elements', () => {
-    const { container } = render(<JoinRoomLoading />);
-    
-    // Card should have proper layout classes
-    const card = container.querySelector('.max-w-md');
-    expect(card).toBeInTheDocument();
-    expect(card).toHaveClass('rounded-2xl', 'p-6');
+  // ── CLS prevention / layout ─────────────────────────────────────────────────
 
-    // Inner card should have proper layout
-    const innerCard = card?.querySelector('.rounded-lg');
-    expect(innerCard).toHaveClass('p-6', 'space-y-5');
+  describe('CLS (Cumulative Layout Shift) prevention', () => {
+    it('has min-h-screen on the section to fill the viewport height', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const section = container.querySelector('section');
+      expect(section).toHaveClass('min-h-screen');
+    });
+
+    it('has w-full on the section to prevent horizontal shift', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const section = container.querySelector('section');
+      expect(section).toHaveClass('w-full');
+    });
+
+    it('uses flex layout to center card — matches JoinRoomPageContent layout', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const section = container.querySelector('section');
+      expect(section).toHaveClass('flex', 'flex-col', 'items-center', 'justify-center');
+    });
+
+    it('has px-4 padding on the section matching the real page', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const section = container.querySelector('section');
+      expect(section).toHaveClass('px-4');
+    });
+
+    it('preserves the error slot space even while loading (min-h-[1.25rem])', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const errorSlot = container.querySelector('.min-h-\\[1\\.25rem\\]');
+      expect(errorSlot).toBeInTheDocument();
+    });
   });
 
-  it('should have proper color/theme variables for integration with main form', () => {
-    const { container } = render(<JoinRoomLoading />);
-    const section = container.querySelector('section');
-    
-    // Check for tycoon theme variables
-    const styles = window.getComputedStyle(section!);
-    expect(section).toHaveClass('bg-[var(--tycoon-bg)]');
+  // ── Theme alignment ─────────────────────────────────────────────────────────
+
+  describe('Theme variable alignment', () => {
+    it('section background matches the real form: bg-[var(--tycoon-bg)]', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const section = container.querySelector('section');
+      expect(section).toHaveClass('bg-[var(--tycoon-bg)]');
+    });
+
+    it('card wrapper uses the same max-w-md constraint as the real page', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const card = container.querySelector('.max-w-md');
+      expect(card).toBeInTheDocument();
+    });
+
+    it('card wrapper has rounded-2xl and shadow-xl matching the real page', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const card = container.querySelector('.max-w-md');
+      expect(card).toHaveClass('rounded-2xl', 'shadow-xl');
+    });
+
+    it('card wrapper has p-6 padding matching the real page', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const card = container.querySelector('.max-w-md');
+      expect(card).toHaveClass('p-6');
+    });
+
+    it('inner card uses bg-[var(--tycoon-bg)] matching JoinRoomPageContent inner wrapper', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const innerCard = container.querySelector('.max-w-md .rounded-lg');
+      expect(innerCard).toHaveClass('bg-[var(--tycoon-bg)]');
+    });
+
+    it('inner card has p-6 and space-y-5 matching the form inner container', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const innerCard = container.querySelector('.max-w-md .rounded-lg');
+      expect(innerCard).toHaveClass('p-6', 'space-y-5');
+    });
   });
 
-  it('should render all expected skeleton slots', () => {
-    const { container } = render(<JoinRoomLoading />);
-    const skeletons = container.querySelectorAll('[data-testid="skeleton"]');
-    
-    // Should have: title, label, hint, input, button skeletons
-    expect(skeletons.length).toBeGreaterThan(0);
+  // ── Skeleton slot structure ─────────────────────────────────────────────────
+
+  describe('Skeleton slots', () => {
+    it('renders at least 4 skeleton placeholders (title + label + hint + input + button)', () => {
+      const { container } = render(<JoinRoomLoading />);
+      // Skeleton renders as an animate-pulse div; count all animate-pulse children
+      const skeletons = container.querySelectorAll('.animate-pulse');
+      expect(skeletons.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('renders a title skeleton in the outer card area (mb-6)', () => {
+      const { container } = render(<JoinRoomLoading />);
+      // Title skeleton is outside the inner card, has mx-auto and mb-6
+      const titleSkeleton = container.querySelector('.mx-auto.mb-6');
+      expect(titleSkeleton).toBeInTheDocument();
+    });
+
+    it('renders a full-width skeleton for the input field', () => {
+      const { container } = render(<JoinRoomLoading />);
+      // Input skeleton uses w-full
+      const inputSkeleton = container.querySelector('.animate-pulse.w-full');
+      expect(inputSkeleton).toBeInTheDocument();
+    });
+
+    it('renders field-label and hint skeletons (w-24, w-56)', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const labelSkeleton = container.querySelector('.animate-pulse.w-24');
+      const hintSkeleton = container.querySelector('.animate-pulse.w-56');
+      // At least one partial-width skeleton for label
+      expect(labelSkeleton ?? hintSkeleton).toBeInTheDocument();
+    });
+
+    it('renders a full-width button skeleton', () => {
+      const { container } = render(<JoinRoomLoading />);
+      // There should be two full-width skeletons: input and button
+      const fullWidthSkeletons = container.querySelectorAll('.animate-pulse.w-full');
+      expect(fullWidthSkeletons.length).toBeGreaterThanOrEqual(2);
+    });
   });
 
-  it('should preserve error slot space even when empty', () => {
-    const { container } = render(<JoinRoomLoading />);
-    const errorSlot = container.querySelector('.min-h-[1.25rem]');
-    
-    // Error slot should exist and have minimum height
-    expect(errorSlot).toBeInTheDocument();
-    expect(errorSlot).toHaveClass('min-h-[1.25rem]');
+  // ── Stale / re-render stability ─────────────────────────────────────────────
+
+  describe('Stale and re-render stability', () => {
+    it('re-renders consistently without adding duplicate sections', () => {
+      const { rerender, container } = render(<JoinRoomLoading />);
+      rerender(<JoinRoomLoading />);
+      expect(container.querySelectorAll('section').length).toBe(1);
+    });
+
+    it('maintains the same skeleton count across multiple renders', () => {
+      const { rerender, container } = render(<JoinRoomLoading />);
+      const firstCount = container.querySelectorAll('.animate-pulse').length;
+      rerender(<JoinRoomLoading />);
+      expect(container.querySelectorAll('.animate-pulse').length).toBe(firstCount);
+    });
+
+    it('does not unmount the section between re-renders (stable DOM identity)', () => {
+      const { rerender, container } = render(<JoinRoomLoading />);
+      const firstSection = container.querySelector('section');
+      rerender(<JoinRoomLoading />);
+      expect(container.querySelector('section')).toBe(firstSection);
+    });
   });
 
-  it('should have bg-[var(--tycoon-bg)] matching the actual form', () => {
-    const { container } = render(<JoinRoomLoading />);
-    const section = container.querySelector('section');
-    expect(section).toHaveClass('bg-[var(--tycoon-bg)]');
-  });
+  // ── Integration: structural parity with the real form ──────────────────────
 
-  it('should be visible and not hidden by default', () => {
-    render(<JoinRoomLoading />);
-    const section = screen.getByLabelText('Loading join room form');
-    expect(section).toBeVisible();
+  describe('Structural parity with JoinRoomPageContent', () => {
+    it('outer wrapper has border border-[var(--tycoon-border)] matching the real card', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const card = container.querySelector('.max-w-md');
+      expect(card).toHaveClass('border');
+    });
+
+    it('inner form area has border matching the real inner card', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const innerCard = container.querySelector('.max-w-md .rounded-lg');
+      expect(innerCard).toHaveClass('border');
+    });
+
+    it('field group has space-y-1.5 to mirror FormField spacing', () => {
+      const { container } = render(<JoinRoomLoading />);
+      const fieldGroup = container.querySelector('.space-y-1\\.5');
+      expect(fieldGroup).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
This PR
closes #1240 
closes #1235 
closes #1236 
closes #1238 



- Rewrote error.test.tsx with correct mock strategy for useErrorReporting, sanitizeError, ERROR_MESSAGES, ErrorCategory, and react-i18next
- Covers reset: () => void contract, digest optional, stale/disconnected states, all error categories (network/auth/server/not_found/rate_limit), dev vs prod showTechnical, and accessibility (heading, button labels)
- Rewrote loading.test.tsx with react-i18next mock (was missing, causing aria-label assertions to fail), replaced data-testid='skeleton' selector with .animate-pulse (actual Skeleton class)
- Covers aria-busy, aria-hidden on skeletons, CLS prevention layout, theme variable alignment, skeleton slot structure, re-render stability, and structural parity with JoinRoomPageContent
- All mock reset types match () => void; digest is optional on Error


Description

 What does this PR change and why? Link the issue: Closes #NNNN -->

 CI Summary


For contract PRs: paste `make ci` output from the `contract/` directory.
For other PRs: paste the relevant CI command output (e.g. npm test, cargo test).



 Checklist

- [ ] CI passes locally (output pasted above)
- [ ] Tests added or updated for changed behaviour
- [ ] No regressions in related flows
- [ ] Documentation updated where APIs changed
- [ ] Security check: Soroban smart contract changes comply with the [Workspace Security Review Checklist](contract/SECURITY_REVIEW_CHECKLIST.md)
