### PR TITLE
feat(audit-trail): 90-day retention purge and admin export endpoint

### DIFF
--- a/backend/src/modules/audit-trail/audit-trail.controller.ts
+++ b/backend/src/modules/audit-trail/audit-trail.controller.ts
@@ -45,6 +45,27 @@ export class AuditTrailController {
     return this.auditTrailService.findAll(query);
   }
 
+  /**
+   * GET /admin/audit-trail/export
+   * Admin export: returns all matching logs as a JSON array.
+   * Optional query filters: userId, action (same as findAll).
+   * Retention policy: logs older than 90 days are purged nightly at 02:00 UTC.
+   */
+  @Get('export')
+  @ApiOperation({
+    summary: 'Export audit trail logs as JSON (admin, compliance)',
+    description:
+      'Returns all matching audit log entries. Retention policy: entries older than 90 days are purged nightly.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Audit log export',
+    type: [AuditTrail],
+  })
+  async exportLogs(@Query() query: QueryAuditTrailDto) {
+    return this.auditTrailService.exportLogs(query);
+  }
+
   @Get('user/:userId')
   @ApiOperation({ summary: 'Retrieve audit trail logs for a specific user' })
   @ApiResponse({

--- a/backend/src/modules/audit-trail/audit-trail.service.spec.ts
+++ b/backend/src/modules/audit-trail/audit-trail.service.spec.ts
@@ -169,4 +169,60 @@ describe('AuditTrailService', () => {
       });
     });
   });
+
+  describe('exportLogs', () => {
+    it('should return all matching logs without pagination', async () => {
+      const findSpy = jest
+        .spyOn(repository, 'find' as any)
+        .mockResolvedValue([mockAuditTrail] as any);
+
+      const result = await service.exportLogs({
+        userId: 1,
+        action: AuditAction.USER_CREATED,
+      });
+
+      expect(findSpy).toHaveBeenCalledWith({
+        where: { userId: 1, action: AuditAction.USER_CREATED },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toEqual([mockAuditTrail]);
+    });
+
+    it('should return all logs when no filter is provided', async () => {
+      const findSpy = jest
+        .spyOn(repository, 'find' as any)
+        .mockResolvedValue([] as any);
+
+      await service.exportLogs({});
+
+      expect(findSpy).toHaveBeenCalledWith({
+        where: {},
+        order: { createdAt: 'DESC' },
+      });
+    });
+  });
+
+  describe('purgeExpiredLogs', () => {
+    it('should delete entries older than the retention window and return count', async () => {
+      const deleteSpy = jest
+        .spyOn(repository, 'delete' as any)
+        .mockResolvedValue({ affected: 5 } as any);
+
+      const deleted = await service.purgeExpiredLogs(90);
+
+      expect(deleted).toBe(5);
+      expect(deleteSpy).toHaveBeenCalledWith({
+        createdAt: expect.objectContaining({ _type: 'lessThan' }),
+      });
+    });
+
+    it('should return 0 when no entries are eligible for purge', async () => {
+      jest
+        .spyOn(repository, 'delete' as any)
+        .mockResolvedValue({ affected: 0 } as any);
+
+      const deleted = await service.purgeExpiredLogs(90);
+      expect(deleted).toBe(0);
+    });
+  });
 });

--- a/backend/src/modules/audit-trail/audit-trail.service.ts
+++ b/backend/src/modules/audit-trail/audit-trail.service.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, FindOptionsWhere } from 'typeorm';
+import { Repository, FindOptionsWhere, LessThan } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { AuditTrail, AuditAction } from './entities/audit-trail.entity';
 import { QueryAuditTrailDto } from './dto/query-audit-trail.dto';
 
@@ -15,8 +16,13 @@ export interface AuditLogOptions {
   reason?: string;
 }
 
+/** Default retention window: 90 days */
+export const AUDIT_RETENTION_DAYS = 90;
+
 @Injectable()
 export class AuditTrailService {
+  private readonly logger = new Logger(AuditTrailService.name);
+
   constructor(
     @InjectRepository(AuditTrail)
     private auditTrailRepository: Repository<AuditTrail>,
@@ -80,5 +86,42 @@ export class AuditTrailService {
     });
 
     return { data, total };
+  }
+
+  /**
+   * Export all audit logs (optionally filtered) as a JSON array.
+   * Admin-only; intended for compliance/data-access requests.
+   */
+  async exportLogs(queryDto: QueryAuditTrailDto): Promise<AuditTrail[]> {
+    const { userId, action } = queryDto;
+    const where: FindOptionsWhere<AuditTrail> = {};
+    if (userId !== undefined) where.userId = userId;
+    if (action !== undefined) where.action = action;
+
+    return this.auditTrailRepository.find({
+      where,
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * Delete audit log entries older than `retentionDays` days.
+   * Runs nightly at 02:00 UTC.
+   * Retention policy: {@link AUDIT_RETENTION_DAYS} days (default 90).
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_2AM)
+  async purgeExpiredLogs(retentionDays = AUDIT_RETENTION_DAYS): Promise<number> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - retentionDays);
+
+    const result = await this.auditTrailRepository.delete({
+      createdAt: LessThan(cutoff),
+    });
+
+    const deleted = result.affected ?? 0;
+    this.logger.log(
+      `Audit retention purge: deleted ${deleted} entries older than ${retentionDays} days (cutoff: ${cutoff.toISOString()})`,
+    );
+    return deleted;
   }
 }


### PR DESCRIPTION
## Summary

Implements audit trail retention policy and admin export per issue #1306.

**Changes:**

`audit-trail.service.ts`
- `purgeExpiredLogs(retentionDays = 90)`: deletes `audit_trails` rows with `createdAt < now - 90d` using `LessThan`. Decorated with `@Cron(EVERY_DAY_AT_2AM)` — runs automatically each night. Logs the number of deleted entries.
- `exportLogs(queryDto)`: returns the full result set (no pagination limit) filtered by userId/action — intended for compliance dumps.

`audit-trail.controller.ts`
- `GET /admin/audit-trail/export` — new admin-only endpoint (JwtAuthGuard + AdminGuard), documented in OpenAPI with retention policy note.

`audit-trail.service.spec.ts`
- 4 new unit tests: exportLogs with filters, exportLogs without filters, purgeExpiredLogs returning 5 deleted, purgeExpiredLogs returning 0.

**Validation:** TypeScript clean on modified files. Existing tests unaffected.

Closes #1306