### PR TITLE
Game join enhanced DTO room-full 409 mapping

### DIFF
--- a/backend/src/modules/games/games-join-room-full.spec.ts
+++ b/backend/src/modules/games/games-join-room-full.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { GamesService } from './games.service';
+import { Game, GameStatus } from './entities/game.entity';
+import { GameSettings } from './entities/game-settings.entity';
+import { GamePlayer } from './entities/game-player.entity';
+import { PaginationService } from '../../common';
+import { GameFullException } from './exceptions/game-exceptions';
+
+describe('GamesService.joinGame - room-full 409 mapping (#1297)', () => {
+  let service: GamesService;
+
+  const mockQueryRunner = {
+    connect: jest.fn(),
+    startTransaction: jest.fn(),
+    commitTransaction: jest.fn(),
+    rollbackTransaction: jest.fn(),
+    release: jest.fn(),
+    manager: {
+      findOne: jest.fn(),
+      count: jest.fn(),
+      create: jest.fn((_entity, data) => data),
+      save: jest.fn((data) => Promise.resolve(data)),
+    },
+  };
+
+  const mockDataSource = {
+    createQueryRunner: jest.fn(() => mockQueryRunner),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GamesService,
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: getRepositoryToken(Game), useValue: {} },
+        { provide: getRepositoryToken(GameSettings), useValue: {} },
+        { provide: getRepositoryToken(GamePlayer), useValue: {} },
+        { provide: DataSource, useValue: mockDataSource },
+        { provide: PaginationService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<GamesService>(GamesService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('throws GameFullException (409, GAME_FULL) when the room is full', async () => {
+    mockQueryRunner.manager.findOne.mockResolvedValueOnce({
+      id: 7,
+      status: GameStatus.PENDING,
+      number_of_players: 2,
+      settings: { startingCash: 1500 },
+    });
+    mockQueryRunner.manager.count.mockResolvedValueOnce(2);
+
+    await expect(service.joinGame(7, 99, {})).rejects.toMatchObject({
+      errorCode: 'GAME_FULL',
+      getStatus: expect.any(Function),
+    });
+
+    expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+  });
+
+  it('exposes a stable errorCode and HTTP 409 for frontend mapServerErrors', async () => {
+    mockQueryRunner.manager.findOne.mockResolvedValueOnce({
+      id: 7,
+      status: GameStatus.PENDING,
+      number_of_players: 2,
+      settings: {},
+    });
+    mockQueryRunner.manager.count.mockResolvedValueOnce(2);
+
+    try {
+      await service.joinGame(7, 99, {});
+      fail('expected GameFullException to be thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GameFullException);
+      expect(err.errorCode).toBe('GAME_FULL');
+      expect(err.getStatus()).toBe(409);
+    }
+  });
+});

--- a/backend/src/modules/games/games.controller.ts
+++ b/backend/src/modules/games/games.controller.ts
@@ -39,7 +39,7 @@ import { RollDiceDto } from './dto/roll-dice.dto';
 import { PayRentDto } from './dto/pay-rent.dto';
 import { PayTaxDto } from './dto/pay-tax.dto';
 import { BuyPropertyDto } from './dto/buy-property.dto';
-import { JoinGameDto } from './dto/join-game.dto';
+import { EnhancedJoinGameDto } from './dto/enhanced-join-game.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { Idempotent } from '../../common/decorators/idempotent.decorator';
 import { IdempotencyInterceptor } from '../../common/interceptors/idempotency.interceptor';
@@ -182,7 +182,7 @@ export class GamesController {
   @ApiUnauthorizedResponse({ description: 'User not authenticated' })
   async joinGame(
     @Param('id', ParseIntPipe) id: number,
-    @Body() dto: JoinGameDto,
+    @Body() dto: EnhancedJoinGameDto,
     @Req() req: Request & { user: { id: number } },
   ) {
     return this.gamesService.joinGame(id, req.user.id, dto);

--- a/backend/src/modules/games/games.service.ts
+++ b/backend/src/modules/games/games.service.ts
@@ -12,11 +12,12 @@ import { GameSettings } from './entities/game-settings.entity';
 import { CreateGameDto } from './dto/create-game.dto';
 import { UpdateGameDto } from './dto/update-game.dto';
 import { UpdateGameSettingsDto } from './dto/update-game-settings.dto';
-import { JoinGameDto } from './dto/join-game.dto';
+import { EnhancedJoinGameDto } from './dto/enhanced-join-game.dto';
 import { GamePlayer } from './entities/game-player.entity';
 import { PaginatedResponse, PaginationService } from '../../common';
 import { GetGamesDto } from './dto/get-games.dto';
 import { secureRandomAlphaNumeric } from '../../common/crypto-secure-random';
+import { GameFullException } from './exceptions/game-exceptions';
 
 /**
  * Generate a unique game code (cryptographically secure per character).
@@ -361,7 +362,7 @@ export class GamesService {
   async joinGame(
     gameId: number,
     userId: number,
-    dto: JoinGameDto,
+    dto: EnhancedJoinGameDto,
   ): Promise<GamePlayer> {
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
@@ -389,7 +390,11 @@ export class GamesService {
       });
 
       if (playerCount >= game.number_of_players) {
-        throw new BadRequestException('Game is full');
+        throw new GameFullException(
+          gameId,
+          playerCount,
+          game.number_of_players,
+        );
       }
 
       const existing = await queryRunner.manager.findOne(GamePlayer, {


### PR DESCRIPTION
## Summary
`GamesService.joinGame` threw a generic `BadRequestException('Game is full')` (HTTP 400, no machine-readable code) when a room was full, even though `GameFullException` (409, `errorCode: GAME_FULL`) already existed in `exceptions/game-exceptions.ts` — it just wasn't wired into the join path. Similarly, `EnhancedJoinGameDto` (stricter address validation) existed but wasn't used by the join route, which still used the looser `JoinGameDto`.

## Context / Before-after
- Before: room-full → 400 Bad Request with a plain message string; join route validated `address` with `JoinGameDto` (no blockchain-address format check).
- After: room-full → 409 Conflict with `{ error: 'GAME_FULL', message, details: { gameId, currentPlayers, maxPlayers } }`, giving the frontend's `mapServerErrors` a stable code to key off. Join route now validates via `EnhancedJoinGameDto`.

## Testing
- Added `games-join-room-full.spec.ts`: asserts a full room throws `GameFullException`, that it carries `errorCode: 'GAME_FULL'`, and that `getStatus()` returns 409; also asserts the transaction is rolled back.
- Not run locally (no `node_modules` installed in this environment) — relying on CI to execute the Jest suite.

Closes #1297