### PR TITLE
fix(shop): bulk-update batch limits, currency validation tests, idempotency test fixes

### DIFF
--- a/backend/docs/ADMIN_ROUTES_MATRIX.md
+++ b/backend/docs/ADMIN_ROUTES_MATRIX.md
@@ -123,6 +123,34 @@ The backend uses two primary guards for admin access control:
 
 ---
 
+### 8. Admin Shop Module
+
+**Base Path**: `/admin/shop`  
+**Controller**: `AdminShopController` (`src/modules/shop/admin-shop.controller.ts`)  
+**Guards**: `JwtAuthGuard`, `AdminGuard`
+
+| HTTP Method | Path | Purpose | Guard Used |
+|-------------|------|---------|------------|
+| PATCH | `/admin/shop/:id/price` | Update a shop item's price (ISO 4217 currency, min 0.01) | AdminGuard |
+| PATCH | `/admin/shop/:id/status` | Toggle a shop item's active status | AdminGuard |
+| POST | `/admin/shop/:id/upload` | Upload up to 5 images for a shop item | AdminGuard |
+| POST | `/admin/shop/bulk/update` | Bulk update 1-100 shop items (partial-success — see below) | AdminGuard |
+
+**Note (#1280 — orphan Express tree audit)**: admin shop management was fully migrated
+from an earlier, pre-Nest implementation into `AdminShopController` under `ShopModule`
+(see commit `22adf0d`, #858). This audit re-confirmed there is no remaining
+standalone/orphan Express router, controller, or app instance for shop management
+anywhere in the repository — `AdminShopController` registered in `ShopModule` is the
+single source of truth for these routes, fully covered by
+`admin-shop.controller.spec.ts`.
+
+**Partial-success policy (#1281)**: `POST /admin/shop/bulk/update` requires 1-100 items
+(`400` if empty or over the limit — see `BulkUpdateShopItemsDto`). Each item is applied
+independently; a failure on one item (e.g. unknown id) is logged and skipped rather than
+aborting the batch, so the response may contain fewer items than were requested.
+
+---
+
 ## Guard Implementations
 
 ### AdminGuard

--- a/backend/docs/SHOP_PURCHASES_RUNBOOK.md
+++ b/backend/docs/SHOP_PURCHASES_RUNBOOK.md
@@ -34,6 +34,20 @@ If a user cannot see their purchased items:
     -   Redis Key: `shop:inventory:<USER_ID>`
     -   Action: `DEL shop:inventory:<USER_ID>`
 
+### 4. Duplicate Purchase Reports (Idempotency)
+`POST /shop/purchase` accepts an `Idempotency-Key` header and is wrapped with
+`IdempotencyInterceptor` (`src/modules/redis/idempotency.interceptor.ts`), matching the
+claim → complete → fail lifecycle used by `shop-api`'s `IdempotencyService.claimKey`:
+-   **Claim**: on a new key, the request is marked `processing` in Redis (`idempotency:<key>`, 24h TTL) before the handler runs.
+-   **Complete**: on success, the response is cached and replayed (with `X-Idempotency-Replayed: true`) for any repeat request using the same key.
+-   **Fail**: if the handler throws, the key is deleted so the client can safely retry with the same key.
+-   A second request while the first is still `processing` receives `409 Conflict`.
+-   Requests without an `Idempotency-Key` header are not deduplicated — each is processed independently.
+
+If a user reports being charged twice for what they believe was one click, check whether
+the client sent the same `Idempotency-Key` on both requests; if not, this is expected
+behavior and should be treated as two independent purchases (see Section 1).
+
 ## Operational Procedures
 
 ### Deactivating a Malfunctioning Shop Item

--- a/backend/src/modules/shop/admin-shop.controller.spec.ts
+++ b/backend/src/modules/shop/admin-shop.controller.spec.ts
@@ -112,15 +112,9 @@ describe('AdminShopController', () => {
       expect(result).toEqual([mockShopItem]);
     });
 
-    it('should handle empty bulk update list', async () => {
-      const bulkUpdateDto: BulkUpdateShopItemsDto = {
-        items: [],
-      };
-
-      await controller.bulkUpdate(bulkUpdateDto);
-
-      expect(service.bulkUpdate).toHaveBeenCalledWith([]);
-    });
+    // Empty/oversized batch rejection (400) is enforced by
+    // BulkUpdateShopItemsDto validation and ShopService.bulkUpdate —
+    // see shop-dto-validation.spec.ts and shop.service.spec.ts.
   });
 
   describe('uploadImages', () => {

--- a/backend/src/modules/shop/admin-shop.controller.ts
+++ b/backend/src/modules/shop/admin-shop.controller.ts
@@ -161,7 +161,9 @@ export class AdminShopController {
     @Param('id', ParseIntPipe) id: number,
     @UploadedFiles() files: Express.Multer.File[],
   ): Promise<ShopItem> {
-    const imageUrls = files.map((file) => `/uploads/shop-items/${file.filename}`);
+    const imageUrls = files.map(
+      (file) => `/uploads/shop-items/${file.filename}`,
+    );
     return this.shopService.update(id, {
       images: imageUrls,
     });
@@ -170,19 +172,30 @@ export class AdminShopController {
   /**
    * POST /admin/shop/bulk/update
    * Bulk update multiple shop items (price, status, etc.)
+   *
+   * Batch size must be between 1 and MAX_BULK_UPDATE_ITEMS (enforced by
+   * BulkUpdateShopItemsDto, 400 on empty/oversized). Partial-success policy:
+   * per-item failures (e.g. unknown id) are skipped and logged rather than
+   * failing the whole batch — see ShopService.bulkUpdate for details.
    */
   @Post('bulk/update')
   @AuditLog(AuditAction.SHOP_ITEM_UPDATED)
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Bulk update shop items (admin only)' })
+  @ApiOperation({
+    summary: 'Bulk update shop items (admin only)',
+    description:
+      'Updates 1-100 shop items in one request. Items that fail individually (e.g. unknown id) are skipped; the response contains only the items that were updated successfully.',
+  })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Items updated successfully.',
+    description:
+      'Items updated successfully (may be a subset of the request; see partial-success policy).',
     type: [ShopItem],
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
-    description: 'Invalid bulk update request.',
+    description:
+      'items is empty, exceeds the batch size limit, or fails item-level validation.',
   })
   @ApiResponse({
     status: HttpStatus.FORBIDDEN,

--- a/backend/src/modules/shop/dto/bulk-update-shop-items.dto.ts
+++ b/backend/src/modules/shop/dto/bulk-update-shop-items.dto.ts
@@ -3,10 +3,15 @@ import {
   IsBoolean,
   IsOptional,
   IsArray,
+  ArrayMinSize,
+  ArrayMaxSize,
   ValidateNested,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
+
+/** Maximum number of items accepted in a single bulk update request. */
+export const MAX_BULK_UPDATE_ITEMS = 100;
 
 export class BulkUpdateItemDto {
   @ApiProperty({ description: 'Shop item ID' })
@@ -26,10 +31,16 @@ export class BulkUpdateItemDto {
 
 export class BulkUpdateShopItemsDto {
   @ApiProperty({
-    description: 'Array of items to update',
+    description: `Array of items to update (1-${MAX_BULK_UPDATE_ITEMS} items). Items are processed independently; a failure on one item does not roll back the others (see ShopService.bulkUpdate partial-success policy).`,
     type: [BulkUpdateItemDto],
+    minItems: 1,
+    maxItems: MAX_BULK_UPDATE_ITEMS,
   })
   @IsArray()
+  @ArrayMinSize(1, { message: 'items must not be empty' })
+  @ArrayMaxSize(MAX_BULK_UPDATE_ITEMS, {
+    message: `items must not contain more than ${MAX_BULK_UPDATE_ITEMS} elements`,
+  })
   @ValidateNested({ each: true })
   @Type(() => BulkUpdateItemDto)
   items: BulkUpdateItemDto[];

--- a/backend/src/modules/shop/dto/shop-dto-validation.spec.ts
+++ b/backend/src/modules/shop/dto/shop-dto-validation.spec.ts
@@ -14,6 +14,11 @@ import {
 } from './create-purchase.dto';
 import { FilterShopItemsDto } from './filter-shop-items.dto';
 import { PurchaseAndGiftDto } from './purchase-and-gift.dto';
+import { UpdateShopPriceDto } from './update-shop-price.dto';
+import {
+  BulkUpdateShopItemsDto,
+  MAX_BULK_UPDATE_ITEMS,
+} from './bulk-update-shop-items.dto';
 import { ShopItemType, ShopItemRarity } from '../enums/shop-item-type.enum';
 
 async function getErrors(DtoClass: new () => object, plain: object) {
@@ -235,5 +240,110 @@ describe('PurchaseAndGiftDto validation (SW-BE-010)', () => {
         message: 'x'.repeat(500),
       }),
     ).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UpdateShopPriceDto (#1282)
+// ---------------------------------------------------------------------------
+
+describe('UpdateShopPriceDto validation (#1282)', () => {
+  const valid = { price: 19.99 };
+
+  it('passes with minimal valid payload', async () => {
+    expect(await getErrors(UpdateShopPriceDto, valid)).toHaveLength(0);
+  });
+
+  it('rejects zero price', async () => {
+    const errors = await getErrors(UpdateShopPriceDto, { price: 0 });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects negative price', async () => {
+    const errors = await getErrors(UpdateShopPriceDto, { price: -5 });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects price with more than 2 decimal places', async () => {
+    const errors = await getErrors(UpdateShopPriceDto, { price: 19.999 });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('accepts a valid 3-letter uppercase ISO 4217 currency', async () => {
+    expect(
+      await getErrors(UpdateShopPriceDto, { ...valid, currency: 'EUR' }),
+    ).toHaveLength(0);
+  });
+
+  it('rejects a 2-letter currency code', async () => {
+    const errors = await getErrors(UpdateShopPriceDto, {
+      ...valid,
+      currency: 'US',
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a 4-letter currency code', async () => {
+    const errors = await getErrors(UpdateShopPriceDto, {
+      ...valid,
+      currency: 'USDD',
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a lowercase currency code', async () => {
+    const errors = await getErrors(UpdateShopPriceDto, {
+      ...valid,
+      currency: 'usd',
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a numeric/non-alphabetic currency code', async () => {
+    const errors = await getErrors(UpdateShopPriceDto, {
+      ...valid,
+      currency: '123',
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('omitting currency is valid (falls back to item default)', async () => {
+    expect(await getErrors(UpdateShopPriceDto, valid)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BulkUpdateShopItemsDto (#1281)
+// ---------------------------------------------------------------------------
+
+describe('BulkUpdateShopItemsDto validation (#1281)', () => {
+  it('passes with a single valid item', async () => {
+    expect(
+      await getErrors(BulkUpdateShopItemsDto, {
+        items: [{ id: 1, price: 9.99 }],
+      }),
+    ).toHaveLength(0);
+  });
+
+  it('rejects an empty items array', async () => {
+    const errors = await getErrors(BulkUpdateShopItemsDto, { items: [] });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it(`rejects a batch exceeding MAX_BULK_UPDATE_ITEMS (${MAX_BULK_UPDATE_ITEMS})`, async () => {
+    const items = Array.from({ length: MAX_BULK_UPDATE_ITEMS + 1 }, (_, i) => ({
+      id: i + 1,
+      active: true,
+    }));
+    const errors = await getErrors(BulkUpdateShopItemsDto, { items });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it(`accepts a batch at exactly MAX_BULK_UPDATE_ITEMS (${MAX_BULK_UPDATE_ITEMS})`, async () => {
+    const items = Array.from({ length: MAX_BULK_UPDATE_ITEMS }, (_, i) => ({
+      id: i + 1,
+      active: true,
+    }));
+    expect(await getErrors(BulkUpdateShopItemsDto, { items })).toHaveLength(0);
   });
 });

--- a/backend/src/modules/shop/shop-purchase-idempotency.spec.ts
+++ b/backend/src/modules/shop/shop-purchase-idempotency.spec.ts
@@ -150,9 +150,15 @@ describe('Shop purchase — idempotency replay and concurrent-key (SW-BE-033)', 
         },
       ],
     })
-      // Skip JWT so tests can hit the endpoint without a real token
+      // Simulate an authenticated user — real auth tested separately
       .overrideGuard(JwtAuthGuard)
-      .useValue({ canActivate: () => true })
+      .useValue({
+        canActivate: (context: ExecutionContext) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = { id: 42 };
+          return true;
+        },
+      })
       // Skip audit-trail interceptor side-effects
       .overrideInterceptor(AuditTrailInterceptor)
       .useValue({ intercept: (_: unknown, next: { handle: () => unknown }) => next.handle() })

--- a/backend/src/modules/shop/shop.controller.spec.ts
+++ b/backend/src/modules/shop/shop.controller.spec.ts
@@ -6,6 +6,8 @@ import { InventoryService } from './inventory.service';
 import { PurchaseAndGiftDto } from './dto/purchase-and-gift.dto';
 import { RedisService } from '../redis/redis.service';
 import { AuditTrailService } from '../audit-trail/audit-trail.service';
+import { IdempotencyInterceptor } from '../redis/idempotency.interceptor';
+import { IdempotencyService } from '../redis/idempotency.service';
 
 describe('ShopController', () => {
   let controller: ShopController;
@@ -44,6 +46,14 @@ describe('ShopController', () => {
 
   const mockAuditTrailService = { log: jest.fn() };
 
+  const mockIdempotencyService = {
+    get: jest.fn(),
+    markProcessing: jest.fn(),
+    markComplete: jest.fn(),
+    markFailed: jest.fn(),
+    delete: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ShopController],
@@ -68,6 +78,11 @@ describe('ShopController', () => {
           provide: AuditTrailService,
           useValue: mockAuditTrailService,
         },
+        {
+          provide: IdempotencyService,
+          useValue: mockIdempotencyService,
+        },
+        IdempotencyInterceptor,
       ],
     }).compile();
 

--- a/backend/src/modules/shop/shop.service.spec.ts
+++ b/backend/src/modules/shop/shop.service.spec.ts
@@ -362,11 +362,41 @@ describe('ShopService', () => {
       expect(result[0].id).toBe(1);
     });
 
-    it('should handle empty bulk update list', async () => {
-      const result = await service.bulkUpdate([]);
-
-      expect(result).toEqual([]);
+    it('should reject an empty bulk update list', async () => {
+      await expect(service.bulkUpdate([])).rejects.toThrow(BadRequestException);
       expect(shopItemRepositoryMock.save).not.toHaveBeenCalled();
+    });
+
+    it('should reject a bulk update list exceeding the max batch size', async () => {
+      const oversized = Array.from({ length: 101 }, (_, i) => ({
+        id: i + 1,
+        active: true,
+      }));
+
+      await expect(service.bulkUpdate(oversized)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(shopItemRepositoryMock.save).not.toHaveBeenCalled();
+    });
+
+    it('should accept a bulk update list at the max batch size', async () => {
+      const atLimit = Array.from({ length: 100 }, (_, i) => ({
+        id: i + 1,
+        active: true,
+      }));
+
+      shopItemRepositoryMock.findOne.mockResolvedValue({
+        id: 1,
+        name: 'Item',
+        active: false,
+      });
+      shopItemRepositoryMock.save.mockImplementation((item) =>
+        Promise.resolve(item),
+      );
+
+      const result = await service.bulkUpdate(atLimit);
+
+      expect(result).toHaveLength(100);
     });
   });
 });

--- a/backend/src/modules/shop/shop.service.ts
+++ b/backend/src/modules/shop/shop.service.ts
@@ -20,6 +20,7 @@ import { GiftStatus } from '../gifts/enums/gift-status.enum';
 import { RedisService } from '../redis/redis.service';
 import { secureRandomHex } from '../../common/crypto-secure-random';
 import { PaginationService, PaginatedResponse } from '../../common';
+import { MAX_BULK_UPDATE_ITEMS } from './dto/bulk-update-shop-items.dto';
 
 /** @deprecated Use PaginatedResponse<ShopItem> from common instead. */
 export type PaginatedShopItems = PaginatedResponse<ShopItem>;
@@ -280,12 +281,30 @@ export class ShopService {
   }
 
   /**
-   * Bulk update multiple shop items
-   * Supports updating price and/or active status for multiple items in a single operation
+   * Bulk update multiple shop items.
+   * Supports updating price and/or active status for multiple items in a single operation.
+   *
+   * Partial-success policy: each item is applied independently. If an item
+   * fails (e.g. not found), it is logged and skipped — it does NOT abort or
+   * roll back the other items in the batch. The response contains only the
+   * items that were updated successfully, so callers must compare the
+   * returned array against the request to detect skipped items.
+   *
+   * Guarded against empty/oversized batches as defense-in-depth; the primary
+   * enforcement is `BulkUpdateShopItemsDto` validation at the HTTP boundary.
    */
   async bulkUpdate(
     updates: Array<{ id: number; price?: number; active?: boolean }>,
   ): Promise<ShopItem[]> {
+    if (updates.length === 0) {
+      throw new BadRequestException('items must not be empty');
+    }
+    if (updates.length > MAX_BULK_UPDATE_ITEMS) {
+      throw new BadRequestException(
+        `items must not contain more than ${MAX_BULK_UPDATE_ITEMS} elements`,
+      );
+    }
+
     const updatedItems: ShopItem[] = [];
 
     for (const update of updates) {


### PR DESCRIPTION
## Summary

Closes #1280, closes #1281, closes #1282, closes #1283.

This batch covers four backend shop-module maintenance tickets. Three were mostly
verification/documentation/test-coverage work since the underlying behavior already
existed; one (#1281) required an actual validation gap fix, and one (#1283) required
fixing broken test wiring that was masking already-correct production behavior.

## What changed

**#1280 — Orphan Express shop management tree**
- Audited the repo for any standalone/orphan Express-based admin shop management code
  (routers, `express()` app instances, duplicate controllers). None exists — admin shop
  management was already fully consolidated into `AdminShopController` under
  `ShopModule` (see `22adf0d`, #858), fully wired into `app.module.ts` and covered by
  `admin-shop.controller.spec.ts`.
- Added the missing "Admin Shop Module" section to `backend/docs/ADMIN_ROUTES_MATRIX.md`
  (it previously had no entry for these routes), documenting the finding and the four
  `/admin/shop/*` routes for future auditors.
- No code removal was needed since there was nothing orphaned to remove/quarantine.

**#1281 — Shop bulkUpdate validation for empty/oversized batches**
- `BulkUpdateShopItemsDto.items` now enforces `1-100` items (`@ArrayMinSize(1)` /
  `@ArrayMaxSize(MAX_BULK_UPDATE_ITEMS)`), rejected with `400` by the global
  `ValidationPipe`.
- `ShopService.bulkUpdate` gained the same guard as defense-in-depth for any
  non-HTTP callers, throwing `BadRequestException`.
- Documented (JSDoc + Swagger + `ADMIN_ROUTES_MATRIX.md`) the pre-existing
  partial-success policy: each item in a batch is applied independently, and a
  per-item failure (e.g. unknown id) is logged and skipped rather than failing the
  whole batch — this behavior was already implemented and tested, just undocumented.

**#1282 — Shop updatePrice ISO 4217 currency enforcement**
- `UpdateShopPriceDto.currency` already enforced a 3-letter uppercase code via
  `@Matches(/^[A-Z]{3}$/)` — it just had no direct test coverage. Added a dedicated
  `UpdateShopPriceDto validation` block to `shop-dto-validation.spec.ts` covering
  price bounds/decimals and currency (2-letter, 4-letter, lowercase, numeric,
  omitted).

**#1283 — Purchases idempotency pattern port notes from shop-api**
- `POST /shop/purchase` already uses `IdempotencyInterceptor` /
  `IdempotencyService` (`src/modules/redis/`), which implements the same
  claim → complete → fail lifecycle as `shop-api`'s `IdempotencyService.claimKey` /
  `markCompleted` / `markFailed` (processing record on claim, cached replay with
  `X-Idempotency-Replayed: true` on complete, key deleted to allow retry on failure,
  `409` on concurrent in-flight requests).
- The existing test suite for this (`shop-purchase-idempotency.spec.ts`, `SW-BE-033`)
  was failing for reasons unrelated to the idempotency logic itself:
  - The `JwtAuthGuard` override stubbed `canActivate: () => true` without attaching
    `req.user`, so `@CurrentUser()` returned `undefined` and the controller crashed
    on `user.id`. Fixed to attach a `req.user` in the guard override, matching the
    pattern already used elsewhere in the codebase (e.g.
    `notifications.e2e.spec.ts`).
  - `shop.controller.spec.ts` didn't provide `IdempotencyService`/
    `IdempotencyInterceptor` in its testing module, so Nest couldn't resolve the
    interceptor bound via `@UseInterceptors(IdempotencyInterceptor)` on
    `createPurchase` even for non-HTTP unit tests. Added the missing providers.
- Added an operational note to `backend/docs/SHOP_PURCHASES_RUNBOOK.md` explaining
  the idempotency lifecycle for on-call triage of "charged twice" reports.
- No production code changes were needed for the idempotency logic itself.

## Verification performed

- `cd backend && npx jest src/modules/shop` — 8 suites / 109 tests, all passing
  (was 6 suites passing / 2 suites failing before this change).
- `cd backend && npx jest` (full suite) — no shop-related failures remain; the only
  failing suites are pre-existing and unrelated to this batch (see below).
- `cd backend && npx eslint <changed files>` — 56 problems both before and after
  (all pre-existing baseline issues in files this batch touched); zero new lint
  errors introduced.
- `cd backend && npx nest build` — 4 pre-existing TS errors in unrelated modules
  (see below); no new build errors from this batch's changes.
- Confirmed via `git diff origin/main upstream/main` and by running the full suite
  against clean `upstream/main` that all pre-existing failures listed below already
  fail without this branch's changes.

## Test plan

- [x] `BulkUpdateShopItemsDto` rejects `items: []` and batches > 100 with 400
      (`shop-dto-validation.spec.ts`)
- [x] `ShopService.bulkUpdate` rejects empty/oversized batches, accepts exactly 100
      (`shop.service.spec.ts`)
- [x] `UpdateShopPriceDto` rejects 2-letter, 4-letter, lowercase, and numeric
      currency codes; accepts valid 3-letter uppercase codes
      (`shop-dto-validation.spec.ts`)
- [x] Shop purchase idempotency: replay same key → identical response, single
      `createPurchase` call, `X-Idempotency-Replayed` header; concurrent in-flight
      key → 409; failed handler → key deleted for retry; TTL expiry re-processes
      (`shop-purchase-idempotency.spec.ts`, now passing)
- [x] `ShopController` unit tests resolve their testing module and pass
      (`shop.controller.spec.ts`, now passing)

## Known pre-existing issues (out of scope, not touched)

These fail identically on a clean `upstream/main` checkout and are unrelated to
this batch's shop-module scope, so they were left untouched:
- `modules/auth/audit/auth-audit.spec.ts`, `auth-idempotency-replay.spec.ts`,
  `auth-pagination.spec.ts`
- `modules/board-styles/board-styles-dto-validation.spec.ts`,
  `board-styles-idempotency-replay.spec.ts`, `board-styles.service.spec.ts`
  (missing `LoggerService` in test DI)
- `modules/chance/chance-idempotency.spec.ts`, `chance-validation.spec.ts`
- `modules/community-chest/community-chest.service.spec.ts`
- `modules/uploads/uploads.controller.spec.ts` (file-type/magic-byte validation)
- `npx nest build` pre-existing TS errors in `chance.controller.ts`,
  `chance.module.ts`, and `observability/tracing/tracing.service.ts`

## Closes

Closes #1280
Closes #1281
Closes #1282
Closes #1283