### PR TITLE
feat(jobs): bound worker concurrency and expose failed-job metrics

### DIFF
--- a/backend/src/modules/jobs/jobs-metrics.service.spec.ts
+++ b/backend/src/modules/jobs/jobs-metrics.service.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Issue #1314 — JobsMetricsService: failed-job metrics.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { HttpMetricsService } from '../metrics/http-metrics.service';
+import { JobsMetricsService } from './jobs-metrics.service';
+
+const mockDataSource = {
+  driver: { master: { totalCount: 3, idleCount: 2, waitingCount: 0 } },
+  options: { poolSize: 5 },
+  query: jest.fn(),
+};
+
+describe('JobsMetricsService', () => {
+  let jobsMetrics: JobsMetricsService;
+  let httpMetrics: HttpMetricsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JobsMetricsService,
+        HttpMetricsService,
+        { provide: getDataSourceToken(), useValue: mockDataSource },
+      ],
+    }).compile();
+
+    jobsMetrics = module.get(JobsMetricsService);
+    httpMetrics = module.get(HttpMetricsService);
+  });
+
+  it('starts at zero for an unseen queue/job combination', async () => {
+    expect(await jobsMetrics.getFailedCount('background-jobs', 'sample-echo')).toBe(0);
+  });
+
+  it('increments the failed counter per queue/job label pair', async () => {
+    jobsMetrics.recordFailure('background-jobs', 'sample-echo');
+    jobsMetrics.recordFailure('background-jobs', 'sample-echo');
+    jobsMetrics.recordFailure('background-jobs', 'other-job');
+
+    expect(await jobsMetrics.getFailedCount('background-jobs', 'sample-echo')).toBe(2);
+    expect(await jobsMetrics.getFailedCount('background-jobs', 'other-job')).toBe(1);
+  });
+
+  it('exposes tycoon_jobs_failed_total on the shared metrics registry', async () => {
+    jobsMetrics.recordFailure('background-jobs', 'sample-echo');
+    const text = await httpMetrics.getMetricsText();
+    expect(text).toContain('tycoon_jobs_failed_total');
+  });
+
+  it('falls back to "unknown" when no job name is available', async () => {
+    jobsMetrics.recordFailure('background-jobs', '');
+    expect(await jobsMetrics.getFailedCount('background-jobs', 'unknown')).toBe(1);
+  });
+});

--- a/backend/src/modules/jobs/jobs-metrics.service.ts
+++ b/backend/src/modules/jobs/jobs-metrics.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { Counter } from 'prom-client';
+import { HttpMetricsService } from '../metrics/http-metrics.service';
+
+/**
+ * JobsMetricsService (SW-BE issue #1314)
+ *
+ * Tracks failed BullMQ jobs so operators can see failure counts on the
+ * existing Prometheus /metrics endpoint without a separate scrape target.
+ * Registers into HttpMetricsService's shared Registry so both sets of
+ * metrics are exposed together.
+ */
+@Injectable()
+export class JobsMetricsService {
+  private readonly jobsFailedTotal: Counter;
+
+  constructor(private readonly httpMetrics: HttpMetricsService) {
+    this.jobsFailedTotal = new Counter({
+      name: 'tycoon_jobs_failed_total',
+      help: 'Total number of background jobs that failed, by queue and job name',
+      labelNames: ['queue', 'job_name'],
+      registers: [this.httpMetrics.registry],
+    });
+  }
+
+  recordFailure(queue: string, jobName: string): void {
+    this.jobsFailedTotal.inc({ queue, job_name: jobName || 'unknown' });
+  }
+
+  async getFailedCount(queue: string, jobName: string): Promise<number> {
+    const metric = await this.jobsFailedTotal.get();
+    const match = metric.values.find(
+      (v) => v.labels.queue === queue && v.labels.job_name === jobName,
+    );
+    return match?.value ?? 0;
+  }
+}

--- a/backend/src/modules/jobs/jobs.module.ts
+++ b/backend/src/modules/jobs/jobs.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { SampleProcessor } from './processors/sample.processor';
+import { JobsMetricsService } from './jobs-metrics.service';
+import { MetricsModule } from '../metrics/metrics.module';
 
 @Module({
   imports: [
+    MetricsModule,
     BullModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -23,7 +26,7 @@ import { SampleProcessor } from './processors/sample.processor';
       name: 'background-jobs',
     }),
   ],
-  providers: [SampleProcessor],
+  providers: [SampleProcessor, JobsMetricsService],
   exports: [BullModule],
 })
 export class JobsModule {}

--- a/backend/src/modules/jobs/processors/sample.processor.spec.ts
+++ b/backend/src/modules/jobs/processors/sample.processor.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Issue #1314 — SampleProcessor: failed-job metric recording.
+ */
+import { SampleProcessor } from './sample.processor';
+import { JobsMetricsService } from '../jobs-metrics.service';
+
+describe('SampleProcessor', () => {
+  let jobsMetrics: { recordFailure: jest.Mock };
+  let processor: SampleProcessor;
+
+  beforeEach(() => {
+    jobsMetrics = { recordFailure: jest.fn() };
+    processor = new SampleProcessor(jobsMetrics as unknown as JobsMetricsService);
+  });
+
+  it('records a failure metric with the queue and job name on the failed event', () => {
+    const job = { id: '1', name: 'sample-echo' } as any;
+    processor.onFailed(job, new Error('boom'));
+
+    expect(jobsMetrics.recordFailure).toHaveBeenCalledWith(
+      'background-jobs',
+      'sample-echo',
+    );
+  });
+
+  it('falls back to "unknown" job name when the job is undefined', () => {
+    processor.onFailed(undefined, new Error('boom'));
+
+    expect(jobsMetrics.recordFailure).toHaveBeenCalledWith(
+      'background-jobs',
+      'unknown',
+    );
+  });
+
+  it('processes a known job type', async () => {
+    const job = { id: '1', name: 'sample-echo', data: { message: 'hi' } } as any;
+    await expect(processor.process(job)).resolves.toEqual({
+      success: true,
+      echoed: 'hi',
+    });
+  });
+});

--- a/backend/src/modules/jobs/processors/sample.processor.ts
+++ b/backend/src/modules/jobs/processors/sample.processor.ts
@@ -1,10 +1,24 @@
-import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import { Logger } from '@nestjs/common';
+import { JobsMetricsService } from '../jobs-metrics.service';
 
-@Processor('background-jobs')
+/** Max jobs this worker processes concurrently; override via JOBS_CONCURRENCY. */
+const JOBS_CONCURRENCY = Number(process.env.JOBS_CONCURRENCY) || 5;
+
+@Processor('background-jobs', { concurrency: JOBS_CONCURRENCY })
 export class SampleProcessor extends WorkerHost {
   private readonly logger = new Logger(SampleProcessor.name);
+
+  constructor(private readonly jobsMetrics: JobsMetricsService) {
+    super();
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job<any, any, string> | undefined, err: Error): void {
+    this.logger.error(`Job ${job?.id} (${job?.name}) failed: ${err.message}`);
+    this.jobsMetrics.recordFailure('background-jobs', job?.name ?? 'unknown');
+  }
 
   async process(job: Job<any, any, string>): Promise<any> {
     this.logger.log(`Processing job ${job.id} of type ${job.name}...`);


### PR DESCRIPTION
## Summary
`SampleProcessor` previously ran with BullMQ's default (unbounded) concurrency and failed jobs were only visible in logs. This adds a configurable concurrency cap and exposes a failed-job counter on the existing Prometheus `/metrics` endpoint.

## Changes
- `SampleProcessor` is now decorated with `@Processor('background-jobs', { concurrency: JOBS_CONCURRENCY })`, defaulting to 5, overridable via the `JOBS_CONCURRENCY` env var.
- New `JobsMetricsService` registers `tycoon_jobs_failed_total{queue,job_name}` (a `Counter`) on `HttpMetricsService`'s shared `Registry`, so it appears in the same scrape output as HTTP/DB metrics — no new endpoint needed.
- `SampleProcessor` now handles the BullMQ `failed` worker event (`@OnWorkerEvent('failed')`), logging the error and incrementing the new counter.
- `JobsModule` imports `MetricsModule` and registers `JobsMetricsService`.

## Before / after
- Before: unbounded worker concurrency; failed jobs only logged, no metric.
- After: concurrency bounded (default 5, env-configurable); `GET /metrics` includes `tycoon_jobs_failed_total` incremented on every job failure, labeled by queue and job name.

## Testing
- `backend/src/modules/jobs/jobs-metrics.service.spec.ts` — counter starts at 0, increments per label pair, appears in scraped text, "unknown" fallback for empty job name.
- `backend/src/modules/jobs/processors/sample.processor.spec.ts` — `onFailed` records the metric with correct labels (including the undefined-job fallback), and `process` still handles the known job type correctly.

Closes #1314