### PR TITLE
test(webhooks): replay-window edge-case tests and signature policy docs

### DIFF
--- a/backend/docs/webhooks-runbook.md
+++ b/backend/docs/webhooks-runbook.md
@@ -109,6 +109,26 @@ Webhooks features use feature flags for gradual rollout:
 
 ## Security Considerations
 
+### Signature Verification and Replay-Window
+
+Every inbound webhook is authenticated with an HMAC-SHA256 signature computed over `<timestamp>.<raw-body>`.
+
+| Property | Value |
+|---|---|
+| Algorithm | HMAC-SHA256 |
+| Header – signature | `X-Stripe-Signature` (hex-encoded) |
+| Header – timestamp | `X-Stripe-Timestamp` (Unix seconds) |
+| Replay window | **300 seconds (5 minutes)** |
+| Comparison | `crypto.timingSafeEqual` (constant-time) |
+
+Requests are rejected (HTTP 401) when:
+1. Either header is missing or the raw body is empty.
+2. The timestamp is non-numeric or `|now - timestamp| > 300 s` — this covers both *stale* replays and *future-dated* forgeries.
+3. The signature length does not match the expected HMAC length.
+4. The HMAC values do not match.
+
+All rejections are logged via the observability service and written to the audit log, so failed signature attempts are fully traceable.
+
 ### Secret Management
 - Webhook secrets stored in secure environment variables
 - No secrets logged in application logs

--- a/backend/src/modules/webhooks/webhooks.service.spec.ts
+++ b/backend/src/modules/webhooks/webhooks.service.spec.ts
@@ -141,6 +141,49 @@ describe('WebhooksService', () => {
       );
     });
 
+    it('should reject future timestamp beyond tolerance window (replay protection)', async () => {
+      // A timestamp set 10 minutes in the future is outside the 5-minute window
+      const futureTimestamp = (Math.floor(Date.now() / 1000) + 700).toString();
+      const body = JSON.stringify({ test: 'data' });
+
+      await expect(
+        service.verifySignature('anysig', futureTimestamp, Buffer.from(body), 'stripe'),
+      ).rejects.toThrow('Webhook timestamp outside of tolerance');
+
+      expect(observability.logSignatureVerification).toHaveBeenCalledWith(
+        'stripe',
+        false,
+        expect.any(Number),
+        'timestamp_outside_tolerance',
+      );
+    });
+
+    it('should reject a non-numeric timestamp', async () => {
+      const body = JSON.stringify({ test: 'data' });
+
+      await expect(
+        service.verifySignature('anysig', 'not-a-number', Buffer.from(body), 'stripe'),
+      ).rejects.toThrow('Webhook timestamp outside of tolerance');
+    });
+
+    it('should accept a timestamp at the edge of the tolerance window (299 s ago)', async () => {
+      const edgeTimestamp = (Math.floor(Date.now() / 1000) - 299).toString();
+      const body = JSON.stringify({ test: 'data' });
+      const signedPayload = `${edgeTimestamp}.${body}`;
+      const signature = require('crypto')
+        .createHmac('sha256', secret)
+        .update(signedPayload)
+        .digest('hex');
+
+      const result = await service.verifySignature(
+        signature,
+        edgeTimestamp,
+        Buffer.from(body),
+        'stripe',
+      );
+      expect(result).toBe(true);
+    });
+
     it('should log failure for missing signature', async () => {
       const timestamp = Math.floor(Date.now() / 1000).toString();
       const body = JSON.stringify({ test: 'data' });


### PR DESCRIPTION
## Summary

Completes signature verification and replay-window coverage for the webhooks module.

**Changes:**
- New test: future timestamp (700 s ahead) is rejected — covers forward-replay forgeries
- New test: non-numeric timestamp string is rejected
- New test: timestamp at exactly 299 s ago is accepted (edge of 300 s window)
- `webhooks-runbook.md` — added a Signature Verification and Replay-Window table documenting algorithm, headers, window size, and all rejection conditions

**Validation:** No production code changed. Pre-existing implementation already enforces `|now − ts| > 300 s` rejection via `toleranceSeconds = 300`.

Closes #1301