### PR TITLE
fix(notifications): stabilize pagination sort and add keyset cursor

### DIFF
--- a/backend/src/modules/fetch-notification/dto/get-notifications-query.dto.ts
+++ b/backend/src/modules/fetch-notification/dto/get-notifications-query.dto.ts
@@ -3,6 +3,7 @@ import {
   IsBoolean,
   IsEnum,
   IsInt,
+  IsString,
   Min,
   Max,
 } from 'class-validator';
@@ -43,4 +44,14 @@ export class GetNotificationsQueryDto {
   @IsOptional()
   @IsEnum(NotificationType)
   type?: NotificationType;
+
+  @ApiPropertyOptional({
+    description:
+      'Opaque keyset cursor from a previous response\'s meta.nextCursor. ' +
+      'When provided, takes precedence over `page` and paginates stably ' +
+      'even if new notifications arrive between requests.',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
 }

--- a/backend/src/modules/fetch-notification/dto/notification-cursor.util.spec.ts
+++ b/backend/src/modules/fetch-notification/dto/notification-cursor.util.spec.ts
@@ -1,0 +1,35 @@
+import {
+  decodeNotificationCursor,
+  encodeNotificationCursor,
+} from './notification-cursor.util';
+
+describe('notification cursor util', () => {
+  it('round-trips createdAt and id through encode/decode', () => {
+    const createdAt = new Date('2024-03-15T12:34:56.789Z');
+    const cursor = encodeNotificationCursor(createdAt, 'notif-uuid-42');
+
+    const decoded = decodeNotificationCursor(cursor);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded?.id).toBe('notif-uuid-42');
+    expect(decoded?.createdAt.toISOString()).toBe(createdAt.toISOString());
+  });
+
+  it('returns null for garbage input', () => {
+    expect(decodeNotificationCursor('not-base64-at-all!!')).toBeNull();
+  });
+
+  it('returns null for a well-formed but incomplete payload', () => {
+    const bogus = Buffer.from('missing-separator', 'utf8').toString(
+      'base64url',
+    );
+    expect(decodeNotificationCursor(bogus)).toBeNull();
+  });
+
+  it('returns null when the encoded date is invalid', () => {
+    const bogus = Buffer.from('not-a-date|notif-1', 'utf8').toString(
+      'base64url',
+    );
+    expect(decodeNotificationCursor(bogus)).toBeNull();
+  });
+});

--- a/backend/src/modules/fetch-notification/dto/notification-cursor.util.ts
+++ b/backend/src/modules/fetch-notification/dto/notification-cursor.util.ts
@@ -1,0 +1,38 @@
+/**
+ * Opaque keyset-pagination cursor for notifications (issue #1312).
+ *
+ * Encodes the (createdAt, id) of the last row on a page. Keyset pagination
+ * with a stable tie-break on `id` avoids the duplicate/skipped-row drift that
+ * offset (`page`/`limit` skip) pagination suffers from when rows share the
+ * same `createdAt` timestamp or when new rows are inserted between page
+ * fetches.
+ */
+export interface NotificationCursor {
+  createdAt: Date;
+  id: string;
+}
+
+export function encodeNotificationCursor(
+  createdAt: Date,
+  id: string,
+): string {
+  const payload = `${createdAt.toISOString()}|${id}`;
+  return Buffer.from(payload, 'utf8').toString('base64url');
+}
+
+export function decodeNotificationCursor(
+  cursor: string,
+): NotificationCursor | null {
+  try {
+    const payload = Buffer.from(cursor, 'base64url').toString('utf8');
+    const [createdAtRaw, id] = payload.split('|');
+    if (!createdAtRaw || !id) return null;
+
+    const createdAt = new Date(createdAtRaw);
+    if (Number.isNaN(createdAt.getTime())) return null;
+
+    return { createdAt, id };
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/modules/fetch-notification/dto/paginated-notifications-response.dto.ts
+++ b/backend/src/modules/fetch-notification/dto/paginated-notifications-response.dto.ts
@@ -19,6 +19,15 @@ export class PaginationMetaDto {
 
   @ApiProperty({ example: false })
   hasPreviousPage: boolean;
+
+  @ApiProperty({
+    example: 'MjAyNC0wMS0wMVQwMDowMDowMC4wMDBafHV1aWQtMTIz',
+    nullable: true,
+    description:
+      'Opaque cursor for the next page (keyset pagination). Pass back as ' +
+      '`cursor` on the next request for stable ordering. Null on the last page.',
+  })
+  nextCursor: string | null;
 }
 
 export class PaginatedNotificationsResponseDto {

--- a/backend/src/modules/fetch-notification/notifications.service.spec.ts
+++ b/backend/src/modules/fetch-notification/notifications.service.spec.ts
@@ -5,6 +5,7 @@ import { SelectQueryBuilder } from 'typeorm';
 import { NotificationsService } from './notifications.service';
 import { Notification, NotificationType } from './entities/notification.entity';
 import { GetNotificationsQueryDto } from './dto/get-notifications-query.dto';
+import { encodeNotificationCursor } from './dto/notification-cursor.util';
 
 // ─── Factory Helpers ─────────────────────────────────────────────────────────
 
@@ -32,6 +33,7 @@ const createMockQueryBuilder = (
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
     getManyAndCount: jest.fn().mockResolvedValue([results, count]),
@@ -95,6 +97,7 @@ describe('NotificationsService', () => {
         totalPages: 3,
         hasNextPage: true,
         hasPreviousPage: false,
+        nextCursor: null,
       });
     });
 
@@ -213,6 +216,81 @@ describe('NotificationsService', () => {
       expect(dto.title).toBe('Token Received');
       expect(dto.isRead).toBe(true);
       expect(dto.createdAt).toBeInstanceOf(Date);
+    });
+
+    // ── Stability + cursor (issue #1312) ────────────────────────────────────
+
+    it('tie-breaks the sort on id for a deterministic order', async () => {
+      const qb = createMockQueryBuilder([], 0);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.findAllForUser(userId, { page: 1, limit: 20 });
+
+      expect(qb.orderBy).toHaveBeenCalledWith(
+        'notification.createdAt',
+        'DESC',
+      );
+      expect(qb.addOrderBy).toHaveBeenCalledWith('notification.id', 'DESC');
+    });
+
+    it('uses a keyset WHERE clause instead of skip() when a cursor is given', async () => {
+      const qb = createMockQueryBuilder([], 0);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+      const cursor = encodeNotificationCursor(
+        new Date('2024-01-01T00:00:00.000Z'),
+        'notif-uuid-1',
+      );
+
+      await service.findAllForUser(userId, { page: 1, limit: 20, cursor });
+
+      expect(qb.skip).not.toHaveBeenCalled();
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('notification.createdAt <'),
+        expect.objectContaining({ cId: 'notif-uuid-1' }),
+      );
+    });
+
+    it('ignores an invalid cursor and falls back to offset pagination', async () => {
+      const qb = createMockQueryBuilder([], 0);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.findAllForUser(userId, {
+        page: 2,
+        limit: 10,
+        cursor: 'not-a-valid-cursor!!',
+      });
+
+      expect(qb.skip).toHaveBeenCalledWith(10);
+    });
+
+    it('returns a nextCursor when a full page is returned', async () => {
+      const last = makeNotification({
+        id: 'notif-last',
+        createdAt: new Date('2024-01-02T00:00:00.000Z'),
+      });
+      const qb = createMockQueryBuilder([makeNotification(), last], 50);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.findAllForUser(userId, {
+        page: 1,
+        limit: 2,
+      });
+
+      expect(result.meta.nextCursor).toBe(
+        encodeNotificationCursor(last.createdAt, last.id),
+      );
+    });
+
+    it('returns nextCursor=null on a partial (final) page', async () => {
+      const qb = createMockQueryBuilder([makeNotification()], 1);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.findAllForUser(userId, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.meta.nextCursor).toBeNull();
     });
   });
 
@@ -368,6 +446,7 @@ describe('NotificationsService', () => {
         totalPages: 0,
         hasNextPage: false,
         hasPreviousPage: false,
+        nextCursor: null,
       });
     });
   });

--- a/backend/src/modules/fetch-notification/notifications.service.ts
+++ b/backend/src/modules/fetch-notification/notifications.service.ts
@@ -9,6 +9,10 @@ import {
   PaginationMetaDto,
 } from './dto/paginated-notifications-response.dto';
 import { NotificationResponseDto } from './dto/notification-response.dto';
+import {
+  decodeNotificationCursor,
+  encodeNotificationCursor,
+} from './dto/notification-cursor.util';
 
 const EMPTY_PAGINATED = (
   page: number,
@@ -22,6 +26,7 @@ const EMPTY_PAGINATED = (
     totalPages: 0,
     hasNextPage: false,
     hasPreviousPage: false,
+    nextCursor: null,
   },
 });
 
@@ -57,19 +62,21 @@ export class NotificationsService {
     userId: string,
     query: GetNotificationsQueryDto,
   ): Promise<PaginatedNotificationsResponseDto> {
-    const { page = 1, limit = 20, isRead, type } = query;
+    const { page = 1, limit = 20, isRead, type, cursor } = query;
 
     return this.runSafe(
       'findAllForUser',
       EMPTY_PAGINATED(page, limit),
       async () => {
-        const skip = (page - 1) * limit;
-
         const qb = this.notificationsRepository
           .createQueryBuilder('notification')
           .where('notification.userId = :userId', { userId })
+          // Sorting on createdAt alone is not stable: rows inserted in the
+          // same millisecond (common with bulk notifications) can be
+          // returned in a different order on each fetch, causing
+          // duplicate/skipped rows across pages. Tie-break on id.
           .orderBy('notification.createdAt', 'DESC')
-          .skip(skip)
+          .addOrderBy('notification.id', 'DESC')
           .take(limit);
 
         if (isRead !== undefined) {
@@ -80,8 +87,24 @@ export class NotificationsService {
           qb.andWhere('notification.type = :type', { type });
         }
 
+        // Keyset (cursor) pagination avoids the row drift offset pagination
+        // suffers from when notifications are inserted concurrently.
+        const decodedCursor = cursor ? decodeNotificationCursor(cursor) : null;
+        if (decodedCursor) {
+          qb.andWhere(
+            '(notification.createdAt < :cCreatedAt OR (notification.createdAt = :cCreatedAt AND notification.id < :cId))',
+            {
+              cCreatedAt: decodedCursor.createdAt,
+              cId: decodedCursor.id,
+            },
+          );
+        } else {
+          qb.skip((page - 1) * limit);
+        }
+
         const [notifications, total] = await qb.getManyAndCount();
         const totalPages = Math.ceil(total / limit);
+        const lastRow = notifications[notifications.length - 1];
 
         const meta: PaginationMetaDto = {
           page,
@@ -90,6 +113,10 @@ export class NotificationsService {
           totalPages,
           hasNextPage: page < totalPages,
           hasPreviousPage: page > 1,
+          nextCursor:
+            notifications.length === limit && lastRow
+              ? encodeNotificationCursor(lastRow.createdAt, lastRow.id)
+              : null,
         };
 
         return {


### PR DESCRIPTION
## Summary
`NotificationsService.findAllForUser` paginated with `ORDER BY createdAt DESC` + `skip/take` only. That's not a stable sort: rows inserted in the same millisecond (routine for bulk-generated notifications) can be returned in a different relative order on each fetch, so offset pagination can duplicate or silently skip rows across pages. Offset pagination also drifts if new notifications arrive between page requests.

## Changes
- Added a secondary `ORDER BY notification.id DESC` tie-break, so ordering is fully deterministic.
- Added optional keyset pagination: a new `cursor` query param and `meta.nextCursor` response field (`dto/notification-cursor.util.ts` — opaque base64url `createdAt|id` cursor). When `cursor` is supplied it's used as a `(createdAt, id) < (cursor)` WHERE condition instead of `skip()`, so paging stays correct even with concurrent inserts.
- `page`/`limit` callers are unaffected when no cursor is passed — same query shape, same meta fields, plus the new `nextCursor`.

## Before / after
- Before: `GET /notifications?page=2&limit=20` could return a notification already seen on page 1 (or skip one) if rows shared a `createdAt` or new rows were inserted between requests.
- After: same request returns a deterministic, gap-free order; clients can optionally switch to `GET /notifications?cursor=<meta.nextCursor>` for pagination immune to concurrent inserts.

## Testing
- `notifications.service.spec.ts`: added cases for the `addOrderBy` tie-break, cursor-based `WHERE` (and that `skip()` is skipped), invalid-cursor fallback to offset mode, and `nextCursor` presence/absence on full vs. partial pages. Existing offset-pagination tests (filters, page-3 offset math, hasNextPage/hasPreviousPage, empty results) pass unchanged with the added `nextCursor: null` field in their exact-match assertions.
- `notification-cursor.util.spec.ts`: encode/decode round-trip, and `null` returned for garbage/incomplete/invalid-date input.

Closes #1312