### PR TITLE
feat: resolve issues #1348, #1349, #1350, #1351 with tests and invariants

### DIFF
--- a/contract/contracts/tycoon-collectibles/src/enumeration_tests.rs
+++ b/contract/contracts/tycoon-collectibles/src/enumeration_tests.rs
@@ -479,3 +479,146 @@ fn test_transfer_partial_balance_keeps_token_in_sender_enumeration() {
     // Bob now owns it
     assert_eq!(client.owned_token_count(&bob), 1);
 }
+
+// ── gas-safe pagination (SW-COL-ENM-001) ──────────────────────────────────────
+
+/// tokens_of_owner_page with page_size=MAX_PAGE_SIZE(100) returns up to 100 tokens.
+#[test]
+fn test_pagination_max_page_size_returns_full_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    // Mint 150 tokens (IDs 1..=150)
+    for i in 1u128..=150 {
+        client.buy_collectible(&user, &i, &1);
+    }
+
+    // Page 0 with MAX_PAGE_SIZE (100) returns 100 tokens
+    let page0 = client.tokens_of_owner_page(&user, &0, &100).unwrap();
+    assert_eq!(page0.len(), 100, "page 0 must return MAX_PAGE_SIZE tokens");
+
+    // Page 1 returns remaining 50
+    let page1 = client.tokens_of_owner_page(&user, &1, &100).unwrap();
+    assert_eq!(page1.len(), 50, "page 1 must return remaining 50 tokens");
+}
+
+/// tokens_of_owner_page with page_size > MAX_PAGE_SIZE returns error.
+#[test]
+fn test_pagination_page_size_exceeds_max_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    client.buy_collectible(&user, &1, &1);
+
+    let result = client.try_tokens_of_owner_page(&user, &0, &101);
+    assert!(result.is_err(), "page_size > MAX_PAGE_SIZE must return error");
+}
+
+/// tokens_of_owner_page with page_size=0 returns error.
+#[test]
+fn test_pagination_zero_page_size_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    client.buy_collectible(&user, &1, &1);
+
+    let result = client.try_tokens_of_owner_page(&user, &0, &0);
+    assert!(result.is_err(), "page_size=0 must return error");
+}
+
+/// tokens_of_owner_page for an out-of-bounds page returns empty Vec.
+#[test]
+fn test_pagination_out_of_bounds_page_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    client.buy_collectible(&user, &5, &1);
+
+    // Page 10 is way out of bounds for 1 token
+    let page = client.tokens_of_owner_page(&user, &10, &10).unwrap();
+    assert_eq!(page.len(), 0, "out-of-bounds page must return empty Vec");
+}
+
+/// tokens_of_owner_page for an empty owner returns empty Vec.
+#[test]
+fn test_pagination_empty_owner_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    let page = client.tokens_of_owner_page(&user, &0, &10).unwrap();
+    assert_eq!(page.len(), 0, "empty owner page must be empty");
+}
+
+/// iterate_owned_tokens with batch_size=MAX_PAGE_SIZE returns full batch.
+#[test]
+fn test_iterate_max_batch_size_returns_full_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    for i in 1u128..=100 {
+        client.buy_collectible(&user, &i, &1);
+    }
+
+    let (batch, has_more) = client.iterate_owned_tokens(&user, &0, &100);
+    assert_eq!(batch.len(), 100, "batch must contain MAX_PAGE_SIZE tokens");
+    assert!(!has_more, "no more tokens after full batch");
+
+    // Next batch must be empty
+    let (next, more) = client.iterate_owned_tokens(&user, &100, &10);
+    assert_eq!(next.len(), 0, "next batch after full scan must be empty");
+    assert!(!more, "no more after full scan");
+}
+
+/// iterate_owned_tokens correctly reports has_more across page boundaries.
+#[test]
+fn test_iterate_has_more_across_pages() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    // 10 tokens, batch_size=3 -> 4 iterations expected
+    for i in 1u128..=10 {
+        client.buy_collectible(&user, &i, &1);
+    }
+
+    let mut start = 0u32;
+    let batch_size = 3u32;
+    let mut total_collected = 0u32;
+
+    loop {
+        let (batch, has_more) = client.iterate_owned_tokens(&user, &start, &batch_size);
+        total_collected += batch.len() as u32;
+        if !has_more {
+            break;
+        }
+        start += batch_size;
+    }
+
+    assert_eq!(total_collected, 10, "must collect all 10 tokens across iterations");
+}
+
+/// token_of_owner_by_index on empty owner panics (consistent with existing behavior).
+#[test]
+#[should_panic]
+fn test_token_of_owner_by_index_on_empty_owner_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    // No tokens owned, index 0 should panic
+    client.token_of_owner_by_index(&user, &0);
+}

--- a/contract/contracts/tycoon-token/src/error_branch_tests.rs
+++ b/contract/contracts/tycoon-token/src/error_branch_tests.rs
@@ -451,6 +451,62 @@ fn test_metadata_consistency() {
     assert_eq!(decimals1, decimals2, "decimals changed between calls");
 }
 
+/// Snapshot: token metadata values after initialization.
+/// SNAPSHOT: name="Tycoon", symbol="TYC", decimals=18
+#[test]
+fn test_snapshot_token_metadata() {
+    let (e, client, _) = setup();
+
+    // SNAPSHOT: name must be "Tycoon"
+    assert_eq!(
+        client.name(),
+        String::from_str(&e, "Tycoon"),
+        "snapshot: token name"
+    );
+    // SNAPSHOT: symbol must be "TYC"
+    assert_eq!(
+        client.symbol(),
+        String::from_str(&e, "TYC"),
+        "snapshot: token symbol"
+    );
+    // SNAPSHOT: decimals must be 18
+    assert_eq!(client.decimals(), 18, "snapshot: token decimals");
+}
+
+/// Snapshot: contract state after a sequence of mint → transfer → burn.
+/// SNAPSHOT: state after mint+transfer+burn
+#[test]
+fn test_snapshot_state_after_operations() {
+    let (e, client, admin) = setup();
+    let user = Address::generate(&e);
+    let supply_before = client.total_supply();
+
+    // Mint to user
+    let mint_amount: i128 = 5_000_000_000_000_000_000_000;
+    client.mint(&user, &mint_amount);
+    assert_eq!(client.balance(&user), mint_amount, "snapshot: user balance after mint");
+    assert_eq!(client.total_supply(), supply_before + mint_amount, "snapshot: supply after mint");
+
+    // Transfer from admin to user
+    let transfer_amount: i128 = 1_000_000_000_000_000_000_000;
+    client.transfer(&admin, &user, &transfer_amount);
+    let expected_user = mint_amount + transfer_amount;
+    let expected_admin = INITIAL_SUPPLY - transfer_amount;
+    assert_eq!(client.balance(&user), expected_user, "snapshot: user balance after transfer");
+    assert_eq!(client.balance(&admin), expected_admin, "snapshot: admin balance after transfer");
+
+    // Burn from user
+    let burn_amount: i128 = 2_000_000_000_000_000_000_000;
+    client.burn(&user, &burn_amount);
+    let expected_user_final = expected_user - burn_amount;
+    let expected_supply_final = supply_before + mint_amount - burn_amount;
+    assert_eq!(client.balance(&user), expected_user_final, "snapshot: user balance after burn");
+    assert_eq!(client.total_supply(), expected_supply_final, "snapshot: supply after burn");
+
+    // Final snapshot: supply conserved (initial + mint - burn)
+    assert!(client.total_supply() >= INITIAL_SUPPLY, "snapshot: supply never below initial");
+}
+
 /// Balance queries for multiple unknown addresses should all return 0.
 #[test]
 fn test_multiple_unknown_addresses_return_zero() {

--- a/contract/contracts/tycoon-token/src/invariant_tests.rs
+++ b/contract/contracts/tycoon-token/src/invariant_tests.rs
@@ -21,6 +21,9 @@
 /// | INV-15 | Only the admin can mint; non-admin callers are rejected |
 /// | INV-16 | `MintEvent` is emitted with correct `to` and `amount` on every mint |
 /// | INV-17 | `BurnEvent` is emitted with correct `from` and `amount` on every burn |
+/// | INV-18 | Self-transfer (`transfer` with `from == to`) is a net-noop: balance and supply unchanged |
+/// | INV-19 | Self-transfer_from (`spender == from == to`) is a net-noop: balance and supply unchanged, allowance consumed |
+/// | INV-20 | `burn_from` reduces allowance by exactly the burn amount (single, sequential, exhaustive) |
 ///
 /// Test names follow the pattern `test_inv_<ID>_<short_description>`.
 use super::*;
@@ -580,4 +583,155 @@ fn test_burn_from_exact_allowance_boundary() {
     client.burn_from(&spender, &admin, &exact);
     assert_eq!(client.allowance(&admin, &spender), 0);
     assert_eq!(client.total_supply(), INITIAL_SUPPLY - exact);
+}
+
+// ── INV-18 ────────────────────────────────────────────────────────────────────
+
+/// INV-18: Self-transfer must leave both balance and total_supply unchanged
+/// (net-noop invariant). The tokens never leave the owner's wallet.
+#[test]
+fn test_inv_18_self_transfer_net_noop() {
+    let (_, client, admin) = setup();
+    let balance_before = client.balance(&admin);
+    let supply_before = client.total_supply();
+
+    let amount: i128 = 500_000_000_000_000_000_000;
+    client.transfer(&admin, &admin, &amount);
+
+    assert_eq!(
+        client.balance(&admin),
+        balance_before,
+        "INV-18: self-transfer must not change balance"
+    );
+    assert_eq!(
+        client.total_supply(),
+        supply_before,
+        "INV-18: self-transfer must not change total supply"
+    );
+}
+
+// ── INV-19 ────────────────────────────────────────────────────────────────────
+
+/// INV-19: Self-transfer_from (spender == from) must leave balance and supply
+/// unchanged. Even though the spender is the same address, the allowance is
+/// consumed by the operation.
+#[test]
+fn test_inv_19_self_transfer_from_net_noop() {
+    let (_, client, admin) = setup();
+    let balance_before = client.balance(&admin);
+    let supply_before = client.total_supply();
+    let allowance_amount: i128 = 1_000_000_000_000_000_000_000;
+
+    // Admin approves themselves as spender (from == spender)
+    client.approve(&admin, &admin, &allowance_amount, &0);
+    assert_eq!(client.allowance(&admin, &admin), allowance_amount);
+
+    // Self-transfer_from: spender=admin, from=admin, to=admin
+    client.transfer_from(&admin, &admin, &admin, &allowance_amount);
+
+    assert_eq!(
+        client.balance(&admin),
+        balance_before,
+        "INV-19: self-transfer_from must not change balance"
+    );
+    assert_eq!(
+        client.total_supply(),
+        supply_before,
+        "INV-19: self-transfer_from must not change total supply"
+    );
+    // Allowance is consumed by the transfer_from
+    assert_eq!(
+        client.allowance(&admin, &admin),
+        0,
+        "INV-19: self-transfer_from consumes allowance"
+    );
+}
+
+// ── INV-20 ────────────────────────────────────────────────────────────────────
+
+/// INV-20: burn_from reduces allowance by exactly the burn amount.
+#[test]
+fn test_inv_20_burn_from_allowance_decrement_exact() {
+    let (_, client, admin) = setup();
+    let spender = Address::generate(&client.env);
+    let allowance_amount: i128 = 1_000_000_000_000_000_000_000;
+    let burn_amount: i128 = 300_000_000_000_000_000_000;
+
+    client.approve(&admin, &spender, &allowance_amount, &0);
+    client.burn_from(&spender, &admin, &burn_amount);
+
+    let remaining = client.allowance(&admin, &spender);
+    assert_eq!(
+        remaining,
+        allowance_amount - burn_amount,
+        "INV-20: allowance must be reduced by exactly the burn amount"
+    );
+    assert_eq!(
+        client.total_supply(),
+        INITIAL_SUPPLY - burn_amount,
+        "INV-20: supply reduced by burn amount"
+    );
+}
+
+/// INV-20b: Sequential burn_from calls decrement allowance cumulatively.
+#[test]
+fn test_inv_20b_burn_from_sequential_decrements() {
+    let (_, client, admin) = setup();
+    let spender = Address::generate(&client.env);
+    let allowance_amount: i128 = 1_000_000_000_000_000_000_000;
+    let burn_chunk: i128 = 200_000_000_000_000_000_000;
+
+    client.approve(&admin, &spender, &allowance_amount, &0);
+
+    // First burn
+    client.burn_from(&spender, &admin, &burn_chunk);
+    assert_eq!(
+        client.allowance(&admin, &spender),
+        allowance_amount - burn_chunk,
+        "INV-20b: allowance after first burn"
+    );
+
+    // Second burn
+    client.burn_from(&spender, &admin, &burn_chunk);
+    assert_eq!(
+        client.allowance(&admin, &spender),
+        allowance_amount - 2 * burn_chunk,
+        "INV-20b: allowance after second burn"
+    );
+
+    // Third burn (exhausts allowance)
+    client.burn_from(&spender, &admin, &burn_chunk);
+    let expected_burned = 3 * burn_chunk;
+    assert_eq!(
+        client.allowance(&admin, &spender),
+        allowance_amount - expected_burned,
+        "INV-20b: allowance after third burn"
+    );
+    assert_eq!(
+        client.total_supply(),
+        INITIAL_SUPPLY - expected_burned,
+        "INV-20b: supply reduced cumulatively"
+    );
+}
+
+/// INV-20c: burn_from with exact allowance leaves allowance at zero.
+#[test]
+fn test_inv_20c_burn_from_exhausts_allowance() {
+    let (_, client, admin) = setup();
+    let spender = Address::generate(&client.env);
+    let allowance_amount: i128 = 500_000_000_000_000_000_000;
+
+    client.approve(&admin, &spender, &allowance_amount, &0);
+    client.burn_from(&spender, &admin, &allowance_amount);
+
+    assert_eq!(
+        client.allowance(&admin, &spender),
+        0,
+        "INV-20c: allowance must be zero after burning full allowance"
+    );
+    assert_eq!(
+        client.total_supply(),
+        INITIAL_SUPPLY - allowance_amount,
+        "INV-20c: supply reduced by full allowance amount"
+    );
 }


### PR DESCRIPTION
## Closes #1348
## Closes #1349
## Closes #1350
## Closes #1351

### What does this PR do?

#### Issue #1348 — Snapshot tests for token metadata name/symbol/decimals
- Adds test_snapshot_token_metadata in error_branch_tests.rs: inline snapshot verifying name=Tycoon, symbol=TYC, decimals=18
- Adds test_snapshot_state_after_operations: snapshot of balances and supply after mint to transfer to burn sequence

#### Issue #1349 — Self-transfer net-noop invariant
- Adds test_inv_18_self_transfer_net_noop (INV-18): balance and supply unchanged when from==to
- Adds test_inv_19_self_transfer_from_net_noop (INV-19): net-noop when spender==from==to, allowance consumed

#### Issue #1350 — Burn_from allowance decrement exactness
- Adds test_inv_20_burn_from_allowance_decrement_exact (INV-20): single burn reduces allowance exactly
- Adds test_inv_20b_burn_from_sequential_decrements: cumulative decrement across 3 burns
- Adds test_inv_20c_burn_from_exhausts_allowance: full allowance burn leaves zero

#### Issue #1351 — Collectibles enumeration gas-safe pagination
- Adds 8 tests verifying tokens_of_owner_page and iterate_owned_tokens
- Covers MAX_PAGE_SIZE enforcement, error paths, out-of-bounds, empty owner, has_more tracking

### Additional changes
- Updates invariant_tests.rs doc comment to include INV-18, INV-19, INV-20

