### PR TITLE
feature:Integration fixture dead_code helpers allowlist

### DIFF
--- a/.github/workflows/contract-build.yml
+++ b/.github/workflows/contract-build.yml
@@ -1,0 +1,65 @@
+name: Contract Build & Integration Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  contract-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contract
+    env:
+      # Safety rule (#1359): integration tests MUST NOT connect to staging.
+      # STELLAR_NETWORK is deliberately unset — any test that reads it to
+      # obtain a live network env will fail fast here.
+      STELLAR_NETWORK: ""
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contract
+
+      - name: Install wasm-opt (binaryen)
+        run: sudo apt-get update -qq && sudo apt-get install -y binaryen
+
+      - name: Build release WASM artifacts
+        run: make build-wasm
+
+      - name: Verify WASM size budgets
+        run: make wasm-check
+
+      - name: Run unit tests (all packages)
+        run: make test
+
+      - name: Run integration tests
+        # Mirrors: cargo test --package tycoon-integration-tests -- --nocapture
+        run: make test-integration
+
+      - name: Generate WASM SHA-256 hashes
+        run: make wasm-hashes
+
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tycoon-wasm-${{ github.sha }}
+          path: |
+            contract/target/wasm32-unknown-unknown/release/*.wasm
+            contract/deploy/wasm-hashes.txt
+            contract/deploy/wasm-size-report.md
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/contract-hygiene.yml
+++ b/.github/workflows/contract-hygiene.yml
@@ -1,0 +1,39 @@
+name: Contract Hygiene
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  contract-hygiene:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contract
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contract
+
+      - name: Check formatting (cargo fmt --check)
+        # Fails if any file diverges from `cargo fmt` output.
+        run: make fmt-check
+
+      - name: Lint with clippy (-D warnings)
+        # Treats every warning as a hard error to keep the workspace warning-free.
+        run: make clippy-deny

--- a/contract/integration-tests/Cargo.toml
+++ b/contract/integration-tests/Cargo.toml
@@ -15,4 +15,4 @@ tycoon-token         = { path = "../contracts/tycoon-token" }
 tycoon-reward-system = { path = "../contracts/tycoon-reward-system" }
 tycoon-game          = { path = "../contracts/tycoon-game" }
 tycoon-boost-system  = { path = "../contracts/tycoon-boost-system", features = ["testutils"] }
-tycoon-collectibles  = { path = "../contracts/tycoon-collectibles" }
+tycoon-collectibles  = { path = "../contracts/tycoon-collectibles", features = ["testutils"] }

--- a/contract/integration-tests/src/collectibles_integration.rs
+++ b/contract/integration-tests/src/collectibles_integration.rs
@@ -1,0 +1,458 @@
+/// # Cross-contract flow: Collectibles — full ecosystem integration
+///
+/// Exercises `TycoonCollectibles` through the shared `Fixture`, covering
+/// initialization, minting, transfers, burns, shop operations, perk burns,
+/// pause/unpause, and access-control guards.
+///
+/// Each test creates its own `Fixture::new()` — no shared state.
+///
+/// | Test | Path |
+/// |------|------|
+/// | `fixture_collectibles_is_initialized`              | collectibles.admin() == fixture.admin |
+/// | `backend_mint_issues_token_to_player`              | backend_mint → balance_of |
+/// | `mint_collectible_generates_unique_token_id`       | mint_collectible returns distinct ids |
+/// | `transfer_collectible_between_players`             | transfer → balances update |
+/// | `transfer_requires_sender_balance`                 | transfer with no balance panics |
+/// | `burn_reduces_balance`                             | burn → balance decremented |
+/// | `burn_exceeds_balance_rejected`                    | burn > balance panics |
+/// | `burn_collectible_for_perk_works`                  | burn_collectible_for_perk succeeds when unpaused |
+/// | `burn_collectible_for_perk_blocked_when_paused`    | set_pause(true) blocks perk burn |
+/// | `perk_burn_resumes_after_unpause`                  | set_pause(false) restores perk burn |
+/// | `non_admin_cannot_set_backend_minter`              | attacker cannot set minter |
+/// | `non_admin_cannot_stock_shop`                      | attacker cannot stock shop |
+/// | `admin_revoke_replaces_minter`                     | set_backend_minter twice, old minter rejected |
+/// | `multi_player_independent_balances`                | three players, isolated inventory |
+/// | `double_initialize_rejected`                       | second initialize panics |
+/// | `stock_shop_and_buy_with_tyc`                      | stock_shop → buy_collectible_from_shop (TYC) |
+/// | `stock_shop_and_buy_with_usdc`                     | stock_shop → buy_collectible_from_shop (USDC) |
+/// | `buy_from_empty_stock_rejected`                    | out-of-stock purchase panics |
+/// | `owned_token_count_tracks_mint_and_burn`           | count invariant across mint and burn |
+/// | `tokens_of_returns_all_owned_ids`                  | tokens_of reflects minted set |
+/// | `stale_token_id_balance_is_zero`                   | balance_of on unknown id returns 0 |
+/// | `admin_can_update_perk_strength`                   | set_token_perk updates perk/strength |
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use crate::fixture::{Fixture, TestFixtureConfig};
+    use soroban_sdk::{
+        testutils::Address as _,
+        token::StellarAssetClient,
+        Address,
+    };
+    use tycoon_collectibles::TycoonCollectiblesClient;
+
+    // ── Fixture sanity ────────────────────────────────────────────────────────
+
+    /// The fixture wires collectibles with the fixture admin — admin() must match.
+    #[test]
+    fn fixture_collectibles_is_initialized() {
+        let f = Fixture::new();
+        // get_backend_minter returns None until set_backend_minter is called.
+        // The contract is initialized so double-init must fail (tested below).
+        // The simplest observable initialization fact is that the contract is
+        // deployed and a read-only call succeeds.
+        assert_eq!(f.collectibles.get_backend_minter(), None);
+    }
+
+    // ── Minting ───────────────────────────────────────────────────────────────
+
+    /// backend_mint issues `amount` tokens of `token_id` to `to`.
+    #[test]
+    fn backend_mint_issues_token_to_player() {
+        let f = Fixture::new();
+        // Grant backend-minter role
+        f.collectibles.set_backend_minter(&f.backend);
+        let token_id: u128 = 1001;
+        f.collectibles.backend_mint(&f.backend, &f.player_a, &token_id, &3u64);
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &token_id), 3);
+    }
+
+    /// Each `mint_collectible` call returns a distinct token id.
+    #[test]
+    fn mint_collectible_generates_unique_token_id() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        // mint_collectible(caller, to, perk=0, strength=1)
+        // Perk::None == 0 in the enum; strength 1 is valid
+        let id1 = f.collectibles.mint_collectible(&f.admin, &f.player_a, &0u32, &1u32);
+        let id2 = f.collectibles.mint_collectible(&f.admin, &f.player_b, &0u32, &1u32);
+        let id3 = f.collectibles.mint_collectible(&f.admin, &f.player_c, &0u32, &1u32);
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        assert_ne!(id1, id3);
+        // Each player holds exactly 1 of their token
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &id1), 1);
+        assert_eq!(f.collectibles.balance_of(&f.player_b, &id2), 1);
+        assert_eq!(f.collectibles.balance_of(&f.player_c, &id3), 1);
+    }
+
+    // ── Transfer ──────────────────────────────────────────────────────────────
+
+    /// Transferring a collectible moves balance from sender to receiver.
+    #[test]
+    fn transfer_collectible_between_players() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        let token_id: u128 = 42;
+        f.collectibles.backend_mint(&f.backend, &f.player_a, &token_id, &5u64);
+
+        f.collectibles.transfer(&f.player_a, &f.player_b, &token_id, &2u64);
+
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &token_id), 3);
+        assert_eq!(f.collectibles.balance_of(&f.player_b, &token_id), 2);
+    }
+
+    /// Transfer fails when the sender has no balance.
+    #[test]
+    fn transfer_requires_sender_balance() {
+        let f = Fixture::new();
+        let token_id: u128 = 99;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            f.collectibles.transfer(&f.player_a, &f.player_b, &token_id, &1u64);
+        }));
+        assert!(result.is_err(), "transfer with no balance must panic");
+    }
+
+    // ── Burn ──────────────────────────────────────────────────────────────────
+
+    /// Burning a collectible decrements the owner's balance.
+    #[test]
+    fn burn_reduces_balance() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        let token_id: u128 = 200;
+        f.collectibles.backend_mint(&f.backend, &f.player_a, &token_id, &4u64);
+        f.collectibles.burn(&f.player_a, &token_id, &2u64);
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &token_id), 2);
+    }
+
+    /// Burning more than owned panics.
+    #[test]
+    fn burn_exceeds_balance_rejected() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        let token_id: u128 = 300;
+        f.collectibles.backend_mint(&f.backend, &f.player_a, &token_id, &1u64);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            f.collectibles.burn(&f.player_a, &token_id, &2u64);
+        }));
+        assert!(result.is_err(), "burn > balance must panic");
+    }
+
+    // ── Perk burn ─────────────────────────────────────────────────────────────
+
+    /// `burn_collectible_for_perk` succeeds when the contract is not paused.
+    #[test]
+    fn burn_collectible_for_perk_works() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        // Mint a token with a real perk (perk=1 = first non-None variant)
+        let token_id = f.collectibles.mint_collectible(&f.admin, &f.player_a, &1u32, &5u32);
+        // Contract is unpaused by default — burn_collectible_for_perk must succeed
+        f.collectibles.burn_collectible_for_perk(&f.player_a, &token_id);
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &token_id), 0);
+    }
+
+    /// `burn_collectible_for_perk` is blocked while the contract is paused.
+    #[test]
+    fn burn_collectible_for_perk_blocked_when_paused() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        let token_id = f.collectibles.mint_collectible(&f.admin, &f.player_a, &1u32, &5u32);
+        f.collectibles.set_pause(&true);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            f.collectibles.burn_collectible_for_perk(&f.player_a, &token_id);
+        }));
+        assert!(result.is_err(), "perk burn while paused must be rejected");
+        // Balance unchanged — no tokens burned
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &token_id), 1);
+    }
+
+    /// Unpausing restores perk-burn functionality.
+    #[test]
+    fn perk_burn_resumes_after_unpause() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        let token_id = f.collectibles.mint_collectible(&f.admin, &f.player_a, &1u32, &5u32);
+        f.collectibles.set_pause(&true);
+        f.collectibles.set_pause(&false);
+        f.collectibles.burn_collectible_for_perk(&f.player_a, &token_id);
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &token_id), 0);
+    }
+
+    // ── Access control ────────────────────────────────────────────────────────
+
+    /// A non-admin address cannot call `set_backend_minter`.
+    #[test]
+    fn non_admin_cannot_set_backend_minter() {
+        use soroban_sdk::IntoVal;
+        use tycoon_collectibles::TycoonCollectibles;
+        let env = soroban_sdk::Env::default();
+        let contract_id = env.register(TycoonCollectibles, ());
+        let client = TycoonCollectiblesClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let new_minter = Address::generate(&env);
+        env.mock_all_auths();
+        let _ = client.initialize(&admin);
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "set_backend_minter",
+                args: soroban_sdk::vec![&env, new_minter.clone().into_val(&env)],
+                sub_invokes: &[],
+            },
+        }]);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.set_backend_minter(&new_minter);
+        }));
+        assert!(result.is_err(), "non-admin must not set backend minter");
+    }
+
+    /// A non-admin address cannot call `stock_shop`.
+    #[test]
+    fn non_admin_cannot_stock_shop() {
+        use soroban_sdk::IntoVal;
+        use tycoon_collectibles::TycoonCollectibles;
+        let env = soroban_sdk::Env::default();
+        let contract_id = env.register(TycoonCollectibles, ());
+        let client = TycoonCollectiblesClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let tyc = Address::generate(&env);
+        let usdc = Address::generate(&env);
+        env.mock_all_auths();
+        let _ = client.initialize(&admin);
+        let _ = client.init_shop(&tyc, &usdc);
+        // Remove admin auth — attacker attempts stock_shop
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "stock_shop",
+                args: soroban_sdk::vec![
+                    &env,
+                    1u64.into_val(&env),
+                    0u32.into_val(&env),
+                    1u32.into_val(&env),
+                    100u128.into_val(&env),
+                    10u128.into_val(&env)
+                ],
+                sub_invokes: &[],
+            },
+        }]);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.stock_shop(&1u64, &0u32, &1u32, &100u128, &10u128);
+        }));
+        assert!(result.is_err(), "non-admin must not stock shop");
+    }
+
+    /// Setting backend_minter twice updates the minter; the old minter is rejected.
+    #[test]
+    fn admin_revoke_replaces_minter() {
+        let f = Fixture::new();
+        let first_minter = Address::generate(&f.env);
+        let second_minter = Address::generate(&f.env);
+
+        f.collectibles.set_backend_minter(&first_minter);
+        assert_eq!(f.collectibles.get_backend_minter(), Some(first_minter.clone()));
+
+        f.collectibles.set_backend_minter(&second_minter);
+        assert_eq!(f.collectibles.get_backend_minter(), Some(second_minter.clone()));
+
+        // Old minter can no longer mint
+        let token_id: u128 = 1234;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            f.collectibles.backend_mint(&first_minter, &f.player_a, &token_id, &1u64);
+        }));
+        assert!(result.is_err(), "replaced minter must not mint");
+    }
+
+    // ── Multi-player isolation ────────────────────────────────────────────────
+
+    /// Three players each receive different tokens; balances are independent.
+    #[test]
+    fn multi_player_independent_balances() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        let id_a: u128 = 10;
+        let id_b: u128 = 20;
+        let id_c: u128 = 30;
+
+        f.collectibles.backend_mint(&f.backend, &f.player_a, &id_a, &3u64);
+        f.collectibles.backend_mint(&f.backend, &f.player_b, &id_b, &5u64);
+        f.collectibles.backend_mint(&f.backend, &f.player_c, &id_c, &7u64);
+
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &id_a), 3);
+        assert_eq!(f.collectibles.balance_of(&f.player_b, &id_b), 5);
+        assert_eq!(f.collectibles.balance_of(&f.player_c, &id_c), 7);
+
+        // Cross-check: players have 0 balance for each other's tokens
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &id_b), 0);
+        assert_eq!(f.collectibles.balance_of(&f.player_b, &id_c), 0);
+        assert_eq!(f.collectibles.balance_of(&f.player_c, &id_a), 0);
+    }
+
+    // ── State guards ──────────────────────────────────────────────────────────
+
+    /// A second `initialize` call is rejected — state is not corrupted.
+    #[test]
+    fn double_initialize_rejected() {
+        let f = Fixture::new();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // Fixture already initialized collectibles; second call must fail
+            f.collectibles.initialize(&f.admin);
+        }));
+        assert!(result.is_err(), "double-initialize must be rejected");
+    }
+
+    // ── Shop flow ─────────────────────────────────────────────────────────────
+
+    /// `stock_shop` → `buy_collectible_from_shop` (TYC path) completes successfully.
+    #[test]
+    fn stock_shop_and_buy_with_tyc() {
+        let f = Fixture::new();
+        let tyc_price: u128 = 50_000_000_000_000_000_000; // 50 TYC
+        let token_id: u128;
+
+        // Admin initializes the shop and stocks one collectible type
+        f.collectibles.init_shop(&f.tyc_id, &f.usdc_id);
+        token_id = f.collectibles.stock_shop(&1u64, &0u32, &1u32, &tyc_price, &0u128);
+
+        // Fund player_a with enough TYC for the purchase
+        f.mint_tyc(&f.player_a, tyc_price as i128 + 1_000_000_000_000_000_000);
+
+        let balance_before = f.tyc_balance(&f.player_a);
+        f.collectibles.buy_collectible_from_shop(&f.player_a, &token_id, &false);
+
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &token_id), 1);
+        assert_eq!(f.tyc_balance(&f.player_a), balance_before - tyc_price as i128);
+    }
+
+    /// `stock_shop` → `buy_collectible_from_shop` (USDC path) completes successfully.
+    #[test]
+    fn stock_shop_and_buy_with_usdc() {
+        let f = Fixture::new();
+        let usdc_price: u128 = 5_000_000; // 5 USDC (6 decimals)
+        let token_id: u128;
+
+        f.collectibles.init_shop(&f.tyc_id, &f.usdc_id);
+        token_id = f.collectibles.stock_shop(&1u64, &0u32, &1u32, &0u128, &usdc_price);
+
+        // Fund player_b with USDC
+        f.mint_usdc(&f.player_b, usdc_price as i128 + 1_000_000);
+
+        let usdc_before = f.usdc_balance(&f.player_b);
+        f.collectibles.buy_collectible_from_shop(&f.player_b, &token_id, &true);
+
+        assert_eq!(f.collectibles.balance_of(&f.player_b, &token_id), 1);
+        assert_eq!(f.usdc_balance(&f.player_b), usdc_before - usdc_price as i128);
+    }
+
+    /// Purchasing when stock is depleted panics.
+    #[test]
+    fn buy_from_empty_stock_rejected() {
+        let f = Fixture::new();
+        f.collectibles.init_shop(&f.tyc_id, &f.usdc_id);
+        // Stock 1 item, then buy it to exhaust stock
+        let tyc_price: u128 = 1_000_000_000_000_000_000;
+        let token_id = f.collectibles.stock_shop(&1u64, &0u32, &1u32, &tyc_price, &0u128);
+        f.mint_tyc(&f.player_a, tyc_price as i128 * 2);
+        f.collectibles.buy_collectible_from_shop(&f.player_a, &token_id, &false);
+
+        // Second purchase — stock exhausted
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            f.collectibles.buy_collectible_from_shop(&f.player_a, &token_id, &false);
+        }));
+        assert!(result.is_err(), "out-of-stock purchase must be rejected");
+    }
+
+    // ── Enumeration helpers ───────────────────────────────────────────────────
+
+    /// `owned_token_count` tracks mint and burn correctly.
+    #[test]
+    fn owned_token_count_tracks_mint_and_burn() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        assert_eq!(f.collectibles.owned_token_count(&f.player_a), 0);
+
+        let id1 = f.collectibles.mint_collectible(&f.admin, &f.player_a, &0u32, &1u32);
+        let id2 = f.collectibles.mint_collectible(&f.admin, &f.player_a, &0u32, &1u32);
+        assert_eq!(f.collectibles.owned_token_count(&f.player_a), 2);
+
+        f.collectibles.burn(&f.player_a, &id1, &1u64);
+        assert_eq!(f.collectibles.owned_token_count(&f.player_a), 1);
+
+        f.collectibles.burn(&f.player_a, &id2, &1u64);
+        assert_eq!(f.collectibles.owned_token_count(&f.player_a), 0);
+    }
+
+    /// `tokens_of` returns all token ids owned by the player.
+    #[test]
+    fn tokens_of_returns_all_owned_ids() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        let id1 = f.collectibles.mint_collectible(&f.admin, &f.player_b, &0u32, &1u32);
+        let id2 = f.collectibles.mint_collectible(&f.admin, &f.player_b, &0u32, &1u32);
+
+        let owned = f.collectibles.tokens_of(&f.player_b);
+        assert_eq!(owned.len(), 2);
+        // Both ids must appear in the list
+        let mut found1 = false;
+        let mut found2 = false;
+        for i in 0..owned.len() {
+            let t = owned.get(i).unwrap();
+            if t == id1 { found1 = true; }
+            if t == id2 { found2 = true; }
+        }
+        assert!(found1, "id1 must be in tokens_of");
+        assert!(found2, "id2 must be in tokens_of");
+    }
+
+    /// `balance_of` returns 0 for a token id that was never minted to the address.
+    #[test]
+    fn stale_token_id_balance_is_zero() {
+        let f = Fixture::new();
+        let ghost_token_id: u128 = 0xDEAD_BEEF_CAFE;
+        assert_eq!(f.collectibles.balance_of(&f.player_a, &ghost_token_id), 0);
+        // No state should be created for unknown queries
+        assert_eq!(f.collectibles.owned_token_count(&f.player_a), 0);
+    }
+
+    // ── Perk management ───────────────────────────────────────────────────────
+
+    /// Admin can update perk and strength for an existing token.
+    #[test]
+    fn admin_can_update_perk_strength() {
+        let f = Fixture::new();
+        f.collectibles.set_backend_minter(&f.backend);
+        let token_id: u128 = 777;
+        f.collectibles.backend_mint(&f.backend, &f.player_a, &token_id, &1u64);
+
+        // Set perk to 1 (first non-None variant) with strength 10
+        f.collectibles.set_token_perk(&token_id, &1u32, &10u32);
+
+        assert_eq!(f.collectibles.get_token_strength(&token_id), 10);
+    }
+
+    // ── Fixture config: no collectibles ──────────────────────────────────────
+
+    /// `TestFixtureConfig { deploy_collectibles: false }` skips collectibles init.
+    /// The field is present; no panic on access to the stub address.
+    #[test]
+    fn fixture_config_without_collectibles() {
+        let env = soroban_sdk::Env::default();
+        env.mock_all_auths();
+        let config = crate::fixture::TestFixtureConfig {
+            deploy_boost_system: true,
+            deploy_collectibles: false,
+            usdc_game_fund: 0,
+        };
+        let f = Fixture::new_with_config(&env, config);
+        // Accessing the stub address must not panic
+        let _ = f.collectibles_id.clone();
+    }
+}

--- a/contract/integration-tests/src/fixture.rs
+++ b/contract/integration-tests/src/fixture.rs
@@ -16,13 +16,14 @@
 ///
 /// ## Deployed contracts
 ///
-/// | Field              | Contract                          |
-/// |--------------------|-----------------------------------|
-/// | `tyc_id`           | TYC token (Stellar asset / SEP-41)|
-/// | `usdc_id`          | USDC mock token (SEP-41)          |
-/// | `reward_id`        | TycoonRewardSystem                |
-/// | `game_id`          | TycoonContract (tycoon-game)      |
-/// | `boost_system_id`  | TycoonBoostSystem                 |
+/// | Field              | Contract                           |
+/// |--------------------|------------------------------------|
+/// | `tyc_id`           | TYC token (Stellar asset / SEP-41) |
+/// | `usdc_id`          | USDC mock token (SEP-41)           |
+/// | `reward_id`        | TycoonRewardSystem                 |
+/// | `game_id`          | TycoonContract (tycoon-game)       |
+/// | `boost_system_id`  | TycoonBoostSystem                  |
+/// | `collectibles_id`  | TycoonCollectibles                 |
 #[cfg(test)]
 pub use inner::{Fixture, TestFixtureConfig, GAME_FUND, REWARD_FUND};
 
@@ -38,6 +39,7 @@ mod inner {
         Address, Env, Vec,
     };
     use tycoon_boost_system::{TycoonBoostSystem, TycoonBoostSystemClient};
+    use tycoon_collectibles::{TycoonCollectibles, TycoonCollectiblesClient};
     use tycoon_game::TycoonContractClient;
     use tycoon_reward_system::{TycoonRewardSystem, TycoonRewardSystemClient};
 
@@ -45,17 +47,31 @@ mod inner {
     pub const REWARD_FUND: i128 = 1_000_000_000_000_000_000_000_000;
     /// TYC pre-funded to the game contract (500 000 TYC, 18 decimals).
     pub const GAME_FUND: i128 = 500_000_000_000_000_000_000_000;
+    /// Default USDC seed minted to the game contract (10 000 USDC, 6 decimals).
+    pub const DEFAULT_USDC_GAME_FUND: i128 = 10_000_000_000;
 
-    /// Configuration for test fixture setup
+    /// Configuration for test fixture setup.
+    ///
+    /// Use `TestFixtureConfig::default()` for standard cross-contract tests.
+    /// Override individual fields to opt-in to optional subsystems or change
+    /// seed balances.
     #[derive(Clone)]
     pub struct TestFixtureConfig {
+        /// Deploy and initialize the boost system. Default: `true`.
         pub deploy_boost_system: bool,
+        /// Deploy and initialize the collectibles contract. Default: `true`.
+        pub deploy_collectibles: bool,
+        /// USDC amount minted to the game contract on setup (6 decimals).
+        /// Set to 0 to skip. Default: `DEFAULT_USDC_GAME_FUND`.
+        pub usdc_game_fund: i128,
     }
 
     impl Default for TestFixtureConfig {
         fn default() -> Self {
             Self {
                 deploy_boost_system: true,
+                deploy_collectibles: true,
+                usdc_game_fund: DEFAULT_USDC_GAME_FUND,
             }
         }
     }
@@ -76,21 +92,28 @@ mod inner {
         pub reward_id: Address,
         pub game_id: Address,
         pub boost_system_id: Address,
+        pub collectibles_id: Address,
         // Clients
         pub tyc: TokenClient<'a>,
         pub reward: TycoonRewardSystemClient<'a>,
         pub game: TycoonContractClient<'a>,
         pub boost_system: TycoonBoostSystemClient<'a>,
+        pub collectibles: TycoonCollectiblesClient<'a>,
     }
 
     #[allow(dead_code)]
     impl Fixture<'_> {
+        /// Create a fully-wired fixture with all subsystems enabled.
         pub fn new() -> Self {
             let env = Env::default();
             let config = TestFixtureConfig::default();
             Self::new_with_config(&env, config)
         }
 
+        /// Create a fixture with a custom configuration.
+        ///
+        /// Use this when you need to disable optional subsystems (e.g. boost
+        /// system or collectibles) or override the USDC seed fund.
         pub fn new_with_config(env: &Env, config: TestFixtureConfig) -> Self {
             env.mock_all_auths();
 
@@ -125,6 +148,11 @@ mod inner {
             StellarAssetClient::new(env, &tyc_id).mint(&game_id, &GAME_FUND);
             game.set_backend_game_controller(&backend);
 
+            // Seed USDC to the game contract if requested
+            if config.usdc_game_fund > 0 {
+                StellarAssetClient::new(env, &usdc_id).mint(&game_id, &config.usdc_game_fund);
+            }
+
             // Boost system (optional)
             let boost_system_id = if config.deploy_boost_system {
                 env.register(TycoonBoostSystem, ())
@@ -134,6 +162,17 @@ mod inner {
             let boost_system = TycoonBoostSystemClient::new(env, &boost_system_id);
             if config.deploy_boost_system {
                 boost_system.initialize(&admin);
+            }
+
+            // Collectibles contract (optional)
+            let collectibles_id = if config.deploy_collectibles {
+                env.register(TycoonCollectibles, ())
+            } else {
+                Address::generate(env)
+            };
+            let collectibles = TycoonCollectiblesClient::new(env, &collectibles_id);
+            if config.deploy_collectibles {
+                collectibles.initialize(&admin);
             }
 
             Fixture {
@@ -148,12 +187,16 @@ mod inner {
                 reward_id,
                 game_id,
                 boost_system_id,
+                collectibles_id,
                 tyc,
                 reward,
                 game,
                 boost_system,
+                collectibles,
             }
         }
+
+        // ── Token helpers ─────────────────────────────────────────────────────
 
         /// TYC balance of any address.
         pub fn tyc_balance(&self, addr: &Address) -> i128 {
@@ -163,6 +206,34 @@ mod inner {
         /// USDC balance of any address.
         pub fn usdc_balance(&self, addr: &Address) -> i128 {
             TokenClient::new(&self.env, &self.usdc_id).balance(addr)
+        }
+
+        /// Return a `TokenClient` for the USDC contract.
+        ///
+        /// Useful when tests need repeated USDC queries without constructing the
+        /// client inline each time.
+        pub fn usdc_client(&self) -> TokenClient<'_> {
+            TokenClient::new(&self.env, &self.usdc_id)
+        }
+
+        /// Assert that `addr` holds exactly `expected` TYC, with a descriptive
+        /// message on failure.
+        pub fn assert_tyc_balance(&self, addr: &Address, expected: i128, msg: &str) {
+            let actual = self.tyc_balance(addr);
+            assert_eq!(
+                actual, expected,
+                "TYC balance mismatch for {msg}: got {actual}, expected {expected}"
+            );
+        }
+
+        /// Assert that `addr` holds exactly `expected` USDC, with a descriptive
+        /// message on failure.
+        pub fn assert_usdc_balance(&self, addr: &Address, expected: i128, msg: &str) {
+            let actual = self.usdc_balance(addr);
+            assert_eq!(
+                actual, expected,
+                "USDC balance mismatch for {msg}: got {actual}, expected {expected}"
+            );
         }
 
         /// Mint TYC to an address (admin operation).
@@ -175,18 +246,30 @@ mod inner {
             StellarAssetClient::new(&self.env, &self.usdc_id).mint(to, &amount);
         }
 
+        /// Mint USDC directly into the game contract and return the new balance.
+        ///
+        /// Convenience wrapper for tests that need to top-up the game's USDC
+        /// treasury without constructing a `StellarAssetClient` themselves.
+        pub fn mint_usdc_to_game(&self, amount: i128) -> i128 {
+            StellarAssetClient::new(&self.env, &self.usdc_id).mint(&self.game_id, &amount);
+            self.usdc_balance(&self.game_id)
+        }
+
         /// Transfer TYC from one address to another.
         pub fn transfer_tyc(&self, from: &Address, to: &Address, amount: i128) {
             self.tyc.transfer(from, to, &amount);
         }
 
+        // ── Ledger helpers ────────────────────────────────────────────────────
+
         /// Get the current ledger sequence number.
-        #[allow(dead_code)]
         pub fn current_ledger(&self) -> u32 {
             self.env.ledger().sequence()
         }
 
         /// Advance ledger by a number of sequences.
+        ///
+        /// Each sequence is assumed to be 5 seconds (Stellar mainnet cadence).
         pub fn advance_ledger(&self, sequences: u32) {
             use soroban_sdk::testutils::{Ledger, LedgerInfo};
             let current = self.env.ledger().get();
@@ -198,6 +281,8 @@ mod inner {
         }
 
         /// Set ledger to a specific sequence number.
+        ///
+        /// Timestamp is derived as `sequence * 5` seconds from epoch.
         pub fn set_ledger(&self, sequence: u32) {
             use soroban_sdk::testutils::{Ledger, LedgerInfo};
             let current = self.env.ledger().get();
@@ -208,10 +293,39 @@ mod inner {
             });
         }
 
+        /// Advance the ledger by approximately `seconds` of wall-clock time.
+        ///
+        /// Converts seconds to sequences using the 5 s/ledger Stellar cadence.
+        /// Fractional sequences are truncated; a minimum of 1 sequence is
+        /// always advanced so the ledger actually moves forward.
+        pub fn advance_ledger_by_seconds(&self, seconds: u64) {
+            let sequences = u32::max(1, (seconds / 5) as u32);
+            self.advance_ledger(sequences);
+        }
+
+        // ── Player helpers ────────────────────────────────────────────────────
+
         /// Create a new player address (for dynamic test scenarios).
         pub fn new_player(&self) -> Address {
             Address::generate(&self.env)
         }
+
+        /// Create a new address and register it in the game contract under
+        /// `username`, returning the address.
+        ///
+        /// Allows tests to set up registered players in a single line:
+        /// ```ignore
+        /// let alice = f.new_registered_player("alice");
+        /// ```
+        pub fn new_registered_player(&self, username: &str) -> Address {
+            use soroban_sdk::String;
+            let player = Address::generate(&self.env);
+            let uname = String::from_str(&self.env, username);
+            self.game.register_player(&uname, &player);
+            player
+        }
+
+        // ── Boost system helpers ──────────────────────────────────────────────
 
         /// Get all active boost IDs for a player.
         pub fn get_boost_ids(&self, player: &Address) -> Vec<u128> {
@@ -236,6 +350,19 @@ mod inner {
                 }
             }
             false
+        }
+
+        // ── Reward helpers ────────────────────────────────────────────────────
+
+        /// Mint a voucher and immediately redeem it, returning the TYC amount
+        /// transferred to `player`.
+        ///
+        /// Useful in tests that care about the end balance but not the voucher
+        /// lifecycle details.
+        pub fn mint_and_redeem(&self, player: &Address, value: u128) -> i128 {
+            let tid = self.reward.mint_voucher(&self.admin, player, &value);
+            self.reward.redeem_voucher_from(player, &tid);
+            value as i128
         }
     }
 }

--- a/contract/integration-tests/src/lib.rs
+++ b/contract/integration-tests/src/lib.rs
@@ -32,3 +32,6 @@ mod security_review_checklist;
 mod simulation_scenarios;
 #[cfg(test)]
 mod token_reward_flow;
+// Collectibles cross-contract integration tests
+#[cfg(test)]
+mod collectibles_integration;


### PR DESCRIPTION
closes #1324
closes #1325
closes #1327
closes #1326


# Workspace Security Review Checklist — Soroban Contracts (SW-CONTRACT-HYGIENE-001)

**Stellar Wave batch** | **Issue:** SW-CONTRACT-HYGIENE-001 | **PR:** references SW-CONTRACT-HYGIENE-001

This document is the single authoritative workspace-level security checklist for all
contracts under `contract/contracts/`. Per-contract checklists live alongside each
crate and are linked below.

---

## 1. Per-Contract Checklist Status

| Contract | Checklist | Status |
|---|---|---|
| tycoon-token | [SECURITY_REVIEW_CHECKLIST.md](contracts/tycoon-token/SECURITY_REVIEW_CHECKLIST.md) | ✅ Complete |
| tycoon-collectibles | [SECURITY_REVIEW_CHECKLIST.md](contracts/tycoon-collectibles/SECURITY_REVIEW_CHECKLIST.md) | ⚠️ Items unchecked — pre-mainnet |
| tycoon-boost-system | [SECURITY_REVIEW_CHECKLIST.md](contracts/tycoon-boost-system/SECURITY_REVIEW_CHECKLIST.md) | ✅ Complete (1 open medium) |
| tycoon-reward-system | No dedicated checklist | 🔲 Needed before mainnet |
| tycoon-game | No dedicated checklist | 🔲 Needed before mainnet |
| tycoon-lib | [SECURITY_REVIEW_CHECKLIST.md](contracts/tycoon-lib/SECURITY_REVIEW_CHECKLIST.md) | ✅ Library only — no auth surface (checklist added #1008) |

---

## 2. Workspace-Wide Security Properties

### 2.1 No Unaudited Oracle or Privileged Pattern in Production

- [x] No contract reads an external price feed or oracle
- [x] All privileged roles (admin, backend minter, game controller) are set at `initialize` time and require `require_auth()` on every mutation
- [x] No contract grants itself elevated privileges via `env.current_contract_address()` as an auth principal
- [x] **RESOLVED:** `tycoon-game::admin_mint_registration_voucher` has idempotency guard — tracked as BLK-002 in `CEI_SECURITY_AUDIT.md`
- [x] **RESOLVED:** `tycoon-collectibles::buy_collectible` gated behind admin.require_auth() — tracked as BLK-001 in `CEI_SECURITY_AUDIT.md`

### 2.2 CEI (Checks-Effects-Interactions) Compliance

All cross-contract calls audited in `CEI_SECURITY_AUDIT.md`. Summary:

| Contract | Function | CEI Status |
|---|---|---|
| tycoon-reward-system | `redeem_voucher_from` | ✅ Fixed |
| tycoon-collectibles | `buy_collectible_from_shop` | ✅ Fixed |
| tycoon-main-game | `leave_pending_game` | ✅ Fixed |
| tycoon-game | `withdraw_funds` | ✅ Safe (no post-call mutation) |
| tycoon-collectibles | `buy_collectible` | ✅ Gated behind admin.require_auth() |

### 2.3 Integer Arithmetic

- [x] All token balance mutations use `checked_add` / `checked_sub` with explicit panic messages
- [x] `tycoon-token`: `mint` uses `checked_add` on balance and total supply
- [x] `tycoon-token`: `burn` / `burn_from` use `checked_sub` on total supply
- [x] `tycoon-reward-system`: `_mint` uses `checked_add`; `_burn` uses explicit `>=` guard before subtraction
- [x] `tycoon-boost-system`: stacking arithmetic uses `u64` intermediates to avoid `u32` overflow
- [x] Cargo workspace profile sets `overflow-checks = true` for release builds

### 2.4 Access Control Patterns

- [x] Every admin-only entrypoint calls `require_auth()` on the stored admin address before any state mutation
- [x] `initialize` functions are one-time guarded (panic on re-call)
- [x] No function grants a caller elevated privileges based on caller-supplied input alone
- [x] Backend minter / game controller roles are scoped — they cannot pause, withdraw, or set admin

### 2.5 Event Auditability

- [x] All state-changing operations emit at least one event
- [x] Admin role changes emit events with old + new addresses (tycoon-token `SetAdminEvent`)
- [x] Pause / unpause emit events
- [x] Deprecated function calls emit `DeprecatedFunctionCalledEvent` (tycoon-boost-system)
- [x] No sensitive data (private keys, off-chain secrets) appears in event topics or data

### 2.6 Storage Economics

- [x] Persistent storage entries are removed (not zero-written) when they reach a terminal state
- [x] No unbounded loops over storage — pagination used where enumeration is needed
- [x] Expired boosts are pruned on write paths to prevent unbounded growth
- [x] WASM size budget enforced via `contract/ci/wasm-size-budget.json` and `scripts/check-wasm-sizes.sh`

---

## 3. Soroban Best Practices Compliance

| Practice | Status | Notes |
|---|---|---|
| `resolver = "2"` in workspace Cargo.toml | ✅ | |
| `overflow-checks = true` in release profile | ✅ | |
| `panic = "abort"` in release profile | ✅ | Reduces WASM size; no unwinding |
| `lto = true`, `codegen-units = 1` | ✅ | Optimal WASM size |
| `opt-level = "z"` | ✅ | Size-optimised |
| No `std` in contract crates (`#![no_std]`) | ✅ | All contract crates |
| `soroban-sdk` version pinned at workspace level | ✅ | `soroban-sdk = "23"` |
| Auth checked before state mutation | ✅ | Verified per-contract |
| CEI pattern followed for cross-contract calls | ✅ (with noted blockers) | See §2.2 |
| No raw `unwrap()` on storage reads in production paths | ✅ | `expect("message")` used throughout |

---

## 4. Blockers (Must Fix Before Mainnet)

| ID | Contract | Issue | Severity | Status |
|---|---|---|---|---|
| BLK-001 | tycoon-collectibles | `buy_collectible` allows free unlimited minting | Critical | ✅ Resolved (Gated) |
| BLK-002 | tycoon-game | `admin_mint_registration_voucher` has no idempotency guard | Medium | ✅ Resolved (Idempotent) |

---

## 5. Open Medium Issues

| ID | Contract | Issue | Severity |
|---|---|---|---|
| SW-CONTRACT-HYGIENE-001-M1 | tycoon-boost-system | No `set_admin` / admin key rotation | Medium |
| SW-CONTRACT-HYGIENE-001-M2 | tycoon-reward-system | No dedicated security checklist | Medium |
| SW-CONTRACT-HYGIENE-001-M3 | tycoon-game | No dedicated security checklist | Medium |

---

## 6. CI Requirements

Before merging any PR that touches `contract/`:

- [ ] `cargo check --workspace` passes (excludes `archive/` and `tycoon-main-game` per workspace exclusions)
- [ ] `cargo test --workspace` passes
- [ ] `contract/scripts/check-wasm-sizes.sh` passes (WASM within budget)
- [ ] This checklist reviewed and updated if new entrypoints or roles are added

---

## 7. External Audit

An external audit is recommended before mainnet deployment. See `CEI_SECURITY_AUDIT.md §6` for scope and estimated cost.

**Sign-off required from:** Tech Lead, Smart Contract Dev, Security Reviewer, External Auditor (pending).
