### PR TITLE
Auth observability: failed login metrics without PII

### DIFF
--- a/backend/src/modules/auth/auth-observability.service.spec.ts
+++ b/backend/src/modules/auth/auth-observability.service.spec.ts
@@ -143,9 +143,35 @@ describe('AuthObservabilityService (#872)', () => {
   // Metric registration — counters and histograms are created
   // -------------------------------------------------------------------------
 
+  describe('recordFailedLogin (#1299)', () => {
+    it.each([
+      'unknown_user',
+      'invalid_password',
+      'invalid_credentials',
+      'suspended',
+    ] as const)('increments failed-login counter for reason=%s', (reason) => {
+      const { incMock } = getPromMocks();
+      service.recordFailedLogin(reason);
+      expect(incMock).toHaveBeenCalledWith({ reason });
+    });
+
+    it('log message contains only the reason code, never PII', () => {
+      service.recordFailedLogin('unknown_user');
+      const logArgs = logSpy.mock.calls.flat().join(' ');
+      expect(logArgs).toMatch(/reason=unknown_user/);
+      expect(logArgs).not.toMatch(/@|password|email/i);
+    });
+  });
+
   describe('metric registration', () => {
-    it('creates 3 Counter instances', () => {
-      expect(Counter).toHaveBeenCalledTimes(3);
+    it('creates 4 Counter instances', () => {
+      expect(Counter).toHaveBeenCalledTimes(4);
+    });
+
+    it('failed_logins counter has correct name', () => {
+      const calls = (Counter as jest.Mock).mock.calls as [{ name: string }][];
+      const names = calls.map((c) => c[0].name);
+      expect(names).toContain('tycoon_auth_failed_logins_total');
     });
 
     it('creates 1 Histogram instance', () => {

--- a/backend/src/modules/auth/auth-observability.service.ts
+++ b/backend/src/modules/auth/auth-observability.service.ts
@@ -9,6 +9,7 @@ export class AuthObservabilityService {
   private readonly authOperationDuration: Histogram;
   private readonly tokenRefreshTotal: Counter;
   private readonly tokenReuseTotal: Counter;
+  private readonly failedLoginsTotal: Counter;
 
   constructor() {
     this.authAttemptsTotal = new Counter({
@@ -34,6 +35,12 @@ export class AuthObservabilityService {
       name: 'tycoon_auth_token_reuse_detected_total',
       help: 'Total token reuse / replay attack detections',
     });
+
+    this.failedLoginsTotal = new Counter({
+      name: 'tycoon_auth_failed_logins_total',
+      help: 'Total failed login attempts by reason code (no PII)',
+      labelNames: ['reason'],
+    });
   }
 
   recordAuthAttempt(
@@ -58,5 +65,16 @@ export class AuthObservabilityService {
 
   startTimer(operation: string): () => void {
     return this.authOperationDuration.startTimer({ operation });
+  }
+
+  /**
+   * Records a failed login by reason code only — never pass email, IP,
+   * or any user-identifying value here.
+   */
+  recordFailedLogin(
+    reason: 'unknown_user' | 'invalid_password' | 'suspended' | 'invalid_credentials',
+  ): void {
+    this.failedLoginsTotal.inc({ reason });
+    this.logger.log(`[METRIC] auth_failed_login reason=${reason}`);
   }
 }

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -13,6 +13,7 @@ import { RefreshToken } from './entities/refresh-token.entity';
 import { User } from '../users/entities/user.entity';
 import { AdminLogsModule } from '../admin-logs/admin-logs.module';
 import { AuthAuditService } from './audit/auth-audit.service';
+import { AuthObservabilityService } from './auth-observability.service';
 
 @Module({
   imports: [
@@ -35,7 +36,13 @@ import { AuthAuditService } from './audit/auth-audit.service';
     }),
   ],
   controllers: [AuthController, AdminAuthController],
-  providers: [AuthService, JwtStrategy, LocalStrategy, AuthAuditService],
+  providers: [
+    AuthService,
+    JwtStrategy,
+    LocalStrategy,
+    AuthAuditService,
+    AuthObservabilityService,
+  ],
   exports: [AuthService, JwtModule, JwtStrategy],
 })
 export class AuthModule {}

--- a/backend/src/modules/auth/auth.service.spec.ts
+++ b/backend/src/modules/auth/auth.service.spec.ts
@@ -7,6 +7,7 @@ import { UsersService } from '../users/users.service';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { User } from '../users/entities/user.entity';
 import { AuthAuditService } from './audit/auth-audit.service';
+import { AuthObservabilityService } from './auth-observability.service';
 import * as bcrypt from 'bcrypt';
 
 jest.mock('bcrypt');
@@ -80,6 +81,10 @@ describe('AuthService', () => {
         {
           provide: AuthAuditService,
           useValue: { record: jest.fn() },
+        },
+        {
+          provide: AuthObservabilityService,
+          useValue: { recordFailedLogin: jest.fn() },
         },
       ],
     }).compile();

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -19,6 +19,7 @@ import { User } from '../users/entities/user.entity';
 import { Role } from './enums/role.enum';
 import { AuthAuditService } from './audit/auth-audit.service';
 import { AuthAuditEvent } from './audit/auth-audit.events';
+import { AuthObservabilityService } from './auth-observability.service';
 import { ListRefreshTokensDto, SortOrder } from './dto/list-refresh-tokens.dto';
 import { PaginatedResponse } from '../../common/interfaces/paginated-response.interface';
 
@@ -35,6 +36,7 @@ export class AuthService {
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     private readonly authAudit: AuthAuditService,
+    private readonly authObservability: AuthObservabilityService,
   ) {}
 
   async validateUser(
@@ -57,6 +59,7 @@ export class AuthService {
         ipAddress,
         userAgent,
       });
+      this.authObservability.recordFailedLogin('suspended');
       return null;
     }
 
@@ -76,6 +79,9 @@ export class AuthService {
       ipAddress,
       userAgent,
     });
+    this.authObservability.recordFailedLogin(
+      user ? 'invalid_password' : 'unknown_user',
+    );
     return null;
   }
 
@@ -100,6 +106,7 @@ export class AuthService {
         userAgent,
         meta: { isAdmin: true },
       });
+      this.authObservability.recordFailedLogin('suspended');
       return null;
     }
 
@@ -124,6 +131,9 @@ export class AuthService {
       userAgent,
       meta: { isAdmin: true },
     });
+    this.authObservability.recordFailedLogin(
+      user ? 'invalid_credentials' : 'unknown_user',
+    );
     return null;
   }
 


### PR DESCRIPTION
## Summary
Adds a `tycoon_auth_failed_logins_total` Prometheus counter labeled only by `reason` (`unknown_user`, `invalid_password`, `invalid_credentials`, `suspended`) so failed logins can be observed in CI/dashboards without ever recording email, IP, or other PII in metric labels.

## Context / Before-after
- Before: `AuthObservabilityService` tracked auth attempts and token refresh, but had no dedicated failed-login-by-reason metric, and the service wasn't wired into `AuthModule`/`AuthService` at all.
- After: `AuthObservabilityService` is injected into `AuthService`, and `validateUser`/`validateAdmin` call `recordFailedLogin(reason)` on every failure path (unknown user, bad password, suspended account), counting by reason code only.

## Testing
- Added unit tests in `auth-observability.service.spec.ts` covering counter increments per reason and asserting log output contains no PII.
- Updated `auth.service.spec.ts` to provide a mocked `AuthObservabilityService`.
- Not run locally (no `node_modules` installed in this environment) — relying on CI to execute the Jest suite.

Closes #1299