### PR TITLE
Game pay-rent and unlock-balance validation

### DIFF
--- a/backend/src/modules/games/game-players-ownership.spec.ts
+++ b/backend/src/modules/games/game-players-ownership.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, BadRequestException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { GamePlayersService } from './game-players.service';
+import { GamePlayer } from './entities/game-player.entity';
+import { Game } from './entities/game.entity';
+import { BoostService } from '../perks-boosts/services/boost.service';
+import { PerksBoostsEvents } from '../perks-boosts/services/perks-boosts-events.service';
+import { PaginationService } from '../../common';
+
+describe('GamePlayersService - pay-rent/unlock-balance validation (#1298)', () => {
+  let service: GamePlayersService;
+
+  const mockGamePlayerRepository = {
+    findOne: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockGameRepository = { findOne: jest.fn() };
+  const mockBoostService = { calculateModifiedValue: jest.fn() };
+  const mockEvents = { emit: jest.fn() };
+  const mockPaginationService = { paginate: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GamePlayersService,
+        { provide: getRepositoryToken(GamePlayer), useValue: mockGamePlayerRepository },
+        { provide: getRepositoryToken(Game), useValue: mockGameRepository },
+        { provide: BoostService, useValue: mockBoostService },
+        { provide: PerksBoostsEvents, useValue: mockEvents },
+        { provide: PaginationService, useValue: mockPaginationService },
+      ],
+    }).compile();
+
+    service = module.get<GamePlayersService>(GamePlayersService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('unlockBalance', () => {
+    it('rejects non-positive amounts', async () => {
+      await expect(service.unlockBalance(1, 0)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.unlockBalance(1, -5)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects when requester does not own the player', async () => {
+      mockGamePlayerRepository.findOne.mockResolvedValue({
+        id: 1,
+        user_id: 10,
+        trade_locked_balance: '50',
+      });
+
+      await expect(service.unlockBalance(1, 10, 999)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('allows the owning user to unlock', async () => {
+      const player = { id: 1, user_id: 10, trade_locked_balance: '50' };
+      mockGamePlayerRepository.findOne.mockResolvedValue(player);
+      mockGamePlayerRepository.save.mockImplementation((p) => p);
+
+      const result = await service.unlockBalance(1, 10, 10);
+      expect(result.trade_locked_balance).toBe('40.00');
+    });
+  });
+
+  describe('payRent', () => {
+    it('rejects when requester is not the payer', async () => {
+      mockGamePlayerRepository.findOne
+        .mockResolvedValueOnce({ id: 1, user_id: 10, game_id: 5, balance: 100 })
+        .mockResolvedValueOnce({ id: 2, user_id: 20, game_id: 5, balance: 0 });
+
+      await expect(service.payRent(5, 1, 2, 50, 999)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('allows the owning payer to pay rent', async () => {
+      mockGamePlayerRepository.findOne
+        .mockResolvedValueOnce({ id: 1, user_id: 10, game_id: 5, balance: 100 })
+        .mockResolvedValueOnce({ id: 2, user_id: 20, game_id: 5, balance: 0 });
+      mockBoostService.calculateModifiedValue.mockResolvedValue(50);
+      mockGamePlayerRepository.save.mockResolvedValue([]);
+
+      const result = await service.payRent(5, 1, 2, 50, 10);
+      expect(result.finalRent).toBe(50);
+    });
+  });
+});

--- a/backend/src/modules/games/game-players.controller.ts
+++ b/backend/src/modules/games/game-players.controller.ts
@@ -5,7 +5,10 @@ import {
   Param,
   Post,
   ParseIntPipe,
+  Req,
+  UseGuards,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import { GamePlayersService } from './game-players.service';
 import { LockBalanceDto } from './dto/lock-balance.dto';
 import { UnlockBalanceDto } from './dto/unlock-balance.dto';
@@ -13,6 +16,7 @@ import { RollDiceDto } from './dto/roll-dice.dto';
 import { PayRentDto } from './dto/pay-rent.dto';
 import { PayTaxDto } from './dto/pay-tax.dto';
 import { BuyPropertyDto } from './dto/buy-property.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @Controller('game-players')
 export class GamePlayersController {
@@ -40,11 +44,17 @@ export class GamePlayersController {
   }
 
   @Post(':id/unlock-balance')
+  @UseGuards(JwtAuthGuard)
   async unlockBalance(
     @Param('id', ParseIntPipe) id: number,
     @Body() dto: UnlockBalanceDto,
+    @Req() req: Request & { user: { id: number } },
   ) {
-    const player = await this.gamePlayersService.unlockBalance(id, dto.amount);
+    const player = await this.gamePlayersService.unlockBalance(
+      id,
+      dto.amount,
+      req.user.id,
+    );
     return {
       playerId: player.id,
       balance: player.balance,
@@ -54,16 +64,19 @@ export class GamePlayersController {
   }
 
   @Post(':id/pay-rent/:gameId')
+  @UseGuards(JwtAuthGuard)
   async payRent(
     @Param('id', ParseIntPipe) id: number,
     @Param('gameId', ParseIntPipe) gameId: number,
     @Body() dto: PayRentDto,
+    @Req() req: Request & { user: { id: number } },
   ) {
     return this.gamePlayersService.payRent(
       gameId,
       id,
       dto.payeeId,
       dto.baseRent,
+      req.user.id,
     );
   }
 

--- a/backend/src/modules/games/game-players.service.ts
+++ b/backend/src/modules/games/game-players.service.ts
@@ -66,11 +66,20 @@ export class GamePlayersService {
   /**
    * Unlock funds when trade is cancelled or completed.
    */
-  async unlockBalance(playerId: number, amount: number): Promise<GamePlayer> {
+  async unlockBalance(
+    playerId: number,
+    amount: number,
+    requesterId?: number,
+  ): Promise<GamePlayer> {
     if (amount <= 0) {
       throw new BadRequestException('Unlock amount must be positive');
     }
     const player = await this.findOne(playerId);
+    if (requesterId !== undefined && player.user_id !== requesterId) {
+      throw new ForbiddenException(
+        'You can only unlock balance for your own player',
+      );
+    }
     const currentLocked = parseFloat(player.trade_locked_balance ?? '0');
     if (amount > currentLocked) {
       throw new BadRequestException(
@@ -485,9 +494,14 @@ export class GamePlayersService {
     payerId: number,
     payeeId: number,
     baseRent: number,
+    requesterId?: number,
   ): Promise<{ payer: GamePlayer; payee: GamePlayer; finalRent: number }> {
     const payer = await this.findByGameAndPlayer(gameId, payerId);
     const payee = await this.findByGameAndPlayer(gameId, payeeId);
+
+    if (requesterId !== undefined && payer.user_id !== requesterId) {
+      throw new ForbiddenException('You can only pay rent as your own player');
+    }
 
     // Hook into Boost Engine: Rent modifier - Reduce rent for payer, or Increase rent for payee
     // The game design normally dictates rent multipliers apply to the payee's earnings, but we can evaluate it for both.

--- a/backend/src/modules/games/games.controller.ts
+++ b/backend/src/modules/games/games.controller.ts
@@ -320,18 +320,21 @@ export class GamesController {
   }
 
   @Post(':gameId/players/:playerId/pay-rent')
+  @UseGuards(JwtAuthGuard)
   @Idempotent()
   @ApiOperation({ summary: 'Pay rent with boost modifiers applied' })
   async payRent(
     @Param('gameId', ParseIntPipe) gameId: number,
     @Param('playerId', ParseIntPipe) playerId: number,
     @Body() dto: PayRentDto,
+    @Req() req: Request & { user: { id: number } },
   ) {
     return this.gamePlayersService.payRent(
       gameId,
       playerId,
       dto.payeeId,
       dto.baseRent,
+      req.user.id,
     );
   }
 


### PR DESCRIPTION
## Summary
`pay-rent` and `unlock-balance` already validated positive amounts via `PayRentDto`/`UnlockBalanceDto`, but neither endpoint verified that the authenticated caller actually owned the game player being debited/credited — any authenticated user could pay rent or unlock balance on someone else's player by guessing the player id.

## Context / Before-after
- Before: `GamePlayersService.payRent`/`unlockBalance` took no requester identity; `GamePlayersController` had no auth guard at all on these routes.
- After: both routes require `JwtAuthGuard`; the service compares `req.user.id` against the target player's `user_id` and throws `ForbiddenException` on mismatch. Applied consistently across the two controllers that expose these actions (`GamesController` and `GamePlayersController`).

## Testing
- Added `game-players-ownership.spec.ts` covering: positive-amount rejection (already existing DTO behavior), ownership rejection for both `payRent` and `unlockBalance`, and the happy path where the owning user succeeds.
- Existing `game-boost-integration.spec.ts` tests call `payRent` without a requester id, which remains valid (ownership check is skipped only when no requester id is supplied), so no regressions there.
- Not run locally (no `node_modules` installed in this environment) — relying on CI to execute the Jest suite.

Closes #1298