### PR TITLE
Perk-boost WebSocket gateway auth

### DIFF
--- a/backend/src/modules/perks-boosts/gateways/perk-boost.gateway.spec.ts
+++ b/backend/src/modules/perks-boosts/gateways/perk-boost.gateway.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { PerkBoostGateway } from './perk-boost.gateway';
+import { PerksBoostsEvents } from '../services/perks-boosts-events.service';
+
+describe('PerkBoostGateway - auth (#1296)', () => {
+  let gateway: PerkBoostGateway;
+  let jwtService: { verifyAsync: jest.Mock };
+
+  function makeSocket(overrides: Record<string, any> = {}) {
+    return {
+      id: 'socket-1',
+      handshake: { auth: {}, headers: {}, query: {} },
+      data: {},
+      join: jest.fn(),
+      disconnect: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    jwtService = { verifyAsync: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PerkBoostGateway,
+        {
+          provide: PerksBoostsEvents,
+          useValue: { events$: { subscribe: jest.fn() } },
+        },
+        { provide: JwtService, useValue: jwtService },
+      ],
+    }).compile();
+
+    gateway = module.get<PerkBoostGateway>(PerkBoostGateway);
+  });
+
+  it('disconnects sockets with no token', async () => {
+    const socket = makeSocket();
+    await gateway.handleConnection(socket as any);
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+    expect(socket.join).not.toHaveBeenCalled();
+  });
+
+  it('disconnects sockets with an invalid/expired token', async () => {
+    jwtService.verifyAsync.mockRejectedValue(new Error('invalid token'));
+    const socket = makeSocket({
+      handshake: { auth: { token: 'bad-token' }, headers: {}, query: {} },
+    });
+
+    await gateway.handleConnection(socket as any);
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+    expect(socket.join).not.toHaveBeenCalled();
+  });
+
+  it('joins the room derived from the verified token, not a client-supplied userId', async () => {
+    jwtService.verifyAsync.mockResolvedValue({ sub: 42 });
+    const socket = makeSocket({
+      handshake: {
+        auth: { token: 'good-token' },
+        headers: {},
+        query: { userId: '999' },
+      },
+    });
+
+    await gateway.handleConnection(socket as any);
+    expect(socket.join).toHaveBeenCalledWith('user_42');
+    expect(socket.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('accepts a bearer token from the Authorization header as a fallback', async () => {
+    jwtService.verifyAsync.mockResolvedValue({ sub: 7 });
+    const socket = makeSocket({
+      handshake: {
+        auth: {},
+        headers: { authorization: 'Bearer good-token' },
+        query: {},
+      },
+    });
+
+    await gateway.handleConnection(socket as any);
+    expect(socket.join).toHaveBeenCalledWith('user_7');
+  });
+});

--- a/backend/src/modules/perks-boosts/gateways/perk-boost.gateway.ts
+++ b/backend/src/modules/perks-boosts/gateways/perk-boost.gateway.ts
@@ -6,11 +6,13 @@ import {
   OnGatewayDisconnect,
 } from '@nestjs/websockets';
 import { Logger, OnModuleInit } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import {
   PerksBoostsEvents,
   PerkBoostEvent,
 } from '../services/perks-boosts-events.service';
+import type { JwtPayload } from '../../auth/interfaces/jwt-payload.interface';
 
 @WebSocketGateway({
   namespace: 'boosts',
@@ -28,7 +30,10 @@ export class PerkBoostGateway
   @WebSocketServer() server: Server;
   private readonly logger = new Logger(PerkBoostGateway.name);
 
-  constructor(private readonly events: PerksBoostsEvents) {}
+  constructor(
+    private readonly events: PerksBoostsEvents,
+    private readonly jwtService: JwtService,
+  ) {}
 
   onModuleInit() {
     // Subscribe to internal events and push to clients via WebSockets
@@ -46,12 +51,38 @@ export class PerkBoostGateway
     this.logger.log('Perk Boost WebSocket Gateway initialized');
   }
 
-  handleConnection(client: Socket) {
-    const userId = client.handshake.query.userId;
-    if (userId) {
+  async handleConnection(client: Socket) {
+    const token = this.extractToken(client);
+    if (!token) {
+      this.logger.warn(`Rejected unauthenticated socket ${client.id}: no token`);
+      client.disconnect(true);
+      return;
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync<JwtPayload>(token);
+      const userId = payload.sub;
+      client.data.userId = userId;
       client.join(`user_${userId}`);
       this.logger.log(`Client connected: ${client.id}, User: ${userId}`);
+    } catch {
+      this.logger.warn(
+        `Rejected unauthenticated socket ${client.id}: invalid token`,
+      );
+      client.disconnect(true);
     }
+  }
+
+  private extractToken(client: Socket): string | undefined {
+    const authToken = client.handshake.auth?.token as string | undefined;
+    if (authToken) return authToken;
+
+    const authHeader = client.handshake.headers?.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      return authHeader.slice('Bearer '.length);
+    }
+
+    return undefined;
   }
 
   handleDisconnect(client: Socket) {

--- a/backend/src/modules/perks-boosts/perks-boosts.module.ts
+++ b/backend/src/modules/perks-boosts/perks-boosts.module.ts
@@ -19,6 +19,7 @@ import { NotificationsModule } from '../fetch-notification/notifications.module'
 import { PerkAnalyticsEvent } from './entities/perk-analytics-event.entity';
 import { PerkAnalyticsService } from './services/perk-analytics.service';
 import { Game } from '../games/entities/game.entity';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { Game } from '../games/entities/game.entity';
       Game,
     ]),
     NotificationsModule,
+    AuthModule,
   ],
   controllers: [PerksController, PerksAnalyticsController],
   providers: [


### PR DESCRIPTION
## Summary
`PerkBoostGateway` accepted any WebSocket connection and joined the client to a notification room based on a client-supplied `userId` query parameter, with no verification at all. Any socket could pass an arbitrary `userId` and receive another user's perk/boost notifications. This adds JWT verification and rejects unauthenticated sockets.

## Context / Before-after
- Before: `handleConnection` read `client.handshake.query.userId` directly and called `client.join('user_' + userId)` — no auth check.
- After: `handleConnection` extracts a bearer token (`handshake.auth.token`, falling back to an `Authorization: Bearer` header), verifies it via `JwtService.verifyAsync`, and:
  - Disconnects the socket immediately if no token is present or verification fails (invalid/expired/malformed).
  - Joins the room using the verified token's `sub` (user id) — client-supplied `userId` is no longer trusted.
- `PerksBoostsModule` now imports `AuthModule` to get `JwtService`.

## Testing
- Added `perk-boost.gateway.spec.ts`: covers no-token rejection, invalid-token rejection, joining the room derived from the verified token (ignoring a mismatched client-supplied `userId`), and the Authorization-header fallback path.
- Not run locally (no `node_modules` installed in this environment) — relying on CI to execute the Jest suite.

Closes #1296