### PR TITLE
Feature/frontend fixes 1245 1244 1243 1242

### DIFF
--- a/frontend/src/components/game/GameWaiting.tsx
+++ b/frontend/src/components/game/GameWaiting.tsx
@@ -82,8 +82,21 @@ const DUMMY_GAME_CONFIG = {
 export default function GameWaiting(): React.JSX.Element {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const rawGameCode = searchParams.get("gameCode") ?? DUMMY_GAME_CONFIG.code;
-  const gameCode = rawGameCode.trim().toUpperCase();
+
+  // Derive gameCode with fallback to sessionStorage
+  const rawGameCode = (() => {
+    const fromParams = searchParams.get("gameCode");
+    if (fromParams) return fromParams;
+
+    // Fall back to saved room code
+    if (typeof window !== "undefined") {
+      return sessionStorage.getItem("tycoon.lastJoinCode") ?? null;
+    }
+    return null;
+  })();
+
+  const gameCode = rawGameCode ? rawGameCode.trim().toUpperCase() : "";
+  const hasValidCode = gameCode.length > 0;
 
   const [gamePlayers, setGamePlayers] = useState<GamePlayer[]>(DUMMY_PLAYERS);
   const [playerSymbol, setPlayerSymbol] = useState<PlayerSymbol | null>(null);
@@ -99,6 +112,13 @@ export default function GameWaiting(): React.JSX.Element {
   const isHost = true; // Mock: current user is host
 
   const mountedRef = useRef(true);
+
+  // Save gameCode to sessionStorage when it's valid
+  useEffect(() => {
+    if (hasValidCode && typeof window !== "undefined") {
+      sessionStorage.setItem("tycoon.lastJoinCode", gameCode);
+    }
+  }, [gameCode, hasValidCode]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -179,6 +199,24 @@ export default function GameWaiting(): React.JSX.Element {
 
   // Responsive MediaQuery
   const isMobile = useMediaQuery({ query: "(max-width: 768px)" });
+
+  // Show invalid code message when no code is available
+  if (!loading && !hasValidCode) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#010F10] px-6 py-16 text-[#F0F7F7]">
+        <div className="w-full max-w-md rounded-lg border border-[#00F0FF]/20 bg-[#07181B] p-8 text-center">
+          <h1 className="text-xl font-bold uppercase tracking-wide">Room code is missing or invalid</h1>
+          <p className="mt-4 text-sm text-[#F0F7F7]/75">Please provide a valid game code to join.</p>
+          <button
+            onClick={() => router.push("/")}
+            className="mt-6 rounded-md bg-[#00F0FF] px-4 py-2 font-semibold text-[#010F10] hover:bg-[#86F8FF]"
+          >
+            Retry join
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   // Handler functions
   const handleCopyLink = useCallback(async () => {

--- a/frontend/src/components/offline/OfflineStatus.tsx
+++ b/frontend/src/components/offline/OfflineStatus.tsx
@@ -57,12 +57,12 @@ export default function OfflineStatus() {
         </div>
 
         <div>
-          <p
+          <h2
             id="offline-status-title"
             className="text-sm font-semibold uppercase tracking-[0.14em] text-[#F0F7F7]"
           >
             Connection status
-          </p>
+          </h2>
           <p
             className="mt-2 text-sm leading-6 text-[#F0F7F7]/75"
             aria-live="polite"

--- a/frontend/src/hooks/__tests__/useJoinRoomWebVitals.test.tsx
+++ b/frontend/src/hooks/__tests__/useJoinRoomWebVitals.test.tsx
@@ -24,9 +24,16 @@ function installPerformanceObserverMock(
 describe('useJoinRoomWebVitals', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock PerformanceObserver
+    // Ensure PerformanceObserver is always available as a constructor
     if (!window.PerformanceObserver) {
-      window.PerformanceObserver = vi.fn() as any;
+      class MockPerformanceObserver {
+        observe = vi.fn();
+        disconnect = vi.fn();
+        constructor(callback: PerformanceObserverCallback) {
+          // Minimal constructor — allows instanceof and new checks
+        }
+      }
+      window.PerformanceObserver = MockPerformanceObserver as unknown as typeof PerformanceObserver;
     }
   });
 

--- a/frontend/src/hooks/useReducedMotion.ts
+++ b/frontend/src/hooks/useReducedMotion.ts
@@ -5,6 +5,10 @@ const canUseDOM = typeof window !== "undefined" && "matchMedia" in window;
 /**
  * Hook to detect if the user prefers reduced motion.
  * Returns true if the user has set prefers-reduced-motion: reduce in their OS settings.
+ * Falls back to the provided defaultValue when matchMedia API is unavailable (e.g., during SSR or in older browsers).
+ *
+ * @param defaultValue - The value to return when matchMedia is not available (defaults to false)
+ * @returns boolean indicating whether prefers-reduced-motion is active
  */
 export function useReducedMotion(defaultValue: boolean = false): boolean {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(() => {


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                  
                                                            
  Fixes four frontend platform issues across hooks, components, and tests with improved documentation and a11y support.                                                                       
                                                            
  ## Changes

  ### #1245 — useReducedMotion default when matchMedia missing
  - Document `defaultValue` parameter behavior when matchMedia API is unavailable
  - Clarify SSR/fallback handling in JSDoc

  ### #1244 — useJoinRoomWebVitals PerformanceObserver mocks
  - Replace arrow function vi.fn factories with constructable MockPerformanceObserver class
  - Ensures proper Vitest 4 compatibility with `new` operator

  ### #1243 — GameWaiting room-code fallback and validation
  - Add sessionStorage fallback for game code (`tycoon.lastJoinCode`)
  - Persist valid game codes across page reloads
  - Show 'Room code is missing or invalid' message with retry action when no code available
  - Support both query params and saved codes

  ### #1242 — OfflineStatus and offline page a11y
  - Change OfflineStatus title from `<p>` to `<h2>` for semantic heading hierarchy
  - Fixes role expectations in test suite

  ## Notes

  - Code-only delivery: no install/build/test/scripts run during implementation
  - Committer: favourawaku
  - All changes follow existing patterns and maintain backward compatibility

  Closes #1245, Closes #1244, Closes #1243, Closes #1242