### PR TITLE
test(config): verify boot fails on invalid uploads observability flag

### DIFF
--- a/backend/src/config/env.validation.uploads-observability.spec.ts
+++ b/backend/src/config/env.validation.uploads-observability.spec.ts
@@ -27,4 +27,12 @@ describe('env.validation — uploads observability (SW-BE-009)', () => {
     expect(error).toBeUndefined();
     expect(value.UPLOADS_OBSERVABILITY_ENABLED).toBe(false);
   });
+
+  it('fails validation on an invalid (non-boolean) value, so boot fails fast', () => {
+    const { error } = validationSchema.validate(
+      minimalDevEnv({ UPLOADS_OBSERVABILITY_ENABLED: 'maybe' }),
+    );
+    expect(error).toBeDefined();
+    expect(error?.message).toMatch(/UPLOADS_OBSERVABILITY_ENABLED/);
+  });
 });


### PR DESCRIPTION
## Summary
Adds the missing negative-case test for the `UPLOADS_OBSERVABILITY_ENABLED` env flag: an invalid (non-boolean) value must fail Joi validation, which in turn causes `ConfigModule.forRoot({ validationSchema, validationOptions: { abortEarly: false } })` to throw during `NestFactory.create(AppModule)` — i.e. the process fails to boot rather than starting with a bad config.

## Context / behavior
- `UPLOADS_OBSERVABILITY_ENABLED` is already validated in `env.validation.ts` via `Joi.boolean().truthy('true').falsy('false').default(true)`.
- `app.module.ts` wires this schema into `ConfigModule` with `abortEarly: false`, and `main.ts` has no try/catch around bootstrap, so a validation error already propagates and crashes boot today.
- Before: only the "default true" and "explicit false" cases were covered; the fail-boot path for an invalid value had no test.
- After: `env.validation.uploads-observability.spec.ts` also asserts that `UPLOADS_OBSERVABILITY_ENABLED=maybe` produces a validation error referencing the flag name.

## Testing
- Added unit test in `backend/src/config/env.validation.uploads-observability.spec.ts` covering the invalid-value case (`jest env.validation.uploads-observability`).
- Existing default/explicit-false tests in the same file continue to pass unchanged.

Closes #1315