### PR TITLE
fix(tour-analytics): validate event schema and reject unknown event names

### DIFF
--- a/backend/src/modules/tour-analytics/dto/track-tour-event.dto.spec.ts
+++ b/backend/src/modules/tour-analytics/dto/track-tour-event.dto.spec.ts
@@ -1,0 +1,46 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { TOUR_EVENT_NAMES, TrackTourEventDto } from './track-tour-event.dto';
+
+async function validateDto(plain: Record<string, unknown>) {
+  const dto = plainToInstance(TrackTourEventDto, plain);
+  return validate(dto);
+}
+
+describe('TrackTourEventDto', () => {
+  it.each(TOUR_EVENT_NAMES)('accepts known event name %s', async (event) => {
+    const errors = await validateDto({ event, data: { step: 1 } });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects an unknown event name', async () => {
+    const errors = await validateDto({
+      event: 'tour_hacked',
+      data: {},
+    });
+    expect(errors.some((e) => e.property === 'event')).toBe(true);
+  });
+
+  it('rejects a missing event name', async () => {
+    const errors = await validateDto({ data: {} });
+    expect(errors.some((e) => e.property === 'event')).toBe(true);
+  });
+
+  it('rejects non-integer step values in data', async () => {
+    const errors = await validateDto({
+      event: 'tour_step_viewed',
+      data: { step: 'not-a-number' },
+    });
+    const dataError = errors.find((e) => e.property === 'data');
+    expect(dataError).toBeDefined();
+  });
+
+  it('rejects a malformed timestamp', async () => {
+    const errors = await validateDto({
+      event: 'tour_completed',
+      data: { timestamp: 'not-a-date' },
+    });
+    const dataError = errors.find((e) => e.property === 'data');
+    expect(dataError).toBeDefined();
+  });
+});

--- a/backend/src/modules/tour-analytics/dto/track-tour-event.dto.ts
+++ b/backend/src/modules/tour-analytics/dto/track-tour-event.dto.ts
@@ -1,0 +1,54 @@
+import { Type } from 'class-transformer';
+import {
+  IsIn,
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+/** The only event names this endpoint accepts (issue #1313). */
+export const TOUR_EVENT_NAMES = [
+  'tour_started',
+  'tour_completed',
+  'tour_skipped',
+  'tour_step_viewed',
+] as const;
+
+export type TourEventName = (typeof TOUR_EVENT_NAMES)[number];
+
+export class TourEventDataDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  step?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  totalSteps?: number;
+
+  @IsOptional()
+  @IsString()
+  stepId?: string;
+
+  @IsOptional()
+  @IsISO8601()
+  timestamp?: string;
+}
+
+export class TrackTourEventDto {
+  /** Rejects unknown event names instead of silently accepting them. */
+  @IsIn(TOUR_EVENT_NAMES, {
+    message: `event must be one of: ${TOUR_EVENT_NAMES.join(', ')}`,
+  })
+  event: TourEventName;
+
+  @ValidateNested()
+  @Type(() => TourEventDataDto)
+  data: TourEventDataDto;
+}

--- a/backend/src/modules/tour-analytics/tour-analytics.controller.ts
+++ b/backend/src/modules/tour-analytics/tour-analytics.controller.ts
@@ -1,20 +1,7 @@
 import { Controller, Post, Body, UseGuards, Request } from '@nestjs/common';
 import { TourAnalyticsService } from './tour-analytics.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-
-interface TourEventDto {
-  event:
-    | 'tour_started'
-    | 'tour_completed'
-    | 'tour_skipped'
-    | 'tour_step_viewed';
-  data: {
-    step?: number;
-    totalSteps?: number;
-    stepId?: string;
-    timestamp?: string;
-  };
-}
+import { TrackTourEventDto } from './dto/track-tour-event.dto';
 
 @Controller('analytics/tour')
 @UseGuards(JwtAuthGuard)
@@ -24,7 +11,7 @@ export class TourAnalyticsController {
   @Post()
   async trackTourEvent(
     @Request() req: { user: { id: number } },
-    @Body() eventDto: TourEventDto,
+    @Body() eventDto: TrackTourEventDto,
   ): Promise<{ success: boolean }> {
     await this.tourAnalyticsService.trackEvent(
       req.user.id,


### PR DESCRIPTION
## Summary
`TourAnalyticsController.trackTourEvent` typed its request body as a plain TypeScript `interface`, which is erased at runtime. The app's global `ValidationPipe` (`whitelist`, `forbidNonWhitelisted`, `transform`) never saw this endpoint's shape, so any `event` string (typos, unknown/legacy event names, arbitrary junk) was accepted and forwarded straight to the service and DB.

## Changes
- Added `TrackTourEventDto` (`dto/track-tour-event.dto.ts`) using `class-validator`, following the same pattern as `CacheSetDto`/`PaginationDto` elsewhere in the repo:
  - `event` uses `@IsIn(TOUR_EVENT_NAMES)` — rejects anything outside `tour_started | tour_completed | tour_skipped | tour_step_viewed`.
  - Nested `data` (`TourEventDataDto`) validates `step`/`totalSteps` as non-negative ints, `stepId` as a string, and `timestamp` as ISO-8601.
- Controller now types the body as `TrackTourEventDto` instead of the erased interface, so the global `ValidationPipe` actually enforces it.

## Before / after
- Before: `POST /analytics/tour { "event": "totally_made_up", "data": {} }` → `200 { success: true }`, garbage event persisted.
- After: same request → `400 Bad Request` with a message listing the accepted event names; malformed `data` fields are also rejected.

## Testing
- `backend/src/modules/tour-analytics/dto/track-tour-event.dto.spec.ts`: all four known event names pass; unknown/missing event name rejected; non-integer `step` and malformed `timestamp` in `data` rejected. Uses the repo's existing `validate()`/`plainToInstance()` DTO-test pattern (see `pagination.dto.spec.ts`).

Closes #1313