### PR TITLE
Feature/backend improvements

### DIFF
--- a/backend/src/common/decorators/admin.decorator.ts
+++ b/backend/src/common/decorators/admin.decorator.ts
@@ -1,0 +1,6 @@
+import { UseGuards } from '@nestjs/common';
+import { AdminGuard } from '../guards/admin.guard';
+
+export function RequireAdmin() {
+  return UseGuards(AdminGuard);
+}

--- a/backend/src/common/guards/admin.guard.spec.ts
+++ b/backend/src/common/guards/admin.guard.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext } from '@nestjs/common';
+import { AdminGuard } from './admin.guard';
+import { Role } from '../../modules/auth/enums/role.enum';
+import { ForbiddenException } from '@nestjs/common';
+
+describe('AdminGuard', () => {
+  let guard: AdminGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdminGuard],
+    }).compile();
+
+    guard = module.get<AdminGuard>(AdminGuard);
+  });
+
+  it('should allow admin user with role ADMIN', () => {
+    const mockRequest = {
+      user: { id: 1, role: Role.ADMIN, is_admin: false },
+    };
+
+    const mockContext = {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as ExecutionContext;
+
+    expect(guard.canActivate(mockContext)).toBe(true);
+  });
+
+  it('should allow user with is_admin flag true', () => {
+    const mockRequest = {
+      user: { id: 2, role: Role.USER, is_admin: true },
+    };
+
+    const mockContext = {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as ExecutionContext;
+
+    expect(guard.canActivate(mockContext)).toBe(true);
+  });
+
+  it('should deny regular user without admin role or flag', () => {
+    const mockRequest = {
+      user: { id: 3, role: Role.USER, is_admin: false },
+    };
+
+    const mockContext = {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as ExecutionContext;
+
+    expect(() => guard.canActivate(mockContext)).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('should deny unauthenticated request (no user)', () => {
+    const mockRequest = { user: null };
+
+    const mockContext = {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as ExecutionContext;
+
+    expect(() => guard.canActivate(mockContext)).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('should deny request without user property', () => {
+    const mockRequest = {};
+
+    const mockContext = {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as ExecutionContext;
+
+    expect(() => guard.canActivate(mockContext)).toThrow(
+      ForbiddenException,
+    );
+  });
+});

--- a/backend/src/common/guards/admin.guard.ts
+++ b/backend/src/common/guards/admin.guard.ts
@@ -1,0 +1,25 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Role } from '../../modules/auth/enums/role.enum';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user) {
+      throw new ForbiddenException('User not authenticated');
+    }
+
+    if (user.role !== Role.ADMIN && !user.is_admin) {
+      throw new ForbiddenException('Admin access required');
+    }
+
+    return true;
+  }
+}

--- a/backend/src/modules/board-styles/board-styles.controller.ts
+++ b/backend/src/modules/board-styles/board-styles.controller.ts
@@ -10,11 +10,14 @@ import {
   UseInterceptors,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiQuery, ApiHeader } from '@nestjs/swagger';
 import { BoardStylesService } from './board-styles.service';
 import { AdvancedCacheInterceptor } from '../../common/interceptors/advanced-cache.interceptor';
 import { CacheOptions } from '../../common/decorators/cache-options.decorator';
+import { RequireAdmin } from '../../common/decorators/admin.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CreateBoardStyleDto } from './dto/create-board-style.dto';
 import { UpdateBoardStyleDto } from './dto/update-board-style.dto';
 import { BoardStylesPaginationDto } from './dto/board-styles-pagination.dto';
@@ -30,7 +33,9 @@ export class BoardStylesController {
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Create a new board style (Admin)' })
+  @RequireAdmin()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Create a new board style (Admin only)' })
   @ApiHeader({
     name: 'X-Idempotency-Key',
     required: false,
@@ -86,7 +91,9 @@ export class BoardStylesController {
   }
 
   @Patch(':id')
-  @ApiOperation({ summary: 'Update a board style (Admin)' })
+  @RequireAdmin()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Update a board style (Admin only)' })
   update(
     @Param('id') id: string,
     @Body() updateBoardStyleDto: UpdateBoardStyleDto,
@@ -95,7 +102,9 @@ export class BoardStylesController {
   }
 
   @Delete(':id')
-  @ApiOperation({ summary: 'Delete a board style (Admin)' })
+  @RequireAdmin()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Delete a board style (Admin only)' })
   remove(@Param('id') id: string) {
     return this.boardStylesService.remove(+id);
   }

--- a/backend/src/modules/properties/properties.service.spec.ts
+++ b/backend/src/modules/properties/properties.service.spec.ts
@@ -414,4 +414,70 @@ describe('PropertiesService', () => {
       );
     });
   });
+
+  describe('calculateRent', () => {
+    const mockProperty = {
+      id: 1,
+      name: 'Park Place',
+      rent_site_only: 35,
+      rent_one_house: 175,
+      rent_two_houses: 500,
+      rent_three_houses: 1100,
+      rent_four_houses: 1300,
+      rent_hotel: 2000,
+      is_mortgaged: false,
+    } as Property;
+
+    it('should return rent_site_only when property has 0 houses', () => {
+      const rent = service.calculateRent(mockProperty, 0);
+      expect(rent).toBe(35);
+    });
+
+    it('should return rent_one_house when property has 1 house', () => {
+      const rent = service.calculateRent(mockProperty, 1);
+      expect(rent).toBe(175);
+    });
+
+    it('should return rent_two_houses when property has 2 houses', () => {
+      const rent = service.calculateRent(mockProperty, 2);
+      expect(rent).toBe(500);
+    });
+
+    it('should return rent_three_houses when property has 3 houses', () => {
+      const rent = service.calculateRent(mockProperty, 3);
+      expect(rent).toBe(1100);
+    });
+
+    it('should return rent_four_houses when property has 4 houses', () => {
+      const rent = service.calculateRent(mockProperty, 4);
+      expect(rent).toBe(1300);
+    });
+
+    it('should return rent_hotel when property has 5 houses (hotel)', () => {
+      const rent = service.calculateRent(mockProperty, 5);
+      expect(rent).toBe(2000);
+    });
+
+    it('should return 0 rent when property is mortgaged (edge case)', () => {
+      const mortgagedProperty = { ...mockProperty, is_mortgaged: true };
+      const rent = service.calculateRent(mortgagedProperty, 0);
+      expect(rent).toBe(0);
+    });
+
+    it('should return 0 rent even with hotel when property is mortgaged', () => {
+      const mortgagedProperty = { ...mockProperty, is_mortgaged: true };
+      const rent = service.calculateRent(mortgagedProperty, 5);
+      expect(rent).toBe(0);
+    });
+
+    it('should return 0 for invalid house count', () => {
+      const rent = service.calculateRent(mockProperty, 10);
+      expect(rent).toBe(0);
+    });
+
+    it('should return 0 for negative house count', () => {
+      const rent = service.calculateRent(mockProperty, -1);
+      expect(rent).toBe(0);
+    });
+  });
 });

--- a/backend/src/modules/properties/properties.service.ts
+++ b/backend/src/modules/properties/properties.service.ts
@@ -172,6 +172,42 @@ export class PropertiesService {
   }
 
   /**
+   * Calculate rent for a property based on house count and mortgage status.
+   *
+   * Edge cases:
+   * - If mortgaged: rent is 0 (property generates no income while mortgaged)
+   * - If 0 houses: rent_site_only applies
+   * - If 1-4 houses: corresponding rent tier applies
+   * - If 5 houses (hotel): rent_hotel applies
+   *
+   * @param property - The property entity
+   * @param houseCount - Number of houses on the property (0-5, where 5 = hotel)
+   * @returns Rent amount due (0 if mortgaged)
+   */
+  calculateRent(property: Property, houseCount: number): number {
+    if (property.is_mortgaged) {
+      return 0;
+    }
+
+    switch (houseCount) {
+      case 0:
+        return property.rent_site_only;
+      case 1:
+        return property.rent_one_house;
+      case 2:
+        return property.rent_two_houses;
+      case 3:
+        return property.rent_three_houses;
+      case 4:
+        return property.rent_four_houses;
+      case 5:
+        return property.rent_hotel;
+      default:
+        return 0;
+    }
+  }
+
+  /**
    * Validate rent values generally increase with more houses
    * Logs warning if not, but doesn't throw error (game design decision)
    */

--- a/backend/src/modules/redis/redis.service.spec.ts
+++ b/backend/src/modules/redis/redis.service.spec.ts
@@ -50,22 +50,26 @@ describe('RedisService', () => {
       debug: jest.fn(),
     } as any;
 
+    const configService = {
+      get: jest.fn().mockImplementation((key: string) => {
+        if (key === 'NODE_ENV') return 'test';
+        if (key === 'redis')
+          return {
+            host: 'localhost',
+            port: 6379,
+            db: 0,
+            ttl: 300,
+          };
+        return undefined;
+      }),
+    } as any;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RedisService,
         { provide: CACHE_MANAGER, useValue: cacheManager },
         { provide: LoggerService, useValue: loggerService },
-        {
-          provide: ConfigService,
-          useValue: {
-            get: jest.fn().mockReturnValue({
-              host: 'localhost',
-              port: 6379,
-              db: 0,
-              ttl: 300,
-            }),
-          },
-        },
+        { provide: ConfigService, useValue: configService },
       ],
     }).compile();
 
@@ -75,11 +79,11 @@ describe('RedisService', () => {
   it('should be defined', () => expect(service).toBeDefined());
 
   describe('Session management', () => {
-    it('sets refresh token', async () => {
+    it('sets refresh token with environment namespace', async () => {
       mockRedisInstance.setex.mockResolvedValue('OK');
       await service.setRefreshToken('u1', 'tok');
       expect(mockRedisInstance.setex).toHaveBeenCalledWith(
-        'refresh_token:u1',
+        'test:refresh_token:u1',
         604800,
         'tok',
       );
@@ -92,9 +96,10 @@ describe('RedisService', () => {
       );
     });
 
-    it('gets refresh token', async () => {
+    it('gets refresh token with environment namespace', async () => {
       mockRedisInstance.get.mockResolvedValue('tok');
-      expect(await service.getRefreshToken('u1')).toBe('tok');
+      await service.getRefreshToken('u1');
+      expect(mockRedisInstance.get).toHaveBeenCalledWith('test:refresh_token:u1');
     });
 
     it('returns null on get refresh token error', async () => {
@@ -102,42 +107,44 @@ describe('RedisService', () => {
       expect(await service.getRefreshToken('u1')).toBeNull();
     });
 
-    it('deletes refresh token', async () => {
+    it('deletes refresh token with environment namespace', async () => {
       mockRedisInstance.del.mockResolvedValue(1);
       await service.deleteRefreshToken('u1');
-      expect(mockRedisInstance.del).toHaveBeenCalledWith('refresh_token:u1');
+      expect(mockRedisInstance.del).toHaveBeenCalledWith('test:refresh_token:u1');
     });
   });
 
   describe('Cache operations', () => {
-    it('cache hit', async () => {
+    it('cache hit with environment namespace', async () => {
       cacheManager.get.mockResolvedValue('val');
       expect(await service.get('k')).toBe('val');
+      expect(cacheManager.get).toHaveBeenCalledWith('test:k');
       expect(loggerService.debug).toHaveBeenCalledWith(
         'Cache HIT: k',
         'RedisService',
       );
     });
 
-    it('cache miss', async () => {
+    it('cache miss with environment namespace', async () => {
       cacheManager.get.mockResolvedValue(undefined);
       expect(await service.get('k')).toBeUndefined();
+      expect(cacheManager.get).toHaveBeenCalledWith('test:k');
       expect(loggerService.debug).toHaveBeenCalledWith(
         'Cache MISS: k',
         'RedisService',
       );
     });
 
-    it('sets cache value', async () => {
+    it('sets cache value with environment namespace', async () => {
       cacheManager.set.mockResolvedValue(undefined);
       await service.set('k', 'v', 300);
-      expect(cacheManager.set).toHaveBeenCalledWith('k', 'v', 300);
+      expect(cacheManager.set).toHaveBeenCalledWith('test:k', 'v', 300);
     });
 
-    it('deletes cache key', async () => {
+    it('deletes cache key with environment namespace', async () => {
       cacheManager.del.mockResolvedValue(undefined);
       await service.del('k');
-      expect(cacheManager.del).toHaveBeenCalledWith('k');
+      expect(cacheManager.del).toHaveBeenCalledWith('test:k');
     });
   });
 
@@ -162,11 +169,12 @@ describe('RedisService', () => {
   });
 
   describe('delByPattern', () => {
-    it('deletes matched keys', async () => {
-      mockRedisInstance.keys.mockResolvedValue(['a', 'b']);
+    it('deletes matched keys with environment namespace', async () => {
+      mockRedisInstance.keys.mockResolvedValue(['test:a', 'test:b']);
       mockRedisInstance.del.mockResolvedValue(2);
       await service.delByPattern('prefix:*');
-      expect(mockRedisInstance.del).toHaveBeenCalledWith('a', 'b');
+      expect(mockRedisInstance.keys).toHaveBeenCalledWith('test:prefix:*');
+      expect(mockRedisInstance.del).toHaveBeenCalledWith('test:a', 'test:b');
     });
 
     it('no-ops when no keys match', async () => {

--- a/backend/src/modules/redis/redis.service.ts
+++ b/backend/src/modules/redis/redis.service.ts
@@ -12,6 +12,7 @@ import { AuditAction } from '../audit-trail/entities/audit-trail.entity';
 export class RedisService {
   private readonly logger: LoggerService;
   private readonly auditEnabled: boolean;
+  private readonly environment: string;
   private redis: Redis;
 
   // Prometheus metrics
@@ -29,6 +30,7 @@ export class RedisService {
     @Optional() private readonly auditTrailService?: AuditTrailService,
   ) {
     this.logger = loggerService;
+    this.environment = configService.get<string>('NODE_ENV') || 'development';
 
     const redisConfig = configService.get<{
       host: string;
@@ -115,6 +117,17 @@ export class RedisService {
       );
   }
 
+  /**
+   * Build a namespaced cache key prefixed with NODE_ENV to prevent
+   * multi-environment cache collisions. Keys in dev, staging, and production
+   * will not conflict when using the same Redis instance.
+   * @param key Base cache key (e.g., "refresh_token:123")
+   * @returns Namespaced key (e.g., "development:refresh_token:123")
+   */
+  private buildKey(key: string): string {
+    return `${this.environment}:${key}`;
+  }
+
   // Session management
   async setRefreshToken(
     userId: string,
@@ -125,7 +138,8 @@ export class RedisService {
       operation: 'set_refresh_token',
     });
     try {
-      await this.redis.setex(`refresh_token:${userId}`, ttl, token);
+      const key = this.buildKey(`refresh_token:${userId}`);
+      await this.redis.setex(key, ttl, token);
       this.redisOperationsTotal.inc({ operation: 'set_refresh_token' });
       this.logger.debug(`Set refresh token for user ${userId}`, 'RedisService');
     } catch (error: any) {
@@ -145,7 +159,8 @@ export class RedisService {
       operation: 'get_refresh_token',
     });
     try {
-      const result = await this.redis.get(`refresh_token:${userId}`);
+      const key = this.buildKey(`refresh_token:${userId}`);
+      const result = await this.redis.get(key);
       this.redisOperationsTotal.inc({ operation: 'get_refresh_token' });
       this.logger.debug(
         `Retrieved refresh token for user ${userId}`,
@@ -169,7 +184,8 @@ export class RedisService {
       operation: 'delete_refresh_token',
     });
     try {
-      await this.redis.del(`refresh_token:${userId}`);
+      const key = this.buildKey(`refresh_token:${userId}`);
+      await this.redis.del(key);
       this.redisOperationsTotal.inc({ operation: 'delete_refresh_token' });
       this.logger.debug(
         `Deleted refresh token for user ${userId}`,
@@ -221,7 +237,8 @@ export class RedisService {
       operation: 'cache_get',
     });
     try {
-      const value = await this.cacheManager.get<T>(key);
+      const namespacedKey = this.buildKey(key);
+      const value = await this.cacheManager.get<T>(namespacedKey);
       if (value !== undefined) {
         this.cacheHitsTotal.inc();
         this.logger.debug(`Cache HIT: ${key}`, 'RedisService');
@@ -248,7 +265,8 @@ export class RedisService {
       operation: 'cache_set',
     });
     try {
-      await this.cacheManager.set(key, value, ttl);
+      const namespacedKey = this.buildKey(key);
+      await this.cacheManager.set(namespacedKey, value, ttl);
       this.redisOperationsTotal.inc({ operation: 'cache_set' });
       this.logger.debug(`Cache SET: ${key}`, 'RedisService');
       this.emitAudit(AuditAction.CACHE_SET, {
@@ -272,7 +290,8 @@ export class RedisService {
       operation: 'cache_del',
     });
     try {
-      await this.cacheManager.del(key);
+      const namespacedKey = this.buildKey(key);
+      await this.cacheManager.del(namespacedKey);
       this.redisOperationsTotal.inc({ operation: 'cache_del' });
       this.logger.debug(`Cache DEL: ${key}`, 'RedisService');
       this.emitAudit(AuditAction.CACHE_DEL, { key });
@@ -293,7 +312,8 @@ export class RedisService {
       operation: 'del_by_pattern',
     });
     try {
-      const keys = await this.redis.keys(pattern);
+      const namespacedPattern = this.buildKey(pattern);
+      const keys = await this.redis.keys(namespacedPattern);
       if (keys.length > 0) {
         await this.redis.del(...keys);
         this.redisOperationsTotal.inc({ operation: 'del_by_pattern' });
@@ -323,13 +343,13 @@ export class RedisService {
       operation: 'cache_reset',
     });
     try {
-      // Reset cache by deleting all keys with our prefix
-      const keys = await this.redis.keys('cache:*');
+      const namespacedPattern = this.buildKey('*');
+      const keys = await this.redis.keys(namespacedPattern);
       if (keys.length > 0) {
         await this.redis.del(...keys);
         this.redisOperationsTotal.inc({ operation: 'cache_reset' });
         this.logger.log(
-          `Reset cache: deleted ${keys.length} keys`,
+          `Reset cache: deleted ${keys.length} keys for environment ${this.environment}`,
           'RedisService',
         );
       }

--- a/backend/src/modules/skins/user-skins.controller.ts
+++ b/backend/src/modules/skins/user-skins.controller.ts
@@ -25,7 +25,10 @@ export class UserSkinsController {
   }
 
   @Post('unlock')
-  @ApiOperation({ summary: 'Unlock a skin for the current user' })
+  @ApiOperation({
+    summary: 'Unlock a skin for the current user',
+    description: 'Idempotent operation. If the skin is already unlocked for this user, returns the existing unlock record. Safe to retry.',
+  })
   async unlockSkin(@Request() req: any, @Body() dto: UnlockSkinDto) {
     return this.userSkinsService.unlockSkin(req.user.id, dto.skinId);
   }

--- a/backend/src/modules/skins/user-skins.service.spec.ts
+++ b/backend/src/modules/skins/user-skins.service.spec.ts
@@ -1,0 +1,170 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserSkinsService } from './user-skins.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserSkin } from './entities/user-skin.entity';
+import { Skin } from './entities/skin.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('UserSkinsService', () => {
+  let service: UserSkinsService;
+
+  const mockUserSkinRepository = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockSkinRepository = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserSkinsService,
+        {
+          provide: getRepositoryToken(UserSkin),
+          useValue: mockUserSkinRepository,
+        },
+        {
+          provide: getRepositoryToken(Skin),
+          useValue: mockSkinRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UserSkinsService>(UserSkinsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('unlockSkin', () => {
+    const userId = 1;
+    const skinId = 5;
+
+    it('should throw NotFoundException when skin does not exist', async () => {
+      mockSkinRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.unlockSkin(userId, skinId)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockSkinRepository.findOne).toHaveBeenCalledWith({
+        where: { id: skinId },
+      });
+    });
+
+    it('should return existing unlock when user already owns the skin (idempotent)', async () => {
+      const existingUserSkin: UserSkin = {
+        id: 1,
+        user_id: userId,
+        skin_id: skinId,
+        unlocked_at: new Date('2026-01-01'),
+        user: null,
+        skin: null,
+      };
+
+      mockSkinRepository.findOne.mockResolvedValue({ id: skinId });
+      mockUserSkinRepository.findOne.mockResolvedValue(existingUserSkin);
+
+      const result = await service.unlockSkin(userId, skinId);
+
+      expect(result).toEqual(existingUserSkin);
+      expect(mockUserSkinRepository.create).not.toHaveBeenCalled();
+      expect(mockUserSkinRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should create and return new unlock when user does not own the skin', async () => {
+      const newUserSkin: UserSkin = {
+        id: 2,
+        user_id: userId,
+        skin_id: skinId,
+        unlocked_at: new Date(),
+        user: null,
+        skin: null,
+      };
+
+      mockSkinRepository.findOne.mockResolvedValue({ id: skinId });
+      mockUserSkinRepository.findOne.mockResolvedValue(null);
+      mockUserSkinRepository.create.mockReturnValue(newUserSkin);
+      mockUserSkinRepository.save.mockResolvedValue(newUserSkin);
+
+      const result = await service.unlockSkin(userId, skinId);
+
+      expect(result).toEqual(newUserSkin);
+      expect(mockUserSkinRepository.create).toHaveBeenCalledWith({
+        user_id: userId,
+        skin_id: skinId,
+      });
+      expect(mockUserSkinRepository.save).toHaveBeenCalledWith(newUserSkin);
+    });
+
+    it('should handle multiple calls for the same user/skin (idempotency)', async () => {
+      const existingUserSkin: UserSkin = {
+        id: 1,
+        user_id: userId,
+        skin_id: skinId,
+        unlocked_at: new Date('2026-01-01'),
+        user: null,
+        skin: null,
+      };
+
+      mockSkinRepository.findOne.mockResolvedValue({ id: skinId });
+      mockUserSkinRepository.findOne.mockResolvedValue(existingUserSkin);
+
+      const result1 = await service.unlockSkin(userId, skinId);
+      const result2 = await service.unlockSkin(userId, skinId);
+
+      expect(result1).toEqual(result2);
+      expect(result1.id).toBe(1);
+      expect(mockUserSkinRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAllByUserId', () => {
+    it('should return all skins owned by a user', async () => {
+      const userId = 1;
+      const userSkins: UserSkin[] = [
+        {
+          id: 1,
+          user_id: userId,
+          skin_id: 5,
+          unlocked_at: new Date(),
+          user: null,
+          skin: { id: 5, name: 'Skin A' } as Skin,
+        },
+      ];
+
+      mockUserSkinRepository.find.mockResolvedValue(userSkins);
+
+      const result = await service.findAllByUserId(userId);
+
+      expect(result).toEqual(userSkins);
+      expect(mockUserSkinRepository.find).toHaveBeenCalledWith({
+        where: { user_id: userId },
+        relations: ['skin'],
+        order: { unlocked_at: 'DESC' },
+      });
+    });
+  });
+
+  describe('checkOwnership', () => {
+    it('should return true when user owns the skin', async () => {
+      mockUserSkinRepository.findOne.mockResolvedValue({ id: 1 });
+
+      const result = await service.checkOwnership(1, 5);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when user does not own the skin', async () => {
+      mockUserSkinRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.checkOwnership(1, 5);
+
+      expect(result).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                    
   
  Four backend platform improvements addressing idempotency, authorization, business logic edge cases, and multi-environment caching.                                                                           
                                                                       
  ## Changes                                                                                                                                                                                                    
                                                                       
  ### #1309 — Skin unlock idempotent for same user/skin                                                                                                                                                         
  - Add comprehensive unit tests covering idempotency behavior
  - Document idempotent semantics in API endpoint description                                                                                                                                                   
  - Verify second call returns existing unlock without duplicating     
                                                                                                                                                                                                                
  ### #1311 — Properties rent calculation edge cases                   
  - Add `calculateRent(property, houseCount)` method handling:                                                                                                                                                  
    - Mortgaged properties: 0 rent (no income while mortgaged)                                                                                                                                                  
    - Zero houses: rent_site_only applies                                                                                                                                                                       
    - 1-5 houses: corresponding rent tier applies                                                                                                                                                               
  - Comprehensive unit tests covering all house counts and mortgage state edge cases                                                                                                                            
                                                                                                                                                                                                                
  ### #1308 — Board-styles CRUD authorization                                                                                                                                                                   
  - Create AdminGuard to verify ADMIN role or is_admin flag                                                                                                                                                     
  - Add RequireAdmin decorator for easy application                                                                                                                                                             
  - Apply to POST (create), PATCH (update), DELETE (remove) endpoints                                                                                                                                           
  - Include comprehensive unit tests for admin access, denial, unauthenticated paths                                                                                                                            
                                                                                                                                                                                                                
  ### #1302 — Redis cache key namespacing for multi-env                                                                                                                                                         
  - Add `buildKey()` method prefixing all cache keys with NODE_ENV                                                                                                                                              
  - Apply namespacing to: session tokens, cache operations, patterns, reset                                                                                                                                     
  - Prevents dev/staging/production collisions on shared Redis instance                                                                                                                                         
  - Update all tests to verify environment-prefixed keys                                                                                                                                                        
                                                                                                                                                                                                                
  ## Test Coverage                                                                                                                                                                                              
                                                                                                                                                                                                                
  All changes include unit tests:                                      
  - UserSkinsService: idempotency assertions
  - PropertiesService: rent calculation across all edge cases                                                                                                                                                   
  - AdminGuard: access control verification
  - RedisService: key namespacing verification                                                                                                                                                                  
                                                                       
  Closes #1309, Closes #1311, Closes #1308, Closes #1302     