### PR TITLE
feat:   Contract hardening: boost expiry test, WASM canary docs, budget justification, precedence style note

### DIFF
--- a/contract/ci/wasm-size-budget.json
+++ b/contract/ci/wasm-size-budget.json
@@ -4,19 +4,24 @@
   "regression_threshold_percent": 3,
   "contracts": {
     "tycoon_boost_system.wasm": {
-      "baseline_bytes": 24960
+      "baseline_bytes": 24960,
+      "justification": "Initial recorded baseline"
     },
     "tycoon_token.wasm": {
-      "baseline_bytes": 20802
+      "baseline_bytes": 20802,
+      "justification": "Initial recorded baseline"
     },
     "tycoon_reward_system.wasm": {
-      "baseline_bytes": 21511
+      "baseline_bytes": 21511,
+      "justification": "Initial recorded baseline"
     },
     "tycoon_game.wasm": {
-      "baseline_bytes": 32114
+      "baseline_bytes": 32114,
+      "justification": "Initial recorded baseline"
     },
     "tycoon_collectibles.wasm": {
-      "baseline_bytes": 32796
+      "baseline_bytes": 32796,
+      "justification": "Initial recorded baseline"
     }
   }
 }

--- a/contract/contracts/tycoon-boost-system/src/admin_access_control_tests.rs
+++ b/contract/contracts/tycoon-boost-system/src/admin_access_control_tests.rs
@@ -21,6 +21,7 @@
 //! | AAC-05  | `admin_grant_boost` | Admin grant does not affect other players | Isolation verified |
 //! | AAC-06  | `admin_grant_boost` | Zero value boost | InvalidValue error |
 //! | AAC-07  | `admin_grant_boost` | Past expiry | InvalidExpiry error |
+//! | AAC-07b | `admin_grant_boost` | Grant with future expiry, advance ledger | Boost excluded once ledger reaches expiry |
 //! | AAC-08  | `admin_grant_boost` | Duplicate ID | DuplicateId error |
 //! | AAC-09  | `admin_grant_boost` | Cap exceeded | CapExceeded error |
 //! | AAC-10  | `admin_grant_boost` | Emits event | AdminBoostGrantedEvent published |
@@ -208,6 +209,33 @@ fn test_admin_grant_boost_past_expiry_panics() {
     set_ledger(&env, 200);
     // expires_at_ledger is in the past
     client.admin_grant_boost(&player, &eb(1, BoostType::Additive, 500, 100));
+}
+
+/// AAC-07b: A boost granted with `expires_at_ledger` strictly greater than
+/// the current ledger is accepted and active; once the ledger advances past
+/// that value the boost must no longer contribute to the player's total.
+#[test]
+fn test_admin_grant_boost_expires_after_ledger_advance() {
+    let env = make_env();
+    let (client, _admin) = setup_initialized(&env);
+    let player = Address::generate(&env);
+
+    set_ledger(&env, 100);
+    // expires_at_ledger (150) > current ledger (100) — must be accepted.
+    client.admin_grant_boost(&player, &eb(1, BoostType::Additive, 500, 150));
+
+    let active = client.get_active_boosts(&player);
+    assert_eq!(active.len(), 1);
+    assert_eq!(client.calculate_total_boost(&player), 500);
+
+    // Advance the ledger past expiry.
+    set_ledger(&env, 150);
+    assert_eq!(
+        client.calculate_total_boost(&player),
+        0,
+        "boost must be excluded once current ledger reaches expires_at_ledger"
+    );
+    assert_eq!(client.get_active_boosts(&player).len(), 0);
 }
 
 #[test]

--- a/contract/contracts/tycoon-reward-system/src/lib.rs
+++ b/contract/contracts/tycoon-reward-system/src/lib.rs
@@ -396,6 +396,15 @@ impl TycoonRewardSystem {
     }
 }
 
+// SW-CON-001 canary: `test_mint`/`test_burn` are unauthenticated balance
+// mutators (Option A of MIGRATION_LEGACY_ENTRYPOINTS.md). The `#[cfg(test)]`
+// on this whole `impl` block is the WASM boundary — it is a compile-time
+// gate, not a runtime check, so these entrypoints are never part of the
+// `#[contractimpl]`-generated exports in a `cargo build --release` artifact
+// and cannot appear in the deployed contract's WASM/ABI. Do not move this
+// impl out of `#[cfg(test)]`, do not add a non-test path to `_mint`/`_burn`,
+// and do not drop the block-level `#[cfg(test)]` in favor of per-fn gates —
+// `#[contractimpl]` must never see these fns outside of test builds.
 #[cfg(test)]
 #[contractimpl]
 impl TycoonRewardSystem {

--- a/contract/contracts/tycoon-token/src/integration_coverage.rs
+++ b/contract/contracts/tycoon-token/src/integration_coverage.rs
@@ -203,6 +203,14 @@ mod tests {
     // ── Supply conservation ───────────────────────────────────────────────────
 
     /// Total supply is conserved across a series of transfers between players.
+    ///
+    /// Style note (reference-argument precedence): transfer amounts below are
+    /// written `&(share / n)`, never `&share / n`. `client.transfer` takes
+    /// `&i128`, and `&` binds tighter than `/`, so `&share / n` parses as
+    /// `(&share) / n` — dividing a reference by an integer, which either
+    /// fails to compile or (with an auto-deref/op impl) silently divides the
+    /// wrong operand. Always parenthesize the arithmetic before taking its
+    /// reference: `&(expr)`.
     #[test]
     fn supply_conserved_across_transfers() {
         let (e, client, admin) = setup();

--- a/contract/scripts/check-wasm-sizes.sh
+++ b/contract/scripts/check-wasm-sizes.sh
@@ -31,17 +31,24 @@ FAILED=0
   echo ""
   echo "Regression threshold: **${THRESHOLD_PCT}%** over committed baseline (deployment cost / rent awareness)."
   echo ""
-  echo "| Contract | Baseline (B) | Current (C) | Δ (C−B) | Max allowed (⌊B×(100+${THRESHOLD_PCT})/100⌋) | Status |"
-  echo "|----------|-------------:|------------:|--------:|----------------------------------------------:|:-------|"
+  echo "| Contract | Baseline (B) | Current (C) | Δ (C−B) | Max allowed (⌊B×(100+${THRESHOLD_PCT})/100⌋) | Status | Justification |"
+  echo "|----------|-------------:|------------:|--------:|----------------------------------------------:|:-------|:---------------|"
 } >"$REPORT"
 
 while IFS= read -r line; do
   name="$(echo "$line" | jq -r '.key')"
   baseline="$(echo "$line" | jq -r '.value.baseline_bytes')"
+  justification="$(echo "$line" | jq -r '.value.justification // empty')"
+  if [[ -z "$justification" ]]; then
+    echo "ERROR: $name has no 'justification' string in wasm-size-budget.json." >&2
+    echo "Every baseline entry must record why it is set where it is — required when bumping a baseline." >&2
+    FAILED=1
+    justification="MISSING"
+  fi
   path="$TARGET/$name"
   if [[ ! -f "$path" ]]; then
     echo "ERROR: expected WASM not found: $path (build release wasm first)"
-    echo "| \`$name\` | $baseline | — | — | — | ❌ missing |" >>"$REPORT"
+    echo "| \`$name\` | $baseline | — | — | — | ❌ missing | $justification |" >>"$REPORT"
     FAILED=1
     continue
   fi
@@ -59,7 +66,7 @@ while IFS= read -r line; do
     FAILED=1
   fi
 
-  echo "| \`$name\` | $baseline | $current | $delta | $max_allowed | $status |" >>"$REPORT"
+  echo "| \`$name\` | $baseline | $current | $delta | $max_allowed | $status | $justification |" >>"$REPORT"
 done < <(jq -c '.contracts | to_entries[]' "$BUDGET")
 
 echo "" >>"$REPORT"
@@ -67,7 +74,9 @@ cat "$REPORT" >>"$SUMMARY"
 
 if [[ "$FAILED" -ne 0 ]]; then
   echo "WASM size regression: one or more contracts exceed baseline + ${THRESHOLD_PCT}%." >&2
-  echo "Intentional increase: update \`contract/ci/wasm-size-budget.json\` in the same PR with justification." >&2
+  echo "Intentional increase: update \`contract/ci/wasm-size-budget.json\` in the same PR, bumping" >&2
+  echo "'baseline_bytes' and replacing 'justification' with why the growth is expected (new feature," >&2
+  echo "SDK bump, etc). A missing or stale justification fails this check." >&2
   exit 1
 fi
 

--- a/contract/scripts/test-wasm-size-budget.sh
+++ b/contract/scripts/test-wasm-size-budget.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Unit checks for the WASM size budget process (contract/ci/wasm-size-budget.json
+# + scripts/check-wasm-sizes.sh). Does not build WASM — validates the budget
+# file's shape and the "justification required" rule that check-wasm-sizes.sh
+# enforces at CI time, so contributors get fast feedback before a full build.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRACT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUDGET="$CONTRACT_ROOT/ci/wasm-size-budget.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for this test"
+  exit 1
+fi
+
+FAILED=0
+
+# Every contract entry must carry a non-empty justification string.
+while IFS= read -r line; do
+  name="$(echo "$line" | jq -r '.key')"
+  justification="$(echo "$line" | jq -r '.value.justification // empty')"
+  baseline="$(echo "$line" | jq -r '.value.baseline_bytes // empty')"
+
+  if [[ -z "$baseline" ]]; then
+    echo "FAIL: $name is missing baseline_bytes"
+    FAILED=1
+  fi
+  if [[ -z "$justification" ]]; then
+    echo "FAIL: $name is missing a 'justification' string (required: PR must justify baseline bumps)"
+    FAILED=1
+  fi
+done < <(jq -c '.contracts | to_entries[]' "$BUDGET")
+
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "wasm-size-budget.json failed validation." >&2
+  exit 1
+fi
+
+echo "wasm-size-budget.json: all entries have baseline_bytes and justification. OK."
+exit 0


### PR DESCRIPTION

Body:


## Summary

Closes #1320

closes #1321

closes #1322

closes  #1323

- **#1321 (boost-system):** `admin_grant_boost` had no test that granted a boost with a future `expires_at_ledger` and then advanced the ledger *past* it to confirm expiry. Added `test_admin_grant_boost_expires_after_ledger_advance`, which grants at ledger 100 with `expires_at_ledger = 150`, asserts the boost is active (`calculate_total_boost == 500`), advances to ledger 150, and asserts it's excluded from both `calculate_total_boost` and `get_active_boosts`.
- **#1323 (reward-system):** `test_mint`/`test_burn` were already correctly gated behind a block-level `#[cfg(test)]` `impl`, so they're compiled out of release WASM. Added a doc comment on that block explaining this is a *compile-time* boundary (not a runtime check) per `MIGRATION_LEGACY_ENTRYPOINTS.md`/SW-CON-001, and calling out what must not change (don't move the impl out of `cfg(test)`, don't add a non-test path to `_mint`/`_burn`, don't switch to per-fn gates).
- **#1322 (CI):** Added a required `justification` field to every contract entry in `wasm-size-budget.json`. `check-wasm-sizes.sh` now fails (and prints an error) if an entry is missing it, and surfaces it in the size-report table so reviewers can see why a baseline is where it is. Added `scripts/test-wasm-size-budget.sh` as a fast jq-only unit check of this rule (no WASM build required).
- **#1320 (tycoon-token):** Added a style-note doc comment at the `&(share / n)`-style transfer amounts in `integration_coverage.rs`, explaining why the parens are required (`&` binds tighter than `/`, so `&share / n` silently parses as `(&share) / n`).

## Test plan

- [x] `cargo test -p tycoon-reward-system --no-run` — compiles clean
- [x] `cargo test -p tycoon-token --no-run` — compiles clean
- [x] `bash contract/scripts/test-wasm-size-budget.sh` — passes
- [x] `bash -n contract/scripts/check-wasm-sizes.sh` / `jq empty contract/ci/wasm-size-budget.json` — syntax/JSON valid
- [x] Confirmed via `git stash` that `tycoon-boost-system`'s pre-existing 22 test-compile errors (`u32` vs `usize` in unrelated `assert_eq!(...len(), N as usize)` calls across `cap_stacking_expiry_tests.rs`, `advanced_integration_tests.rs`, `admin_access_control_tests.rs`) predate this change and are unaffected — same count before and after (out of scope for these 4 issues; flagging separately)

