### PR TITLE
feat(email): retry lifecycle events and DLQ logging for email processor

### DIFF
--- a/backend/src/modules/email/email.module.ts
+++ b/backend/src/modules/email/email.module.ts
@@ -4,6 +4,17 @@ import { EmailProcessor } from './email.processor';
 import { JobsModule } from '../jobs/jobs.module';
 import { BullModule } from '@nestjs/bullmq';
 
+/**
+ * EmailModule
+ *
+ * Queue: `email-queue`
+ *   - Max attempts : 3  (exponential backoff, base delay 5 000 ms)
+ *   - On exhaustion: job is kept in the failed set (`removeOnFail: false`) and
+ *     the processor emits a structured error log referencing the recipient and
+ *     template.  Use the BullMQ dashboard (Bull Board) or the Redis CLI to
+ *     inspect / replay DLQ entries:
+ *       LRANGE bull:email-queue:failed 0 -1
+ */
 @Module({
   imports: [
     JobsModule,

--- a/backend/src/modules/email/email.processor.spec.ts
+++ b/backend/src/modules/email/email.processor.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EmailProcessor } from './email.processor';
+import { EmailService } from './email.service';
+
+const mockEmailService = {
+  processEmailJob: jest.fn(),
+};
+
+const buildJob = (overrides: Partial<any> = {}): any => ({
+  id: 'job-1',
+  name: 'send-transactional',
+  attemptsMade: 0,
+  opts: { attempts: 3 },
+  data: {
+    to: 'user@example.com',
+    subject: 'Test',
+    template: 'welcome',
+    context: { name: 'Test' },
+  },
+  ...overrides,
+});
+
+describe('EmailProcessor', () => {
+  let processor: EmailProcessor;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailProcessor,
+        { provide: EmailService, useValue: mockEmailService },
+      ],
+    }).compile();
+
+    processor = module.get<EmailProcessor>(EmailProcessor);
+    jest.clearAllMocks();
+  });
+
+  describe('process()', () => {
+    it('calls emailService.processEmailJob for send-transactional jobs', async () => {
+      const job = buildJob();
+      await processor.process(job);
+      expect(mockEmailService.processEmailJob).toHaveBeenCalledWith(job.data);
+    });
+
+    it('ignores jobs with unrecognised names', async () => {
+      const job = buildJob({ name: 'unknown-job' });
+      await processor.process(job);
+      expect(mockEmailService.processEmailJob).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors thrown by emailService (so BullMQ can retry)', async () => {
+      const err = new Error('SMTP unavailable');
+      mockEmailService.processEmailJob.mockRejectedValueOnce(err);
+      const job = buildJob();
+      await expect(processor.process(job)).rejects.toThrow('SMTP unavailable');
+    });
+  });
+
+  describe('onFailed()', () => {
+    it('logs a DLQ error when all attempts are exhausted', () => {
+      const logSpy = jest.spyOn((processor as any).logger, 'error').mockImplementation(() => {});
+      const job = buildJob({ attemptsMade: 3, opts: { attempts: 3 } });
+      processor.onFailed(job, new Error('SMTP down'));
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('DLQ'),
+        expect.any(String),
+      );
+    });
+
+    it('logs a warning (not error) for intermediate failures', () => {
+      const warnSpy = jest.spyOn((processor as any).logger, 'warn').mockImplementation(() => {});
+      const job = buildJob({ attemptsMade: 1, opts: { attempts: 3 } });
+      processor.onFailed(job, new Error('transient'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('retry'));
+    });
+  });
+
+  describe('onCompleted()', () => {
+    it('logs successful completion', () => {
+      const logSpy = jest.spyOn((processor as any).logger, 'log').mockImplementation(() => {});
+      const job = buildJob();
+      processor.onCompleted(job);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('completed successfully'));
+    });
+  });
+});

--- a/backend/src/modules/email/email.processor.ts
+++ b/backend/src/modules/email/email.processor.ts
@@ -1,16 +1,62 @@
-import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { EmailService, EmailOptions } from './email.service';
 
+/**
+ * Email queue processor.
+ *
+ * Retry policy (configured at enqueue time in EmailService):
+ *   - Max attempts : 3
+ *   - Backoff      : exponential, starting at 5 000 ms
+ *
+ * Dead-Letter Queue (DLQ):
+ *   - Jobs that exhaust all attempts are NOT removed (`removeOnFail: false`).
+ *   - They remain in the "failed" set of `email-queue` and can be inspected or
+ *     re-queued via the BullMQ dashboard / Bull Board.
+ *   - The `failed` event handler below logs a structured error so on-call
+ *     engineers can identify and replay DLQ entries.
+ */
 @Processor('email-queue')
 export class EmailProcessor extends WorkerHost {
+  private readonly logger = new Logger(EmailProcessor.name);
+
   constructor(private readonly emailService: EmailService) {
     super();
   }
 
-  async process(job: Job<EmailOptions, any, string>): Promise<void> {
+  async process(job: Job<EmailOptions, void, string>): Promise<void> {
     if (job.name === 'send-transactional') {
+      this.logger.log(
+        `Processing email job ${job.id} (attempt ${job.attemptsMade + 1} of ${job.opts.attempts ?? 1})`,
+      );
       await this.emailService.processEmailJob(job.data);
     }
+  }
+
+  /** Fires after each failed attempt (including intermediate retries). */
+  @OnWorkerEvent('failed')
+  onFailed(job: Job<EmailOptions>, error: Error): void {
+    const isExhausted = job.attemptsMade >= (job.opts.attempts ?? 1);
+
+    if (isExhausted) {
+      this.logger.error(
+        `Email job ${job.id} moved to DLQ after ${job.attemptsMade} attempt(s). ` +
+          `Recipient: ${job.data?.to ?? 'unknown'}, Template: ${job.data?.template ?? 'unknown'}. ` +
+          `Error: ${error.message}`,
+        error.stack,
+      );
+    } else {
+      this.logger.warn(
+        `Email job ${job.id} failed (attempt ${job.attemptsMade}/${job.opts.attempts ?? 1}). ` +
+          `Will retry. Error: ${error.message}`,
+      );
+    }
+  }
+
+  /** Fires on successful completion. */
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job<EmailOptions>): void {
+    this.logger.log(`Email job ${job.id} completed successfully.`);
   }
 }


### PR DESCRIPTION
## Summary

Wires BullMQ retry lifecycle events into `EmailProcessor` and documents the Dead-Letter Queue (DLQ) policy.

**Changes:**
- `@OnWorkerEvent('failed')` — logs a structured `error`-level message when all 3 attempts are exhausted (DLQ entry), and a `warn`-level message on intermediate retries
- `@OnWorkerEvent('completed')` — structured success log per completed job
- `EmailModule` JSDoc documents max attempts (3), exponential backoff (5 000 ms base), `removeOnFail: false` (failed jobs kept for inspection), and Redis CLI command to inspect DLQ
- New `email.processor.spec.ts` covers `process()`, `onFailed()` (DLQ path + retry path), and `onCompleted()`

**Validation:** TypeScript compilation passes (no new errors introduced). Unit tests pass on CI.

Closes #1300